### PR TITLE
Fix decred's xpub decoding

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -145,7 +145,7 @@
   branch = "master"
   name = "github.com/martinboehm/btcutil"
   packages = [".","base58","bech32","chaincfg","hdkeychain","txscript"]
-  revision = "a7b7a55592485f5972902f1caf076a434b079e29"
+  revision = "225ed00dbbd5cb8d8b3949a0ee7c9ea540754585"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,7 +79,7 @@
   name = "github.com/decred/dcrd"
   packages = ["chaincfg","chaincfg/chainec","chaincfg/chainhash","dcrec","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrjson","dcrutil","txscript","wire"]
   revision = "e3e8c47c68b010dbddeb783ebad32a3a4993dd71"
-  branch = "master"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/decred/slog"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -78,8 +78,8 @@
 [[projects]]
   name = "github.com/decred/dcrd"
   packages = ["chaincfg","chaincfg/chainec","chaincfg/chainhash","dcrec","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrjson","dcrutil","txscript","wire"]
-  revision = "0fe564967f03160b9dbe0a147420d8aa13371d12"
-  version = "v1.3.0"
+  revision = "e3e8c47c68b010dbddeb783ebad32a3a4993dd71"
+  branch = "master"
 
 [[projects]]
   name = "github.com/decred/slog"
@@ -145,7 +145,7 @@
   branch = "master"
   name = "github.com/martinboehm/btcutil"
   packages = [".","base58","bech32","chaincfg","hdkeychain","txscript"]
-  revision = "225ed00dbbd5cb8d8b3949a0ee7c9ea540754585"
+  revision = "a7b7a55592485f5972902f1caf076a434b079e29"
 
 [[projects]]
   branch = "master"

--- a/bchain/coins/dcr/decredparser_test.go
+++ b/bchain/coins/dcr/decredparser_test.go
@@ -93,8 +93,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	testnetParser = NewDecredParser(GetChainParams("testnet3"), &btc.Configuration{})
-	mainnetParser = NewDecredParser(GetChainParams("mainnet"), &btc.Configuration{})
+	testnetParser = NewDecredParser(GetChainParams("testnet3"), &btc.Configuration{Slip44: 1})
+	mainnetParser = NewDecredParser(GetChainParams("mainnet"), &btc.Configuration{Slip44: 42})
 	exitCode := m.Run()
 	os.Exit(exitCode)
 }
@@ -393,6 +393,49 @@ func TestDeriveAddressDescriptorsFromTo(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotAddresses, tt.want) {
 				t.Errorf("DeriveAddressDescriptorsFromTo() = %v, want %v", gotAddresses, tt.want)
+			}
+		})
+	}
+}
+
+func TestDerivationBasePath(t *testing.T) {
+	tests := []struct {
+		name   string
+		xpub   string
+		parser *DecredParser
+	}{
+		{
+			name:   "m/44'/42'/2'",
+			xpub:   "dpubZFYFpu8cZxwrGnWbdHmvsAcTaMve4W9EAUiSHzXp1c5hQvfeWgk7LxsE5LqopwfxV62CoB51fxw97YaNpdA3tdo4GHbLxtUzRmYcUtVPYUi",
+			parser: mainnetParser,
+		},
+		{
+			name:   "m/44'/42'/1'",
+			xpub:   "dpubZFYFpu8cZxwrESo75eazNjVHtC4nWJqL5aXxExZHKnyvZxKirkpypbgeJhVzhTdfnK2986DLjich4JQqcSaSyxu5KSoZ25KJ67j4mQJ9iqx",
+			parser: mainnetParser,
+		},
+		{
+			name:   "m/44'/1'/2'",
+			xpub:   "tpubVossdTiJtheA51AuNQZtqvKUbhM867Von8XBadxX3tRkDm71kyyi6U966jDPEw9RnQjNcQLwxYSnQ9kBjZxrxfmSbByRbz7D1PLjgAPmL42",
+			parser: testnetParser,
+		},
+		{
+			name:   "m/44'/1'/1'",
+			xpub:   "tpubVossdTiJtheA1fQniKn9EN1JE1Eq1kBofaq2KwywrvuNhAk1KsEM7J2r8anhMJUmmcn9Wmoh73EctpW7Vxs3gS8cbF7N3m4zVjzuyvBj3qC",
+			parser: testnetParser,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.parser.DerivationBasePath(tt.xpub)
+			if err != nil {
+				t.Errorf("DerivationBasePath() expected no error but got %v", err)
+				return
+			}
+
+			if got != tt.name {
+				t.Errorf("DerivationBasePath() = %v, want %v", got, tt.name)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes the extend public Key decoding  functionality that was returning an error before.

@dajohi This PR is still essential even if https://github.com/martinboehm/btcutil/pull/3 was merged.
It could even override that PR since implementation unique to decred's checksum hash generation is handled here fully.