### PR TITLE
Fix build error

### DIFF
--- a/build/docker/deb/Dockerfile
+++ b/build/docker/deb/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get clean
 
 ADD gpg-keys /tmp/gpg-keys
-RUN gpg --import /tmp/gpg-keys/*
+RUN gpg --batch --import /tmp/gpg-keys/*
 
 ADD build-deb.sh /build/build-deb.sh
 


### PR DESCRIPTION
The following error occurred during build(`make all-monacoin`).
Probably, I think `GPG_TTY` is empty.
```
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: cannot open '/dev/tty': No such device or address
[3380267.390798] docker0: port 1(vethc7eaef0) entered disabled state
[3380267.392344] veth5e3578a: renamed from eth0
[3380267.431628] docker0: port 1(vethc7eaef0) entered disabled state
[3380267.433775] device vethc7eaef0 left promiscuous mode
[3380267.434952] docker0: port 1(vethc7eaef0) entered disabled state
The command '/bin/sh -c gpg --import /tmp/gpg-keys/*' returned a non-zero code: 2
```