### PR TITLE
fix blockbook package

### DIFF
--- a/build/templates/blockbook/debian/control
+++ b/build/templates/blockbook/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 3.9.5
 
 Package: {{.Blockbook.PackageName}}
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, coreutils, passwd, findutils, psmisc, backend-bitcoin
+Depends: ${shlibs:Depends}, ${misc:Depends}, coreutils, passwd, findutils, psmisc, {{.Backend.PackageName}}
 Description: Satoshilabs blockbook server ({{.Coin.Name}})
 {{end}}


### PR DESCRIPTION
With the following command `backend-bitcoin` is required at package creation, I can't install `blockbook` of altcoins.
`make all-<coin>` 