### PR TITLE
Support Groestlcoin xpub

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -95,7 +95,7 @@
   branch = "master"
   name = "github.com/martinboehm/btcutil"
   packages = [".","base58","bech32","chaincfg","hdkeychain","txscript"]
-  revision = "63034958e64b209cb9294128309dbaed497cde7b"
+  revision = "225ed00dbbd5cb8d8b3949a0ee7c9ea540754585"
 
 [[projects]]
   branch = "master"

--- a/bchain/coins/btc/bitcoinparser.go
+++ b/bchain/coins/btc/bitcoinparser.go
@@ -343,7 +343,7 @@ func (p *BitcoinParser) addrDescFromExtKey(extKey *hdkeychain.ExtendedKey) (bcha
 
 // DeriveAddressDescriptors derives address descriptors from given xpub for listed indexes
 func (p *BitcoinParser) DeriveAddressDescriptors(xpub string, change uint32, indexes []uint32) ([]bchain.AddressDescriptor, error) {
-	extKey, err := hdkeychain.NewKeyFromString(xpub)
+	extKey, err := hdkeychain.NewKeyFromString(xpub, p.Params.Base58CksumHasher)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (p *BitcoinParser) DeriveAddressDescriptorsFromTo(xpub string, change uint3
 	if toIndex <= fromIndex {
 		return nil, errors.New("toIndex<=fromIndex")
 	}
-	extKey, err := hdkeychain.NewKeyFromString(xpub)
+	extKey, err := hdkeychain.NewKeyFromString(xpub, p.Params.Base58CksumHasher)
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +394,7 @@ func (p *BitcoinParser) DeriveAddressDescriptorsFromTo(xpub string, change uint3
 
 // DerivationBasePath returns base path of xpub
 func (p *BitcoinParser) DerivationBasePath(xpub string) (string, error) {
-	extKey, err := hdkeychain.NewKeyFromString(xpub)
+	extKey, err := hdkeychain.NewKeyFromString(xpub, p.Params.Base58CksumHasher)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Depends on https://github.com/martinboehm/btcutil/pull/1
Server with these changes is deployed at:
https://blockbook.groestlcoin.org/xpub/xpub6DGa4qjCDqDNhLWUCEPJSETizUdexA2i5k3wUG2QboRNa4MNJV4k5XthorGcogStY5K5iJ6NHtsznNK599ir8PmA3d1jqEoZHsixDTddNA9?tokens=used
BIP39 tool for GRS: https://groestlcoin.org/bip39/