### PR TITLE
Change DB size on disk Error to warning

### DIFF
--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -1168,7 +1168,7 @@ func dirSize(path string) (int64, error) {
 func (d *RocksDB) DatabaseSizeOnDisk() int64 {
 	size, err := dirSize(d.path)
 	if err != nil {
-		glog.Error("rocksdb: DatabaseSizeOnDisk: ", err)
+		glog.Warning("rocksdb: DatabaseSizeOnDisk: ", err)
 		return 0
 	}
 	return size


### PR DESCRIPTION
Consider change "Error" message to "Warning" in function "DbDiskSize". So messages like "file no longer exists" will not be consider as error, but only warning instead.