### PR TITLE
fix KotoTestnet asc link

### DIFF
--- a/configs/coins/koto_testnet.json
+++ b/configs/coins/koto_testnet.json
@@ -25,7 +25,7 @@
     "version": "2.0.3",
     "binary_url": "https://github.com/KotoDevelopers/koto/releases/download/v2.0.3/koto-2.0.3-linux64.tar.gz",
     "verification_type": "gpg",
-    "verification_source": "https://github.com/KotoDevelopers/koto/releases/download/v2.0.3/koto-2.0.3.tar.gz.asc",
+    "verification_source": "https://github.com/KotoDevelopers/koto/releases/download/v2.0.3/koto-2.0.3-lilnux64.tar.gz.asc",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
         "bin/koto-qt"

--- a/configs/coins/koto_testnet.json
+++ b/configs/coins/koto_testnet.json
@@ -25,7 +25,7 @@
     "version": "2.0.3",
     "binary_url": "https://github.com/KotoDevelopers/koto/releases/download/v2.0.3/koto-2.0.3-linux64.tar.gz",
     "verification_type": "gpg",
-    "verification_source": "https://github.com/KotoDevelopers/koto/releases/download/v2.0.3/koto-2.0.3-lilnux64.tar.gz.asc",
+    "verification_source": "https://github.com/KotoDevelopers/koto/releases/download/v2.0.3/koto-2.0.3-linux64.tar.gz.asc",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
         "bin/koto-qt"


### PR DESCRIPTION
Fixed error in Koto 2.0.3 update (https://github.com/trezor/blockbook/commit/47a77c35c5bfce7ac4852f57c58fd81ad85666f3)
Testnet's link has expired
