### PR TITLE
Check if unindexed confirmed tx height exists

### DIFF
--- a/bchain/types.go
+++ b/bchain/types.go
@@ -76,12 +76,13 @@ type Vout struct {
 // Tx is blockchain transaction
 // unnecessary fields are commented out to avoid overhead
 type Tx struct {
-	Hex      string `json:"hex"`
-	Txid     string `json:"txid"`
-	Version  int32  `json:"version"`
-	LockTime uint32 `json:"locktime"`
-	Vin      []Vin  `json:"vin"`
-	Vout     []Vout `json:"vout"`
+	Hex         string `json:"hex"`
+	Txid        string `json:"txid"`
+	Version     int32  `json:"version"`
+	LockTime    uint32 `json:"locktime"`
+	Vin         []Vin  `json:"vin"`
+	Vout        []Vout `json:"vout"`
+	BlockHeight uint32 `json:"blockHeight,omitempty"`
 	// BlockHash     string `json:"blockhash,omitempty"`
 	Confirmations    uint32      `json:"confirmations,omitempty"`
 	Time             int64       `json:"time,omitempty"`

--- a/db/txcache.go
+++ b/db/txcache.go
@@ -65,13 +65,20 @@ func (c *TxCache) GetTransaction(txid string) (*bchain.Tx, uint32, error) {
 			if err != nil {
 				return nil, 0, err
 			}
-			// the transaction may me not yet indexed, in that case get the height from the backend
-			if ta == nil {
-				h, err = c.chain.GetBestBlockHeight()
-				if err != nil {
-					return nil, 0, err
+			switch {
+			case ta == nil:
+				// the transaction may not yet be indexed, in that case:
+				if tx.BlockHeight > 0 {
+					// Check if the tx height value is set.
+					h = tx.BlockHeight
+				} else {
+					// Get the height from the backend's bestblock.
+					h, err = c.chain.GetBestBlockHeight()
+					if err != nil {
+						return nil, 0, err
+					}
 				}
-			} else {
+			default:
 				h = ta.Height
 			}
 		} else if c.chainType == bchain.ChainEthereumType {


### PR DESCRIPTION
For unindexed confirmed transaction, unnecessary API call is being made to fetch the height from the back-end.
Since the block height could be readily available in most coins when unmarshaling tx data, avoid making that API call to the backed.