### PR TITLE
Update shebangs to use bash from current environment

### DIFF
--- a/build/docker/deb/build-deb.sh
+++ b/build/docker/deb/build-deb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ $# -lt 2 ]; then

--- a/build/templates/blockbook/logrotate.sh
+++ b/build/templates/blockbook/logrotate.sh
@@ -1,5 +1,5 @@
 {{define "main" -}}
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 LOGS={{.Env.BlockbookInstallPath}}/{{.Coin.Alias}}/logs

--- a/build/tools/image_status.sh
+++ b/build/tools/image_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ $# -ne 2 ]; then

--- a/contrib/scripts/backend-deploy-and-test.sh
+++ b/contrib/scripts/backend-deploy-and-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -ne 1 ] && [ $# -ne 4 ]
 then

--- a/contrib/scripts/build-blockchaincfg.sh
+++ b/contrib/scripts/build-blockchaincfg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 go run build/templates/generate.go $1 > /dev/null
 mv build/pkg-defs/blockbook/blockchaincfg.json build

--- a/contrib/scripts/deploy-dev.sh
+++ b/contrib/scripts/deploy-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -lt 2 ]
 then

--- a/contrib/scripts/start-backend-tunnels.sh
+++ b/contrib/scripts/start-backend-tunnels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -ne 1 ]; then
     echo "Usage: $(basename $0) host" 1>&2


### PR DESCRIPTION
Use `#!/usr/bin/env bash` in shebangs instead of `#!/bin/bash`.

The benefit of using `/usr/bin/env bash` is that it will look up bash in current environment.
This will fix builds for some systems that don't have bash in `/bin` (for example, NixOS).

This has a single drawback of not being able to pass more that 1 interpreter option (like `bash -il`), but in our case it's not a problem, since we don't parametrize it anywhere.
