### PR TITLE
update monacoin version

### DIFF
--- a/configs/coins/monacoin.json
+++ b/configs/coins/monacoin.json
@@ -22,10 +22,10 @@
     "package_name": "backend-monacoin",
     "package_revision": "satoshilabs-1",
     "system_user": "monacoin",
-    "version": "0.15.1",
-    "binary_url": "https://github.com/monacoinproject/monacoin/releases/download/monacoin-0.15.1/monacoin-0.15.1-x86_64-linux-gnu.tar.gz",
+    "version": "0.16.2",
+    "binary_url": "https://github.com/monacoinproject/monacoin/releases/download/monacoin-0.16.2/monacoin-0.16.2-x86_64-linux-gnu.tar.gz",
     "verification_type": "gpg-sha256",
-    "verification_source": "https://github.com/monacoinproject/monacoin/releases/download/monacoin-0.15.1/monacoin-0.15.1-signatures.asc",
+    "verification_source": "https://github.com/monacoinproject/monacoin/releases/download/monacoin-0.16.2/monacoin-0.16.2-signatures.asc",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
         "bin/monacoin-qt"


### PR DESCRIPTION
monacoin 0.16.2 has been released so it is an update pull request.
Should I pull request to v0.0.7 ?

I confirmed that it will move once.
https://blockbook.electrum-mona.org/