### PR TITLE
Fix the --vendor-only flag reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+.vendor*
 data*/
 profile/
 blockbook

--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     cd $GOPATH/src && \
     git clone https://github.com/trezor/blockbook.git && \
     cd blockbook && \
-    dep ensure -vendor-only && \
+    dep ensure --vendor-only && \
     cp -r vendor /build/vendor
 
 ADD Makefile /build/Makefile

--- a/build/docker/bin/Makefile
+++ b/build/docker/bin/Makefile
@@ -41,7 +41,7 @@ prepare-sources:
 prepare-vendor:
 	@ if [ "$(UPDATE_VENDOR)" -eq 1 ]; then \
 		echo "Updating vendor"; \
-		cd $(BLOCKBOOK_SRC) && rm -rf vendor* && cp -r /build/vendor . && dep ensure -vendor-only ; \
+		cd $(BLOCKBOOK_SRC) && rm -rf vendor* && cp -r /build/vendor . && dep ensure --vendor-only ; \
 	else \
 		echo "Update of vendor not demanded, keeping version from src" ; \
 	fi

--- a/docs/build.md
+++ b/docs/build.md
@@ -234,7 +234,7 @@ Get blockbook sources, install dependencies, build:
 cd $GOPATH/src
 git clone https://github.com/trezor/blockbook.git
 cd blockbook
-dep ensure -vendor-only
+dep ensure --vendor-only
 go build
 ```
 


### PR DESCRIPTION
The `--vendor-only` dep flag was incorrectly referenced.

Since dependencies related to a specific coin are not added to the repo `Gopkg.toml`, running `dep ensure` to fetch all the dependencies creates `.vendor-new/` folder thus the reason why `.vendor*` was added to the `.gitignore` file.