### PR TITLE
Optimize Docker build

### DIFF
--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM debian:9
 
+ENV DEBIAN_FRONTEND="noninteractive"
 ENV GOLANG_VERSION="go1.12.4.linux-amd64"
 ENV ROCKSDB_VERSION="v5.18.3"
 ENV GOPATH="/go"

--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -2,45 +2,45 @@
 
 FROM debian:9
 
+ENV GOLANG_VERSION="go1.12.4.linux-amd64"
+ENV ROCKSDB_VERSION="v5.18.3"
+ENV GOPATH="/go"
+ENV PATH="$PATH:$GOPATH/bin"
+ENV CGO_CFLAGS="-I/opt/rocksdb/include"
+ENV CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
+
+# upgrade the system and install dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y build-essential git wget pkg-config lxc-dev libzmq3-dev \
                        libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev \
                        liblz4-dev graphviz && \
-    apt-get clean
-
-ENV GOLANG_VERSION=go1.12.4.linux-amd64
-ENV ROCKSDB_VERSION=v5.18.3
-ENV GOPATH=/go
-ENV PATH=$PATH:$GOPATH/bin
-ENV CGO_CFLAGS="-I/opt/rocksdb/include"
-ENV CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
-
-RUN mkdir /build
-
-# install and configure go
-RUN cd /opt && wget https://storage.googleapis.com/golang/$GOLANG_VERSION.tar.gz && \
-    tar xf $GOLANG_VERSION.tar.gz
-RUN ln -s /opt/go/bin/go /usr/bin/go
-RUN mkdir -p $GOPATH
-RUN echo -n "GO version: " && go version
-RUN echo -n "GOPATH: " && echo $GOPATH
-
-# install rocksdb
-RUN cd /opt && git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git
-RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC make -j 4 release
-RUN strip /opt/rocksdb/ldb /opt/rocksdb/sst_dump && \
-    cp /opt/rocksdb/ldb /opt/rocksdb/sst_dump /build
-
-# install build tools
-RUN go get github.com/golang/dep/cmd/dep
-RUN go get github.com/gobuffalo/packr/...
-
-# download pre-loaded depencencies
-RUN \
-    cleanup() { rm -rf $GOPATH/src/blockbook; } && \
-    trap cleanup EXIT && \
-    cd $GOPATH/src && \
+    apt-get clean && \
+    mkdir /build && \
+\
+`# install and configure go` \
+    cd /opt && \
+    wget -q --progress=bar "https://storage.googleapis.com/golang/$GOLANG_VERSION.tar.gz" && \
+    tar xf $GOLANG_VERSION.tar.gz && \
+    ln -s /opt/go/bin/go /usr/bin/go && \
+    mkdir -p "$GOPATH" && \
+    echo -n "GO version: " && go version && \
+    echo -n "GOPATH: " && echo "$GOPATH" && \
+\
+`# install rocksdb` \
+    cd /opt && \
+    git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git && \
+    cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC make -j 4 release && \
+    strip /opt/rocksdb/ldb /opt/rocksdb/sst_dump && \
+    cp /opt/rocksdb/ldb /opt/rocksdb/sst_dump /build && \
+\
+`# install build tools` \
+    go get github.com/golang/dep/cmd/dep && \
+    go get github.com/gobuffalo/packr/... && \
+\
+`# download pre-loaded depencencies` \
+    trap 'rm -rf "$GOPATH/src/blockbook";' EXIT && \
+    cd "$GOPATH/src" && \
     git clone https://github.com/trezor/blockbook.git && \
     cd blockbook && \
     dep ensure -vendor-only && \

--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 `# install rocksdb` \
     cd /opt && \
     git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git && \
-    cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC make -j 4 release && \
+    cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC make -j$(nproc) release && \
     strip /opt/rocksdb/ldb /opt/rocksdb/sst_dump && \
     cp /opt/rocksdb/ldb /opt/rocksdb/sst_dump /build && \
 \

--- a/build/docker/deb/Dockerfile
+++ b/build/docker/deb/Dockerfile
@@ -2,13 +2,13 @@
 
 FROM blockbook-build:latest
 
+ADD gpg-keys /tmp/gpg-keys
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y devscripts debhelper make dh-systemd dh-exec && \
-    apt-get clean
-
-ADD gpg-keys /tmp/gpg-keys
-RUN gpg --batch --import /tmp/gpg-keys/*
+    apt-get clean && \
+    gpg --batch --import /tmp/gpg-keys/*
 
 ADD build-deb.sh /build/build-deb.sh
 


### PR DESCRIPTION
I've chained `RUN` commands to decrease the number of created layers, so the resulting images take less space.

I've also changed the number of compiler threads to have a dynamic value by using `nproc`, this should speed up the compilation a little.

The comments in subshells look hacky, but I didn't find any better way to comment chained code :(