### PR TITLE
Check unindexed confirmed tx height for decred

### DIFF
--- a/bchain/coins/dcr/decredparser.go
+++ b/bchain/coins/dcr/decredparser.go
@@ -172,6 +172,7 @@ func (p *DecredParser) ParseTxFromJson(jsonTx json.RawMessage) (*bchain.Tx, erro
 		Txid:          getTxResult.Result.Txid,
 		Version:       getTxResult.Result.Version,
 		LockTime:      getTxResult.Result.LockTime,
+		BlockHeight:   getTxResult.Result.BlockHeight,
 		Vin:           vins,
 		Vout:          vouts,
 		Confirmations: uint32(getTxResult.Result.Confirmations),


### PR DESCRIPTION
This PR depends on #252 

- Decred's implementation mempool data shows confirmed transactions that are not yet indexed because of the decred's proof of stake implementation. (in blockbook, decred's tx with less than 2 confirmations are listed in the mempool)