### PR TITLE
bcash (+testnet): Bump backend 0.20.5 -> 0.20.6

### DIFF
--- a/configs/coins/bcash.json
+++ b/configs/coins/bcash.json
@@ -22,10 +22,10 @@
     "package_name": "backend-bcash",
     "package_revision": "satoshilabs-1",
     "system_user": "bcash",
-    "version": "0.20.5",
-    "binary_url": "https://download.bitcoinabc.org/0.20.5/linux/bitcoin-abc-0.20.5-x86_64-linux-gnu.tar.gz",
+    "version": "0.20.6",
+    "binary_url": "https://download.bitcoinabc.org/0.20.6/linux/bitcoin-abc-0.20.6-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "8197c0c26553d0c1dd5bc5e033aaec9dd7324ceab8218f075f7d48f4889e3aef",
+    "verification_source": "188f2e5922ce363324f1cbb51e0d502cbb2933458ea909b9871e96c7d53ebdce",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/bitcoin-qt"
@@ -49,7 +49,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Bitcoin ABC:0.20.5/",
+      "subversion": "/Bitcoin ABC:0.20.6/",
       "address_format": "cashaddr",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,

--- a/configs/coins/bcash_testnet.json
+++ b/configs/coins/bcash_testnet.json
@@ -22,10 +22,10 @@
     "package_name": "backend-bcash-testnet",
     "package_revision": "satoshilabs-1",
     "system_user": "bcash",
-    "version": "0.20.5",
-    "binary_url": "https://download.bitcoinabc.org/0.20.5/linux/bitcoin-abc-0.20.5-x86_64-linux-gnu.tar.gz",
+    "version": "0.20.6",
+    "binary_url": "https://download.bitcoinabc.org/0.20.6/linux/bitcoin-abc-0.20.6-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "8197c0c26553d0c1dd5bc5e033aaec9dd7324ceab8218f075f7d48f4889e3aef",
+    "verification_source": "188f2e5922ce363324f1cbb51e0d502cbb2933458ea909b9871e96c7d53ebdce",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/bitcoin-qt"
@@ -49,7 +49,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Bitcoin ABC:0.20.5/",
+      "subversion": "/Bitcoin ABC:0.20.6/",
       "address_format": "cashaddr",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,


### PR DESCRIPTION
Url to checksum https://download.bitcoinabc.org/0.20.6/linux/
Release notes https://github.com/Bitcoin-ABC/bitcoin-abc/releases