### PR TITLE
Fiat rates & Balance history update

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -303,7 +303,7 @@ type BalanceHistory struct {
 	Txs         uint32  `json:"txs"`
 	ReceivedSat *Amount `json:"received"`
 	SentSat     *Amount `json:"sent"`
-	FiatRate    string  `json:"fiatRate,omitempty"`
+	FiatRate    float64 `json:"fiatRate,omitempty"`
 	Txid        string  `json:"txid,omitempty"`
 }
 

--- a/api/worker.go
+++ b/api/worker.go
@@ -932,7 +932,7 @@ func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, fiat 
 }
 
 // GetBalanceHistory returns history of balance for given address
-func (w *Worker) GetBalanceHistory(address string, fromTime, toTime time.Time, fiat string) (BalanceHistories, error) {
+func (w *Worker) GetBalanceHistory(address string, fromTime, toTime time.Time, fiat string, groupBy uint32) (BalanceHistories, error) {
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
 	addrDesc, _, err := w.getAddrDescAndNormalizeAddress(address)
@@ -956,7 +956,7 @@ func (w *Worker) GetBalanceHistory(address string, fromTime, toTime time.Time, f
 			bhs = append(bhs, *bh)
 		}
 	}
-	bha := bhs.SortAndAggregate(3600)
+	bha := bhs.SortAndAggregate(groupBy)
 	if fiat != "" {
 		err = w.setFiatRateToBalanceHistories(bha, fiat)
 		if err != nil {

--- a/api/worker.go
+++ b/api/worker.go
@@ -1146,17 +1146,15 @@ func (w *Worker) getFiatRatesResult(currency string, ticker *db.CurrencyRatesTic
 			Rates:     ticker.Rates,
 		}, nil
 	}
-	rates := make(map[string]float64, 1)
 	timestamp := ticker.Timestamp.UTC().Unix()
 	if rate, found := ticker.Rates[currency]; !found {
 		return nil, NewAPIError(fmt.Sprintf("Currency %q is not available for timestamp %d.", currency, timestamp), true)
 	} else {
-		rates[currency] = rate
+		return &db.ResultTickerAsString{
+			Timestamp: timestamp,
+			Rate:      rate,
+		}, nil
 	}
-	return &db.ResultTickerAsString{
-		Timestamp: timestamp,
-		Rates:     rates,
-	}, nil
 }
 
 // GetFiatRatesForBlockID returns fiat rates for block height or block hash
@@ -1200,7 +1198,7 @@ func (w *Worker) GetCurrentFiatRates(currency string) (*db.ResultTickerAsString,
 }
 
 // GetFiatRatesForTimestamps returns fiat rates for each of the provided dates
-func (w *Worker) GetFiatRatesForTimestamps(timestamps []string, currency string) (*db.ResultTickersAsString, error) {
+func (w *Worker) GetFiatRatesForTimestamps(timestamps []int64, currency string) (*db.ResultTickersAsString, error) {
 	if currency == "" {
 		return nil, NewAPIError("Missing or empty \"currency\" parameter.", true)
 	} else if len(timestamps) == 0 {
@@ -1209,23 +1207,20 @@ func (w *Worker) GetFiatRatesForTimestamps(timestamps []string, currency string)
 
 	ret := &db.ResultTickersAsString{}
 	for _, timestamp := range timestamps {
-		date, err := db.FiatRatesTimestampToTime(timestamp)
-		if err != nil {
-			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Error: fmt.Sprintf("%q is not a valid Unix timestamp.", timestamp)})
-			continue
-		}
-		ticker, err := w.db.FiatRatesFindTicker(date)
+		date := time.Unix(timestamp, 0)
+		date = date.UTC()
+		ticker, err := w.db.FiatRatesFindTicker(&date)
 		if err != nil {
 			glog.Errorf("Error finding ticker for date %v. Error: %v", date, err)
-			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Timestamp: date.Unix(), Error: "Ticker not found."})
+			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Timestamp: date.Unix(), Rate: -1})
 			continue
 		} else if ticker == nil {
-			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Timestamp: date.Unix(), Error: fmt.Sprintf("No tickers available for currency %q", currency)})
+			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Timestamp: date.Unix(), Rate: -1})
 			continue
 		}
 		result, err := w.getFiatRatesResult(currency, ticker)
 		if err != nil {
-			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Error: fmt.Sprintf("%v", err)})
+			ret.Tickers = append(ret.Tickers, db.ResultTickerAsString{Timestamp: date.Unix(), Rate: -1})
 			continue
 		}
 		ret.Tickers = append(ret.Tickers, *result)
@@ -1234,17 +1229,11 @@ func (w *Worker) GetFiatRatesForTimestamps(timestamps []string, currency string)
 }
 
 // GetFiatRatesTickersList returns the list of available fiatRates tickers
-func (w *Worker) GetFiatRatesTickersList(timestampString string) (*db.ResultTickerListAsString, error) {
-	if timestampString == "" {
-		return nil, NewAPIError("Missing or empty \"timestamp\" parameter", true)
-	}
+func (w *Worker) GetFiatRatesTickersList(timestamp int64) (*db.ResultTickerListAsString, error) {
+	date := time.Unix(timestamp, 0)
+	date = date.UTC()
 
-	date, err := db.FiatRatesTimestampToTime(timestampString)
-	if err != nil {
-		return nil, NewAPIError(fmt.Sprintf("%v is not a valid Unix timestamp.", timestampString), false)
-	}
-
-	ticker, err := w.db.FiatRatesFindTicker(date)
+	ticker, err := w.db.FiatRatesFindTicker(&date)
 	if err != nil {
 		return nil, NewAPIError(fmt.Sprintf("Error finding ticker: %v", err), false)
 	} else if ticker == nil {
@@ -1256,7 +1245,6 @@ func (w *Worker) GetFiatRatesTickersList(timestampString string) (*db.ResultTick
 		keys = append(keys, k)
 	}
 	sort.Strings(keys) // sort to get deterministic results
-	timestamp := ticker.Timestamp.UTC().Unix()
 
 	return &db.ResultTickerListAsString{
 		Timestamp: timestamp,

--- a/api/worker.go
+++ b/api/worker.go
@@ -1138,6 +1138,25 @@ func (w *Worker) GetBlocks(page int, blocksOnPage int) (*Blocks, error) {
 	return r, nil
 }
 
+// getFiatRatesResults checks if CurrencyRatesTicker contains all necessary data and returns formatted result
+func (w *Worker) getFiatRatesResults(currency string, ticker *db.CurrencyRatesTicker) (*db.ResultTickerAsString, error) {
+	if currency == "" {
+		return &db.ResultTickerAsString{
+			Timestamp: ticker.Timestamp.UTC().Unix(),
+			Rates:     ticker.Rates,
+		}, nil
+	}
+	timestamp := ticker.Timestamp.UTC().Unix()
+	if rate, found := ticker.Rates[currency]; !found {
+		return nil, NewAPIError(fmt.Sprintf("Currency %q is not available for timestamp %d.", currency, timestamp), true)
+	} else {
+		return &db.ResultTickerAsString{
+			Timestamp: timestamp,
+			Rates:     map[string]float64{currency: rate},
+		}, nil
+	}
+}
+
 // getFiatRatesResult checks if CurrencyRatesTicker contains all necessary data and returns formatted result
 func (w *Worker) getFiatRatesResult(currency string, ticker *db.CurrencyRatesTicker) (*db.ResultTickerAsString, error) {
 	if currency == "" {

--- a/api/worker.go
+++ b/api/worker.go
@@ -925,7 +925,7 @@ func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, fiat 
 			continue
 		}
 		if rate, found := ticker.Rates[fiat]; found {
-			bh.FiatRate = string(rate)
+			bh.FiatRate = rate
 		}
 	}
 	return nil
@@ -1146,7 +1146,7 @@ func (w *Worker) getFiatRatesResult(currency string, ticker *db.CurrencyRatesTic
 			Rates:     ticker.Rates,
 		}, nil
 	}
-	rates := make(map[string]json.Number, 1)
+	rates := make(map[string]float64, 1)
 	timestamp := ticker.Timestamp.UTC().Unix()
 	if rate, found := ticker.Rates[currency]; !found {
 		return nil, NewAPIError(fmt.Sprintf("Currency %q is not available for timestamp %d.", currency, timestamp), true)

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -591,7 +591,7 @@ func (w *Worker) GetXpubUtxo(xpub string, onlyConfirmed bool, gap int) (Utxos, e
 }
 
 // GetXpubBalanceHistory returns history of balance for given xpub
-func (w *Worker) GetXpubBalanceHistory(xpub string, fromTime, toTime time.Time, fiat string, gap int) (BalanceHistories, error) {
+func (w *Worker) GetXpubBalanceHistory(xpub string, fromTime, toTime time.Time, fiat string, gap int, groupBy uint32) (BalanceHistories, error) {
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
 	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTime, toTime)
@@ -622,7 +622,7 @@ func (w *Worker) GetXpubBalanceHistory(xpub string, fromTime, toTime time.Time, 
 			}
 		}
 	}
-	bha := bhs.SortAndAggregate(3600)
+	bha := bhs.SortAndAggregate(groupBy)
 	if fiat != "" {
 		err = w.setFiatRateToBalanceHistories(bha, fiat)
 		if err != nil {

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -42,7 +42,7 @@ type CurrencyRatesTicker struct {
 
 // ResultTickerAsString contains formatted CurrencyRatesTicker data
 type ResultTickerAsString struct {
-	Timestamp string                 `json:"data_timestamp,omitempty"`
+	Timestamp int64                  `json:"ts,omitempty"`
 	Rates     map[string]json.Number `json:"rates,omitempty"`
 	Error     string                 `json:"error,omitempty"`
 }
@@ -54,7 +54,7 @@ type ResultTickersAsString struct {
 
 // ResultTickerListAsString contains formatted data about available currency tickers
 type ResultTickerListAsString struct {
-	Timestamp string   `json:"data_timestamp,omitempty"`
+	Timestamp int64    `json:"data_timestamp,omitempty"`
 	Tickers   []string `json:"available_currencies"`
 	Error     string   `json:"error,omitempty"`
 }
@@ -188,6 +188,17 @@ func FiatRatesConvertDate(date string) (*time.Time, error) {
 	msg := "Date \"" + date + "\" does not match any of available formats. "
 	msg += "Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"
 	return nil, errors.New(msg)
+}
+
+// FiatRatesTimestampToTime converts the unix timestamp string to a Time object
+func FiatRatesTimestampToTime(timestamp string) (*time.Time, error) {
+	i, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	ts := time.Unix(i, 0)
+	ts = ts.UTC()
+	return &ts, nil
 }
 
 // FiatRatesStoreTicker stores ticker data at the specified time

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -42,8 +42,9 @@ type CurrencyRatesTicker struct {
 
 // ResultTickerAsString contains formatted CurrencyRatesTicker data
 type ResultTickerAsString struct {
-	Timestamp int64              `json:"ts,omitempty"`
+	Timestamp int64              `json:"rate_ts,omitempty"`
 	Rates     map[string]float64 `json:"rates,omitempty"`
+	Rate      float64            `json:"rate,omitempty"`
 	Error     string             `json:"error,omitempty"`
 }
 
@@ -188,17 +189,6 @@ func FiatRatesConvertDate(date string) (*time.Time, error) {
 	msg := "Date \"" + date + "\" does not match any of available formats. "
 	msg += "Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"
 	return nil, errors.New(msg)
-}
-
-// FiatRatesTimestampToTime converts the unix timestamp string to a Time object
-func FiatRatesTimestampToTime(timestamp string) (*time.Time, error) {
-	i, err := strconv.ParseInt(timestamp, 10, 64)
-	if err != nil {
-		return nil, err
-	}
-	ts := time.Unix(i, 0)
-	ts = ts.UTC()
-	return &ts, nil
 }
 
 // FiatRatesStoreTicker stores ticker data at the specified time

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -55,7 +55,7 @@ type ResultTickersAsString struct {
 
 // ResultTickerListAsString contains formatted data about available currency tickers
 type ResultTickerListAsString struct {
-	Timestamp int64   `json:"ts,omitempty"`
+	Timestamp int64    `json:"ts,omitempty"`
 	Tickers   []string `json:"available_currencies"`
 	Error     string   `json:"error,omitempty"`
 }

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -37,14 +37,14 @@ const FiatRatesTimeFormat = "20060102150405" // YYYYMMDDhhmmss
 // CurrencyRatesTicker contains coin ticker data fetched from API
 type CurrencyRatesTicker struct {
 	Timestamp *time.Time // return as unix timestamp in API
-	Rates     map[string]json.Number
+	Rates     map[string]float64
 }
 
 // ResultTickerAsString contains formatted CurrencyRatesTicker data
 type ResultTickerAsString struct {
-	Timestamp int64                  `json:"ts,omitempty"`
-	Rates     map[string]json.Number `json:"rates,omitempty"`
-	Error     string                 `json:"error,omitempty"`
+	Timestamp int64              `json:"ts,omitempty"`
+	Rates     map[string]float64 `json:"rates,omitempty"`
+	Error     string             `json:"error,omitempty"`
 }
 
 // ResultTickersAsString contains a formatted CurrencyRatesTicker list

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -42,7 +42,7 @@ type CurrencyRatesTicker struct {
 
 // ResultTickerAsString contains formatted CurrencyRatesTicker data
 type ResultTickerAsString struct {
-	Timestamp int64              `json:"rateTs,omitempty"`
+	Timestamp int64              `json:"ts,omitempty"`
 	Rates     map[string]float64 `json:"rates,omitempty"`
 	Rate      float64            `json:"rate,omitempty"`
 	Error     string             `json:"error,omitempty"`
@@ -55,7 +55,7 @@ type ResultTickersAsString struct {
 
 // ResultTickerListAsString contains formatted data about available currency tickers
 type ResultTickerListAsString struct {
-	Timestamp int64    `json:"dataTimestamp,omitempty"`
+	Timestamp int64   `json:"ts,omitempty"`
 	Tickers   []string `json:"available_currencies"`
 	Error     string   `json:"error,omitempty"`
 }

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -42,7 +42,7 @@ type CurrencyRatesTicker struct {
 
 // ResultTickerAsString contains formatted CurrencyRatesTicker data
 type ResultTickerAsString struct {
-	Timestamp int64              `json:"rate_ts,omitempty"`
+	Timestamp int64              `json:"rateTs,omitempty"`
 	Rates     map[string]float64 `json:"rates,omitempty"`
 	Rate      float64            `json:"rate,omitempty"`
 	Error     string             `json:"error,omitempty"`
@@ -55,7 +55,7 @@ type ResultTickersAsString struct {
 
 // ResultTickerListAsString contains formatted data about available currency tickers
 type ResultTickerListAsString struct {
-	Timestamp int64    `json:"data_timestamp,omitempty"`
+	Timestamp int64    `json:"dataTimestamp,omitempty"`
 	Tickers   []string `json:"available_currencies"`
 	Error     string   `json:"error,omitempty"`
 }

--- a/db/rocksdb_test.go
+++ b/db/rocksdb_test.go
@@ -9,7 +9,6 @@ import (
 	"blockbook/tests/dbtestdata"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -1131,20 +1130,26 @@ func TestRocksTickers(t *testing.T) {
 	ts1, _ := time.Parse(FiatRatesTimeFormat, "20190628000000")
 	ticker1 := &CurrencyRatesTicker{
 		Timestamp: &ts1,
-		Rates: map[string]json.Number{
-			"usd": "20000",
+		Rates: map[string]float64{
+			"usd": 20000,
 		},
 	}
 
 	ts2, _ := time.Parse(FiatRatesTimeFormat, "20190629000000")
 	ticker2 := &CurrencyRatesTicker{
 		Timestamp: &ts2,
-		Rates: map[string]json.Number{
-			"usd": "30000",
+		Rates: map[string]float64{
+			"usd": 30000,
 		},
 	}
-	d.FiatRatesStoreTicker(ticker1)
+	err := d.FiatRatesStoreTicker(ticker1)
+	if err != nil {
+		t.Errorf("Error storing ticker! %v", err)
+	}
 	d.FiatRatesStoreTicker(ticker2)
+	if err != nil {
+		t.Errorf("Error storing ticker! %v", err)
+	}
 
 	ticker, err := d.FiatRatesFindTicker(&key) // should find the closest key (ticker1)
 	if err != nil {

--- a/docs/api.md
+++ b/docs/api.md
@@ -648,7 +648,7 @@ Example error response (e.g. rate unavailable, incorrect currency...):
 Returns a balance history for the specified XPUB or address.
 
 ```
-GET /api/v2/balancehistory/<XPUB | address>?from=<dateFrom>&to=<dateTo>[&fiatcurrency=<currency>&gap=<gap>&groupBy=<groupBySeconds>]
+GET /api/v2/balancehistory/<XPUB | address>?from=<dateFrom>&to=<dateTo>[&fiatcurrency=<currency>&groupBy=<groupBySeconds>]
 ```
 
 Query parameters:
@@ -657,7 +657,6 @@ Query parameters:
 
 The optional query parameters:
 - *fiatcurrency*: if specified, the response will contain calculated fiat amounts at the time of transaction.
-- *gap*: TODO
 - *groupBy*: an interval in seconds, to group results by. Default is 3600 seconds.
 
 Example response (fiatcurrency=usd):
@@ -677,6 +676,20 @@ Example response (fiatcurrency=usd):
     "received":"0",
     "sent":"6169114",
     "fiatRate":479.1233
+  }
+]
+```
+
+Example response (fiatcurrency=usd&groupBy=100000):
+
+```javascript
+[
+  {
+    "time":1397700000,
+    "txs":2,
+    "received":"6169114",
+    "sent":"6169114",
+    "fiatRate":478.2312
   }
 ]
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -680,7 +680,7 @@ Example response (fiatcurrency=usd):
 ]
 ```
 
-Example response (fiatcurrency=usd&groupBy=100000):
+Example response (fiatcurrency=usd&groupBy=86400):
 
 ```javascript
 [

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -100,7 +100,7 @@ func (cg *Coingecko) getTicker(timestamp *time.Time) (*db.CurrencyRatesTicker, e
 
 	type FiatRatesResponse struct {
 		MarketData struct {
-			Prices map[string]json.Number `json:"current_price"`
+			Prices map[string]float64 `json:"current_price"`
 		} `json:"market_data"`
 	}
 

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -143,7 +143,7 @@ func (rd *RatesDownloader) findEarliestMarketData() (*time.Time, error) {
 // syncLatest downloads the latest FiatRates data every rd.PeriodSeconds
 func (rd *RatesDownloader) syncLatest() error {
 	timer := time.NewTimer(rd.periodSeconds)
-	var lastTickerRates map[string]json.Number = nil
+	var lastTickerRates map[string]float64 = nil
 	sameTickerCounter := 0
 	for {
 		ticker, err := rd.downloader.getTicker(nil)

--- a/server/public.go
+++ b/server/public.go
@@ -1058,12 +1058,18 @@ func (s *PublicServer) apiBalanceHistory(r *http.Request, apiVersion int) (inter
 			// time.RFC3339
 			toTime, _ = time.Parse("2006-01-02", t)
 		}
+		var groupBy uint32
+		i, err := strconv.ParseUint(r.URL.Query().Get("groupBy"), 10, 32)
+		if err == nil || i <= 0 {
+			groupBy = 3600
+		}
 		fiat := r.URL.Query().Get("fiatcurrency")
-		history, err = s.api.GetXpubBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, gap)
+
+		history, err = s.api.GetXpubBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, gap, groupBy)
 		if err == nil {
 			s.metrics.ExplorerViews.With(common.Labels{"action": "api-xpub-balancehistory"}).Inc()
 		} else {
-			history, err = s.api.GetBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat)
+			history, err = s.api.GetBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, groupBy)
 			s.metrics.ExplorerViews.With(common.Labels{"action": "api-address-balancehistory"}).Inc()
 		}
 	}

--- a/server/public.go
+++ b/server/public.go
@@ -1130,12 +1130,12 @@ func (s *PublicServer) apiSendTx(r *http.Request, apiVersion int) (interface{}, 
 // apiTickersList returns a list of available FiatRates currencies
 func (s *PublicServer) apiTickersList(r *http.Request, apiVersion int) (interface{}, error) {
 	s.metrics.ExplorerViews.With(common.Labels{"action": "api-tickers-list"}).Inc()
-	date := strings.ToLower(r.URL.Query().Get("date"))
-	result, err := s.api.GetFiatRatesTickersList(date)
+	timestamp := strings.ToLower(r.URL.Query().Get("timestamp"))
+	result, err := s.api.GetFiatRatesTickersList(timestamp)
 	return result, err
 }
 
-// apiTickers returns FiatRates ticker prices for the specified block or date.
+// apiTickers returns FiatRates ticker prices for the specified block or timestamp.
 func (s *PublicServer) apiTickers(r *http.Request, apiVersion int) (interface{}, error) {
 	var result *db.ResultTickerAsString
 	var err error
@@ -1145,10 +1145,10 @@ func (s *PublicServer) apiTickers(r *http.Request, apiVersion int) (interface{},
 		// Get tickers for specified block height or block hash
 		s.metrics.ExplorerViews.With(common.Labels{"action": "api-tickers-block"}).Inc()
 		result, err = s.api.GetFiatRatesForBlockID(block, currency)
-	} else if date := r.URL.Query().Get("date"); date != "" {
-		// Get tickers for specified date
+	} else if timestamp := r.URL.Query().Get("timestamp"); timestamp != "" {
+		// Get tickers for specified timestamp
 		s.metrics.ExplorerViews.With(common.Labels{"action": "api-tickers-date"}).Inc()
-		resultTickers, err := s.api.GetFiatRatesForDates([]string{date}, currency)
+		resultTickers, err := s.api.GetFiatRatesForTimestamps([]string{timestamp}, currency)
 		if err != nil {
 			return nil, err
 		}

--- a/server/public.go
+++ b/server/public.go
@@ -1058,20 +1058,17 @@ func (s *PublicServer) apiBalanceHistory(r *http.Request, apiVersion int) (inter
 			// time.RFC3339
 			toTime, _ = time.Parse("2006-01-02", t)
 		}
-		var groupBy uint32
-		i, err := strconv.ParseUint(r.URL.Query().Get("groupBy"), 10, 32)
-		if err != nil || i <= 0 {
+		var groupBy uint64
+		groupBy, err = strconv.ParseUint(r.URL.Query().Get("groupBy"), 10, 32)
+		if err != nil || groupBy == 0 {
 			groupBy = 3600
-		} else {
-			groupBy = uint32(i)
 		}
 		fiat := r.URL.Query().Get("fiatcurrency")
-
-		history, err = s.api.GetXpubBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, gap, groupBy)
+		history, err = s.api.GetXpubBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, gap, uint32(groupBy))
 		if err == nil {
 			s.metrics.ExplorerViews.With(common.Labels{"action": "api-xpub-balancehistory"}).Inc()
 		} else {
-			history, err = s.api.GetBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, groupBy)
+			history, err = s.api.GetBalanceHistory(r.URL.Path[i+1:], fromTime, toTime, fiat, uint32(groupBy))
 			s.metrics.ExplorerViews.With(common.Labels{"action": "api-address-balancehistory"}).Inc()
 		}
 	}

--- a/server/public.go
+++ b/server/public.go
@@ -1060,8 +1060,10 @@ func (s *PublicServer) apiBalanceHistory(r *http.Request, apiVersion int) (inter
 		}
 		var groupBy uint32
 		i, err := strconv.ParseUint(r.URL.Query().Get("groupBy"), 10, 32)
-		if err == nil || i <= 0 {
+		if err != nil || i <= 0 {
 			groupBy = 3600
+		} else {
+			groupBy = uint32(i)
 		}
 		fiat := r.URL.Query().Get("fiatcurrency")
 

--- a/server/public.go
+++ b/server/public.go
@@ -1130,7 +1130,11 @@ func (s *PublicServer) apiSendTx(r *http.Request, apiVersion int) (interface{}, 
 // apiTickersList returns a list of available FiatRates currencies
 func (s *PublicServer) apiTickersList(r *http.Request, apiVersion int) (interface{}, error) {
 	s.metrics.ExplorerViews.With(common.Labels{"action": "api-tickers-list"}).Inc()
-	timestamp := strings.ToLower(r.URL.Query().Get("timestamp"))
+	timestampString := strings.ToLower(r.URL.Query().Get("timestamp"))
+	timestamp, err := strconv.ParseInt(timestampString, 10, 64)
+	if err != nil {
+		return nil, api.NewAPIError("Parameter \"timestamp\" is not a valid Unix timestamp.", true)
+	}
 	result, err := s.api.GetFiatRatesTickersList(timestamp)
 	return result, err
 }
@@ -1145,10 +1149,16 @@ func (s *PublicServer) apiTickers(r *http.Request, apiVersion int) (interface{},
 		// Get tickers for specified block height or block hash
 		s.metrics.ExplorerViews.With(common.Labels{"action": "api-tickers-block"}).Inc()
 		result, err = s.api.GetFiatRatesForBlockID(block, currency)
-	} else if timestamp := r.URL.Query().Get("timestamp"); timestamp != "" {
+	} else if timestampString := r.URL.Query().Get("timestamp"); timestampString != "" {
 		// Get tickers for specified timestamp
 		s.metrics.ExplorerViews.With(common.Labels{"action": "api-tickers-date"}).Inc()
-		resultTickers, err := s.api.GetFiatRatesForTimestamps([]string{timestamp}, currency)
+
+		timestamp, err := strconv.ParseInt(timestampString, 10, 64)
+		if err != nil {
+			return nil, api.NewAPIError("Parameter \"timestamp\" is not a valid Unix timestamp.", true)
+		}
+
+		resultTickers, err := s.api.GetFiatRatesForTimestamps([]int64{timestamp}, currency)
 		if err != nil {
 			return nil, err
 		}

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -533,7 +533,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1574346615,"rate":7914.5}`,
+				`{"ts":"20191121143015","rates":{"usd":7914.5}}`,
 			},
 		},
 		{
@@ -542,7 +542,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1574344800,"rate":7814.5}`,
+				`{"ts":"20191121140000","rates":{"usd":7814.5}}`,
 			},
 		},
 		{
@@ -569,7 +569,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1574344800,"rate":7100}`,
+				`{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}`,
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1521511200,"rate":2000}`,
+				`{"ts":"20191121140000","rates":{"usd":7814.5}}`,
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1521611721,"rate":2003}`,
+				`{"ts":"20180321055521","rates":{"usd":2003.0}}`,
 			},
 		},
 		{
@@ -596,7 +596,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1574346615,"rate":7134.1}`,
+				`{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}`,
 			},
 		},
 		{
@@ -614,7 +614,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"dataTimestamp":1574346615,"available_currencies":["eur","usd"]}`,
+				`{"ts":"20191121140000","available_currencies":["eur","usd"]}`,
 			},
 		},
 		{
@@ -1212,7 +1212,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "usd",
 				},
 			},
-			want: `{"id":"18","data":{"rateTs":1574346615,"rate":7914.5}}`,
+			want: `{"id":"18","data":{"ts":"20191121143015","rates":{"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates eur",
@@ -1222,7 +1222,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "eur",
 				},
 			},
-			want: `{"id":"19","data":{"rateTs":1574346615,"rate":7134.1}}`,
+			want: `{"id":"19","data":{"ts":"20191121143015","rates":{"eur":7134.1,"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates incorrect currency",
@@ -1275,7 +1275,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1574346615},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"rateTs":1574346615,"rate":7914.5}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"ts":"20191121140000","rates":{"usd":7814.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps closest date, eur",
@@ -1286,7 +1286,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1521507600},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"rateTs":1521511200,"rate":1300}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1297,7 +1297,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"rateTs":1574344800,"rate":7814.5},{"rateTs":1574346615,"rate":7914.5}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"ts":"20191121140000","rates":{"usd":7814.5}},{"ts":"20191121143015","rates":{"usd":7914.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
@@ -1308,7 +1308,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"rateTs":1574344800,"rate":7100},{"rateTs":1574346615,"rate":7134.1}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}},{"ts":"20191121143015","rates":{"eur":7134.1,"usd":7914.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1319,7 +1319,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"rateTs":1574344800,"rate":7814.5},{"rateTs":1574346615,"rate":7914.5},{"rateTs":2000000000,"rate":-1}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"ts":"20191121140000","rates":{"usd":7814.5}},{"ts":"20191121143015","rates":{"usd":7914.5}},{"error":"Date \"not-a-real-date\" does not match any of available formats. Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple errors",
@@ -1340,7 +1340,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamp": 1570346615,
 				},
 			},
-			want: `{"id":"30","data":{"dataTimestamp":1570346615,"available_currencies":["eur","usd"]}}`,
+			want: `{"id":"30","data":{"ts":"20191121140000","available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -154,7 +154,7 @@ func newPostRequest(u string, body string) *http.Request {
 	return r
 }
 
-func insertFiatRate(date string, rates map[string]json.Number, d *db.RocksDB) error {
+func insertFiatRate(date string, rates map[string]float64, d *db.RocksDB) error {
 	convertedDate, err := db.FiatRatesConvertDate(date)
 	if err != nil {
 		return err
@@ -168,39 +168,39 @@ func insertFiatRate(date string, rates map[string]json.Number, d *db.RocksDB) er
 
 // InitTestFiatRates initializes test data for /api/v2/tickers endpoint
 func InitTestFiatRates(d *db.RocksDB) error {
-	if err := insertFiatRate("20180320020000", map[string]json.Number{
-		"usd": "2000.0",
-		"eur": "1300.0",
+	if err := insertFiatRate("20180320020000", map[string]float64{
+		"usd": 2000.0,
+		"eur": 1300.0,
 	}, d); err != nil {
 		return err
 	}
-	if err := insertFiatRate("20180320030000", map[string]json.Number{
-		"usd": "2001.0",
-		"eur": "1301.0",
+	if err := insertFiatRate("20180320030000", map[string]float64{
+		"usd": 2001.0,
+		"eur": 1301.0,
 	}, d); err != nil {
 		return err
 	}
-	if err := insertFiatRate("20180320040000", map[string]json.Number{
-		"usd": "2002.0",
-		"eur": "1302.0",
+	if err := insertFiatRate("20180320040000", map[string]float64{
+		"usd": 2002.0,
+		"eur": 1302.0,
 	}, d); err != nil {
 		return err
 	}
-	if err := insertFiatRate("20180321055521", map[string]json.Number{
-		"usd": "2003.0",
-		"eur": "1303.0",
+	if err := insertFiatRate("20180321055521", map[string]float64{
+		"usd": 2003.0,
+		"eur": 1303.0,
 	}, d); err != nil {
 		return err
 	}
-	if err := insertFiatRate("20191121140000", map[string]json.Number{
-		"usd": "7814.5",
-		"eur": "7100.0",
+	if err := insertFiatRate("20191121140000", map[string]float64{
+		"usd": 7814.5,
+		"eur": 7100.0,
 	}, d); err != nil {
 		return err
 	}
-	return insertFiatRate("20191121143015", map[string]json.Number{
-		"usd": "7914.5",
-		"eur": "7134.1",
+	return insertFiatRate("20191121143015", map[string]float64{
+		"usd": 7914.5,
+		"eur": 7134.1,
 	}, d)
 }
 
@@ -569,7 +569,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574344800,"rates":{"eur":7100.0}}`,
+				`{"ts":1574344800,"rates":{"eur":7100}}`,
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1521511200,"rates":{"usd":2000.0}}`,
+				`{"ts":1521511200,"rates":{"usd":2000}}`,
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1521611721,"rates":{"usd":2003.0}}`,
+				`{"ts":1521611721,"rates":{"usd":2003}}`,
 			},
 		},
 		{
@@ -785,7 +785,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"9876","sent":"0","fiatRate":"1301.0"},{"time":1521594000,"txs":1,"received":"9000","sent":"9876","fiatRate":"1303.0"}]`,
+				`[{"time":1521514800,"txs":1,"received":"9876","sent":"0","fiatRate":1301},{"time":1521594000,"txs":1,"received":"9000","sent":"9876","fiatRate":1303}]`,
 			},
 		},
 		{
@@ -821,7 +821,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"1","sent":"0","fiatRate":"2001.0"}]`,
+				`[{"time":1521514800,"txs":1,"received":"1","sent":"0","fiatRate":2001}]`,
 			},
 		},
 		{
@@ -1286,7 +1286,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []string{"1521507600"},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300.0}}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1308,7 +1308,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []string{"1570346615", "1574346615"},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100.0}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1373,7 +1373,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"fiat":       "usd",
 				},
 			},
-			want: `{"id":"33","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","fiatRate":"2001.0"}]}`,
+			want: `{"id":"33","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","fiatRate":2001}]}`,
 		},
 	}
 

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -524,7 +524,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
+				`{"rateTs":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
 			},
 		},
 		{
@@ -533,7 +533,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1574346615,"rate":7914.5}`,
+				`{"rateTs":1574346615,"rate":7914.5}`,
 			},
 		},
 		{
@@ -542,7 +542,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1574344800,"rate":7814.5}`,
+				`{"rateTs":1574344800,"rate":7814.5}`,
 			},
 		},
 		{
@@ -560,7 +560,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":7980386400,"rate":-1}`,
+				`{"rateTs":7980386400,"rate":-1}`,
 			},
 		},
 		{
@@ -569,7 +569,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1574344800,"rate":7100}`,
+				`{"rateTs":1574344800,"rate":7100}`,
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1521511200,"rate":2000}`,
+				`{"rateTs":1521511200,"rate":2000}`,
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1521611721,"rate":2003}`,
+				`{"rateTs":1521611721,"rate":2003}`,
 			},
 		},
 		{
@@ -596,7 +596,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1574346615,"rate":7134.1}`,
+				`{"rateTs":1574346615,"rate":7134.1}`,
 			},
 		},
 		{
@@ -605,7 +605,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rate_ts":1574346615,"rate":-1}`,
+				`{"rateTs":1574346615,"rate":-1}`,
 			},
 		},
 		{
@@ -614,7 +614,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":1574346615,"available_currencies":["eur","usd"]}`,
+				`{"dataTimestamp":1574346615,"available_currencies":["eur","usd"]}`,
 			},
 		},
 		{
@@ -1202,7 +1202,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"": "",
 				},
 			},
-			want: `{"id":"17","data":{"rate_ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
+			want: `{"id":"17","data":{"rateTs":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates usd",
@@ -1212,7 +1212,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "usd",
 				},
 			},
-			want: `{"id":"18","data":{"rate_ts":1574346615,"rate":7914.5}}`,
+			want: `{"id":"18","data":{"rateTs":1574346615,"rate":7914.5}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates eur",
@@ -1222,7 +1222,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "eur",
 				},
 			},
-			want: `{"id":"19","data":{"rate_ts":1574346615,"rate":7134.1}}`,
+			want: `{"id":"19","data":{"rateTs":1574346615,"rate":7134.1}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates incorrect currency",
@@ -1264,7 +1264,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7885693815},
 				},
 			},
-			want: `{"id":"23","data":{"tickers":[{"rate_ts":7885693815,"rate":-1}]}}`,
+			want: `{"id":"23","data":{"tickers":[{"rateTs":7885693815,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps exact date",
@@ -1275,7 +1275,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1574346615},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"rate_ts":1574346615,"rate":7914.5}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"rateTs":1574346615,"rate":7914.5}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps closest date, eur",
@@ -1286,7 +1286,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1521507600},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"rate_ts":1521511200,"rate":1300}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"rateTs":1521511200,"rate":1300}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1297,7 +1297,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"rate_ts":1574344800,"rate":7814.5},{"rate_ts":1574346615,"rate":7914.5}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"rateTs":1574344800,"rate":7814.5},{"rateTs":1574346615,"rate":7914.5}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
@@ -1308,7 +1308,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"rate_ts":1574344800,"rate":7100},{"rate_ts":1574346615,"rate":7134.1}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"rateTs":1574344800,"rate":7100},{"rateTs":1574346615,"rate":7134.1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1319,7 +1319,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"rate_ts":1574344800,"rate":7814.5},{"rate_ts":1574346615,"rate":7914.5},{"rate_ts":2000000000,"rate":-1}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"rateTs":1574344800,"rate":7814.5},{"rateTs":1574346615,"rate":7914.5},{"rateTs":2000000000,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple errors",
@@ -1330,7 +1330,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7832854800, 2000000000},
 				},
 			},
-			want: `{"id":"29","data":{"tickers":[{"rate_ts":7832854800,"rate":-1},{"rate_ts":2000000000,"rate":-1}]}}`,
+			want: `{"id":"29","data":{"tickers":[{"rateTs":7832854800,"rate":-1},{"rateTs":2000000000,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getTickersList",
@@ -1340,7 +1340,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamp": 1570346615,
 				},
 			},
-			want: `{"id":"30","data":{"data_timestamp":1570346615,"available_currencies":["eur","usd"]}}`,
+			want: `{"id":"30","data":{"dataTimestamp":1570346615,"available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -524,7 +524,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
+				`{"rate_ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
 			},
 		},
 		{
@@ -533,7 +533,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574346615,"rates":{"usd":7914.5}}`,
+				`{"rate_ts":1574346615,"rate":7914.5}`,
 			},
 		},
 		{
@@ -542,16 +542,16 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574344800,"rates":{"usd":7814.5}}`,
+				`{"rate_ts":1574344800,"rate":7814.5}`,
 			},
 		},
 		{
 			name:        "apiFiatRates incorrect timestamp",
 			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&timestamp=yesterday"),
-			status:      http.StatusOK,
+			status:      http.StatusBadRequest,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"error":"\"yesterday\" is not a valid Unix timestamp."}`,
+				`{"error":"Parameter \"timestamp\" is not a valid Unix timestamp."}`,
 			},
 		},
 		{
@@ -560,7 +560,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":7980386400,"error":"No tickers available for currency \"usd\""}`,
+				`{"rate_ts":7980386400,"rate":-1}`,
 			},
 		},
 		{
@@ -569,7 +569,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574344800,"rates":{"eur":7100}}`,
+				`{"rate_ts":1574344800,"rate":7100}`,
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1521511200,"rates":{"usd":2000}}`,
+				`{"rate_ts":1521511200,"rate":2000}`,
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1521611721,"rates":{"usd":2003}}`,
+				`{"rate_ts":1521611721,"rate":2003}`,
 			},
 		},
 		{
@@ -596,7 +596,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574346615,"rates":{"eur":7134.1}}`,
+				`{"rate_ts":1574346615,"rate":7134.1}`,
 			},
 		},
 		{
@@ -605,7 +605,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"error":"Currency \"does_not_exist\" is not available for timestamp 1574346615."}`,
+				`{"rate_ts":1574346615,"rate":-1}`,
 			},
 		},
 		{
@@ -1202,7 +1202,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"": "",
 				},
 			},
-			want: `{"id":"17","data":{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
+			want: `{"id":"17","data":{"rate_ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates usd",
@@ -1212,7 +1212,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "usd",
 				},
 			},
-			want: `{"id":"18","data":{"ts":1574346615,"rates":{"usd":7914.5}}}`,
+			want: `{"id":"18","data":{"rate_ts":1574346615,"rate":7914.5}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates eur",
@@ -1222,7 +1222,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "eur",
 				},
 			},
-			want: `{"id":"19","data":{"ts":1574346615,"rates":{"eur":7134.1}}}`,
+			want: `{"id":"19","data":{"rate_ts":1574346615,"rate":7134.1}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates incorrect currency",
@@ -1253,7 +1253,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []string{"yesterday"},
 				},
 			},
-			want: `{"id":"22","data":{"tickers":[{"error":"\"yesterday\" is not a valid Unix timestamp."}]}}`,
+			want: `{"id":"22","data":{"error":{"message":"json: cannot unmarshal string into Go struct field .timestamps of type int64"}}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps incorrect (future) date",
@@ -1261,10 +1261,10 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "usd",
-					"timestamps": []string{"7885693815"},
+					"timestamps": []int64{7885693815},
 				},
 			},
-			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"error":"No tickers available for currency \"usd\""}]}}`,
+			want: `{"id":"23","data":{"tickers":[{"rate_ts":7885693815,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps exact date",
@@ -1272,10 +1272,10 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "usd",
-					"timestamps": []string{"1574346615"},
+					"timestamps": []int64{1574346615},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"rate_ts":1574346615,"rate":7914.5}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps closest date, eur",
@@ -1283,10 +1283,10 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "eur",
-					"timestamps": []string{"1521507600"},
+					"timestamps": []int64{1521507600},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300}}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"rate_ts":1521511200,"rate":1300}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1294,10 +1294,10 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "usd",
-					"timestamps": []string{"1570346615", "1574346615"},
+					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"rate_ts":1574344800,"rate":7814.5},{"rate_ts":1574346615,"rate":7914.5}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
@@ -1305,10 +1305,10 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "eur",
-					"timestamps": []string{"1570346615", "1574346615"},
+					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"rate_ts":1574344800,"rate":7100},{"rate_ts":1574346615,"rate":7134.1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1316,10 +1316,10 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "usd",
-					"timestamps": []string{"1570346615", "1574346615", "not-a-real-date"},
+					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}},{"error":"\"not-a-real-date\" is not a valid Unix timestamp."}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"rate_ts":1574344800,"rate":7814.5},{"rate_ts":1574346615,"rate":7914.5},{"rate_ts":2000000000,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple errors",
@@ -1327,20 +1327,20 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency":   "usd",
-					"timestamps": []string{"7832854800", "not-a-real-date"},
+					"timestamps": []int64{7832854800, 2000000000},
 				},
 			},
-			want: `{"id":"29","data":{"tickers":[{"ts":7832854800,"error":"No tickers available for currency \"usd\""},{"error":"\"not-a-real-date\" is not a valid Unix timestamp."}]}}`,
+			want: `{"id":"29","data":{"tickers":[{"rate_ts":7832854800,"rate":-1},{"rate_ts":2000000000,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getTickersList",
 			req: websocketReq{
 				Method: "getFiatRatesTickersList",
 				Params: map[string]interface{}{
-					"date": "1570346615",
+					"timestamp": 1570346615,
 				},
 			},
-			want: `{"id":"30","data":{"data_timestamp":1574344800,"available_currencies":["eur","usd"]}}`,
+			want: `{"id":"30","data":{"data_timestamp":1570346615,"available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -521,10 +521,10 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 		{
 			name:        "apiFiatRates missing currency",
 			r:           newGetRequest(ts.URL + "/api/v2/tickers"),
-			status:      http.StatusBadRequest,
+			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"error":"Missing or empty \"currency\" parameter"}`,
+				`{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
 			},
 		},
 		{
@@ -533,52 +533,52 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20191121143015","rates":{"usd":7914.5}}`,
+				`{"ts":1574346615,"rates":{"usd":7914.5}}`,
 			},
 		},
 		{
-			name:        "apiFiatRates get rate by exact date",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&date=20191121140000"),
+			name:        "apiFiatRates get rate by exact timestamp",
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&timestamp=1574344800"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20191121140000","rates":{"usd":7814.5}}`,
+				`{"ts":1574344800,"rates":{"usd":7814.5}}`,
 			},
 		},
 		{
-			name:        "apiFiatRates incorrect date",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&date=yesterday"),
+			name:        "apiFiatRates incorrect timestamp",
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&timestamp=yesterday"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"error":"Date \"yesterday\" does not match any of available formats. Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"}`,
+				`{"error":"\"yesterday\" is not a valid Unix timestamp."}`,
 			},
 		},
 		{
-			name:        "apiFiatRates future date",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&date=20200101000000"),
+			name:        "apiFiatRates future timestamp",
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?currency=usd&timestamp=7980386400"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"error":"No tickers available for 2020-01-01 00:00:00 +0000 UTC (usd)"}`,
+				`{"ts":7980386400,"error":"No tickers available for currency \"usd\""}`,
 			},
 		},
 		{
-			name:        "apiFiatRates get EUR rate (exact date)",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?date=20191121140000&currency=eur"),
+			name:        "apiFiatRates get EUR rate (exact timestamp)",
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?timestamp=1574344800&currency=eur"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}`,
+				`{"ts":1574344800,"rates":{"eur":7100.0}}`,
 			},
 		},
 		{
 			name:        "apiFiatRates get closest rate",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?date=20191121130000&currency=usd"),
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?timestamp=1357045200&currency=usd"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20191121140000","rates":{"usd":7814.5}}`,
+				`{"ts":1521511200,"rates":{"usd":2000.0}}`,
 			},
 		},
 		{
@@ -587,34 +587,34 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20180321055521","rates":{"usd":2003.0}}`,
+				`{"ts":1521611721,"rates":{"usd":2003.0}}`,
 			},
 		},
 		{
 			name:        "apiFiatRates get rate for EUR",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?date=20191121140000&currency=eur"),
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?timestamp=1574346615&currency=eur"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}`,
+				`{"ts":1574346615,"rates":{"eur":7134.1}}`,
 			},
 		},
 		{
 			name:        "apiFiatRates get exact rate for an incorrect currency",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers?date=20191121140000&currency=does_not_exist"),
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?timestamp=1574346615&currency=does_not_exist"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"error":"Currency \"does_not_exist\" is not available for timestamp 20191121140000. Available currencies are: eur,usd"}`,
+				`{"error":"Currency \"does_not_exist\" is not available for timestamp 1574346615."}`,
 			},
 		},
 		{
 			name:        "apiTickerList",
-			r:           newGetRequest(ts.URL + "/api/v2/tickers-list?date=20191121140000"),
+			r:           newGetRequest(ts.URL + "/api/v2/tickers-list?timestamp=1574346615"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"data_timestamp":"20191121140000","available_currencies":["eur","usd"]}`,
+				`{"data_timestamp":1574346615,"available_currencies":["eur","usd"]}`,
 			},
 		},
 		{
@@ -1202,7 +1202,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"": "",
 				},
 			},
-			want: `{"id":"17","data":{"error":{"message":"Missing or empty \"currency\" parameter"}}}`,
+			want: `{"id":"17","data":{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates usd",
@@ -1212,7 +1212,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "usd",
 				},
 			},
-			want: `{"id":"18","data":{"data_timestamp":"20191121143015","rates":{"usd":7914.5}}}`,
+			want: `{"id":"18","data":{"ts":1574346615,"rates":{"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates eur",
@@ -1222,7 +1222,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "eur",
 				},
 			},
-			want: `{"id":"19","data":{"data_timestamp":"20191121143015","rates":{"eur":7134.1,"usd":7914.5}}}`,
+			want: `{"id":"19","data":{"ts":1574346615,"rates":{"eur":7134.1}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates incorrect currency",
@@ -1232,115 +1232,115 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "does-not-exist",
 				},
 			},
-			want: `{"id":"20","data":{"error":{"message":"Currency \"does-not-exist\" is not available for timestamp 20191121143015. Available currencies are: eur,usd"}}}`,
+			want: `{"id":"20","data":{"error":{"message":"Currency \"does-not-exist\" is not available for timestamp 1574346615."}}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates missing date",
+			name: "websocket getFiatRatesForTimestamps missing date",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
 					"currency": "usd",
 				},
 			},
-			want: `{"id":"21","data":{"error":{"message":"No dates provided"}}}`,
+			want: `{"id":"21","data":{"error":{"message":"No timestamps provided"}}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates incorrect date",
+			name: "websocket getFiatRatesForTimestamps incorrect date",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
-					"dates":    []string{"yesterday"},
+					"currency":   "usd",
+					"timestamps": []string{"yesterday"},
 				},
 			},
-			want: `{"id":"22","data":{"tickers":[{"error":"Date \"yesterday\" does not match any of available formats. Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"}]}}`,
+			want: `{"id":"22","data":{"tickers":[{"error":"\"yesterday\" is not a valid Unix timestamp."}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates incorrect (future) date",
+			name: "websocket getFiatRatesForTimestamps incorrect (future) date",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
-					"dates":    []string{"20200101000000"},
+					"currency":   "usd",
+					"timestamps": []string{"7885693815"},
 				},
 			},
-			want: `{"id":"23","data":{"tickers":[{"error":"No tickers available for 2020-01-01 00:00:00 +0000 UTC (usd)"}]}}`,
+			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"error":"No tickers available for currency \"usd\""}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates exact date",
+			name: "websocket getFiatRatesForTimestamps exact date",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
-					"dates":    []string{"20191121140000"},
+					"currency":   "usd",
+					"timestamps": []string{"1574346615"},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"data_timestamp":"20191121140000","rates":{"usd":7814.5}}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates closest date, eur",
+			name: "websocket getFiatRatesForTimestamps closest date, eur",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "eur",
-					"dates":    []string{"20191121130000"},
+					"currency":   "eur",
+					"timestamps": []string{"1521507600"},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"data_timestamp":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300.0}}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates multiple dates usd",
+			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
-					"dates":    []string{"20191121140000", "20191121143015"},
+					"currency":   "usd",
+					"timestamps": []string{"1570346615", "1574346615"},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"data_timestamp":"20191121140000","rates":{"usd":7814.5}},{"data_timestamp":"20191121143015","rates":{"usd":7914.5}}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates multiple dates eur",
+			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "eur",
-					"dates":    []string{"20191121140000", "20191121143015"},
+					"currency":   "eur",
+					"timestamps": []string{"1570346615", "1574346615"},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"data_timestamp":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}},{"data_timestamp":"20191121143015","rates":{"eur":7134.1,"usd":7914.5}}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100.0}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates multiple dates with an error",
+			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
-					"dates":    []string{"20191121140000", "20191121143015", "not-a-real-date"},
+					"currency":   "usd",
+					"timestamps": []string{"1570346615", "1574346615", "not-a-real-date"},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"data_timestamp":"20191121140000","rates":{"usd":7814.5}},{"data_timestamp":"20191121143015","rates":{"usd":7914.5}},{"error":"Date \"not-a-real-date\" does not match any of available formats. Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}},{"error":"\"not-a-real-date\" is not a valid Unix timestamp."}]}}`,
 		},
 		{
-			name: "websocket getFiatRatesForDates multiple errors",
+			name: "websocket getFiatRatesForTimestamps multiple errors",
 			req: websocketReq{
-				Method: "getFiatRatesForDates",
+				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
-					"dates":    []string{"20200101000000", "not-a-real-date"},
+					"currency":   "usd",
+					"timestamps": []string{"7832854800", "not-a-real-date"},
 				},
 			},
-			want: `{"id":"29","data":{"tickers":[{"error":"No tickers available for 2020-01-01 00:00:00 +0000 UTC (usd)"},{"error":"Date \"not-a-real-date\" does not match any of available formats. Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"}]}}`,
+			want: `{"id":"29","data":{"tickers":[{"ts":7832854800,"error":"No tickers available for currency \"usd\""},{"error":"\"not-a-real-date\" is not a valid Unix timestamp."}]}}`,
 		},
 		{
 			name: "websocket getTickersList",
 			req: websocketReq{
 				Method: "getFiatRatesTickersList",
 				Params: map[string]interface{}{
-					"date": "20191121140000",
+					"date": "1570346615",
 				},
 			},
-			want: `{"id":"30","data":{"data_timestamp":"20191121140000","available_currencies":["eur","usd"]}}`,
+			want: `{"id":"30","data":{"data_timestamp":1574344800,"available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -524,7 +524,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
+				`{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}`,
 			},
 		},
 		{
@@ -533,7 +533,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20191121143015","rates":{"usd":7914.5}}`,
+				`{"ts":1574346615,"rate":7914.5}`,
 			},
 		},
 		{
@@ -542,7 +542,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20191121140000","rates":{"usd":7814.5}}`,
+				`{"ts":1574344800,"rate":7814.5}`,
 			},
 		},
 		{
@@ -560,7 +560,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":7980386400,"rate":-1}`,
+				`{"ts":7980386400,"rate":-1}`,
 			},
 		},
 		{
@@ -569,7 +569,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}`,
+				`{"ts":1574344800,"rate":7100}`,
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20191121140000","rates":{"usd":7814.5}}`,
+				`{"ts":1521511200,"rate":2000}`,
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20180321055521","rates":{"usd":2003.0}}`,
+				`{"ts":1521611721,"rate":2003}`,
 			},
 		},
 		{
@@ -596,7 +596,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}`,
+				`{"ts":1574346615,"rate":7134.1}`,
 			},
 		},
 		{
@@ -605,7 +605,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"rateTs":1574346615,"rate":-1}`,
+				`{"ts":1574346615,"rate":-1}`,
 			},
 		},
 		{
@@ -614,7 +614,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":"20191121140000","available_currencies":["eur","usd"]}`,
+				`{"ts":1574346615,"available_currencies":["eur","usd"]}`,
 			},
 		},
 		{
@@ -1202,7 +1202,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"": "",
 				},
 			},
-			want: `{"id":"17","data":{"rateTs":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
+			want: `{"id":"17","data":{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates usd",
@@ -1212,7 +1212,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "usd",
 				},
 			},
-			want: `{"id":"18","data":{"ts":"20191121143015","rates":{"usd":7914.5}}}`,
+			want: `{"id":"18","data":{"ts":1574346615,"rate":7914.5}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates eur",
@@ -1222,7 +1222,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currency": "eur",
 				},
 			},
-			want: `{"id":"19","data":{"ts":"20191121143015","rates":{"eur":7134.1,"usd":7914.5}}}`,
+			want: `{"id":"19","data":{"ts":1574346615,"rate":7134.1}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates incorrect currency",
@@ -1264,7 +1264,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7885693815},
 				},
 			},
-			want: `{"id":"23","data":{"tickers":[{"rateTs":7885693815,"rate":-1}]}}`,
+			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps exact date",
@@ -1275,7 +1275,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1574346615},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"ts":"20191121140000","rates":{"usd":7814.5}}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"ts":1574346615,"rate":7914.5}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps closest date, eur",
@@ -1286,7 +1286,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1521507600},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rate":1300}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1297,7 +1297,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"ts":"20191121140000","rates":{"usd":7814.5}},{"ts":"20191121143015","rates":{"usd":7914.5}}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"ts":1574344800,"rate":7814.5},{"ts":1574346615,"rate":7914.5}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
@@ -1308,7 +1308,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"ts":"20191121140000","rates":{"eur":7100.0,"usd":7814.5}},{"ts":"20191121143015","rates":{"eur":7134.1,"usd":7914.5}}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rate":7100},{"ts":1574346615,"rate":7134.1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1319,7 +1319,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"ts":"20191121140000","rates":{"usd":7814.5}},{"ts":"20191121143015","rates":{"usd":7914.5}},{"error":"Date \"not-a-real-date\" does not match any of available formats. Possible formats are: YYYYMMDDhhmmss, YYYYMMDDhhmm, YYYYMMDDhh, YYYYMMDD"}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rate":7814.5},{"ts":1574346615,"rate":7914.5},{"ts":2000000000,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple errors",
@@ -1330,7 +1330,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7832854800, 2000000000},
 				},
 			},
-			want: `{"id":"29","data":{"tickers":[{"rateTs":7832854800,"rate":-1},{"rateTs":2000000000,"rate":-1}]}}`,
+			want: `{"id":"29","data":{"tickers":[{"ts":7832854800,"rate":-1},{"ts":2000000000,"rate":-1}]}}`,
 		},
 		{
 			name: "websocket getTickersList",
@@ -1340,7 +1340,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamp": 1570346615,
 				},
 			},
-			want: `{"id":"30","data":{"ts":"20191121140000","available_currencies":["eur","usd"]}}`,
+			want: `{"id":"30","data":{"ts":1570346615,"available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -791,7 +791,7 @@ func (s *WebsocketServer) OnNewTxAddr(tx *bchain.Tx, addrDesc bchain.AddressDesc
 	}
 }
 
-func (s *WebsocketServer) broadcastTicker(currency string, rates map[string]json.Number) {
+func (s *WebsocketServer) broadcastTicker(currency string, rates map[string]float64) {
 	s.fiatRatesSubscriptionsLock.Lock()
 	defer s.fiatRatesSubscriptionsLock.Unlock()
 	as, ok := s.fiatRatesSubscriptions[currency]
@@ -820,7 +820,7 @@ func (s *WebsocketServer) broadcastTicker(currency string, rates map[string]json
 // OnNewFiatRatesTicker is a callback that broadcasts info about fiat rates affecting subscribed currency
 func (s *WebsocketServer) OnNewFiatRatesTicker(ticker *db.CurrencyRatesTicker) {
 	for currency, rate := range ticker.Rates {
-		s.broadcastTicker(currency, map[string]json.Number{currency: rate})
+		s.broadcastTicker(currency, map[string]float64{currency: rate})
 	}
 	s.broadcastTicker("!ALL!", ticker.Rates)
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -839,7 +839,6 @@ func (s *WebsocketServer) getFiatRatesForTimestamps(timestamps []int64, currency
 }
 
 func (s *WebsocketServer) getFiatRatesTickersList(timestamp int64) (interface{}, error) {
-	glog.Errorf("ts: %v", timestamp)
 	ret, err := s.api.GetFiatRatesTickersList(timestamp)
 	return ret, err
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -263,6 +263,7 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 			To         string `json:"to"`
 			Fiat       string `json:"fiat"`
 			Gap        int    `json:"gap"`
+			GroupBy    uint32 `json:"groupBy"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
@@ -279,9 +280,9 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 					return
 				}
 			}
-			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.Gap)
+			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.Gap, r.GroupBy)
 			if err != nil {
-				rv, err = s.api.GetBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat)
+				rv, err = s.api.GetBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.GroupBy)
 			}
 		}
 		return

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -280,6 +280,9 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 					return
 				}
 			}
+			if r.GroupBy <= 0 {
+				r.GroupBy = 3600
+			}
 			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.Gap, r.GroupBy)
 			if err != nil {
 				rv, err = s.api.GetBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.GroupBy)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -23,6 +23,9 @@ const upgradeFailed = "Upgrade failed: "
 const outChannelSize = 500
 const defaultTimeout = 60 * time.Second
 
+// allRates is a special "currency" parameter that means all available currencies
+const allFiatRates = "!ALL!"
+
 var (
 	// ErrorMethodNotAllowed is returned when client tries to upgrade method other than GET
 	ErrorMethodNotAllowed = errors.New("Method not allowed")
@@ -699,7 +702,7 @@ func (s *WebsocketServer) subscribeFiatRates(c *websocketChannel, currency strin
 	defer s.fiatRatesSubscriptionsLock.Unlock()
 
 	if currency == "" {
-		currency = "!ALL!"
+		currency = allFiatRates
 	}
 	as, ok := s.fiatRatesSubscriptions[currency]
 	if !ok {
@@ -822,7 +825,7 @@ func (s *WebsocketServer) OnNewFiatRatesTicker(ticker *db.CurrencyRatesTicker) {
 	for currency, rate := range ticker.Rates {
 		s.broadcastTicker(currency, map[string]float64{currency: rate})
 	}
-	s.broadcastTicker("!ALL!", ticker.Rates)
+	s.broadcastTicker(allFiatRates, ticker.Rates)
 }
 
 func (s *WebsocketServer) getCurrentFiatRates(currency string) (interface{}, error) {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -283,9 +284,9 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 			if r.GroupBy <= 0 {
 				r.GroupBy = 3600
 			}
-			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.Gap, r.GroupBy)
+			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, fromTime, toTime, strings.ToLower(r.Fiat), r.Gap, r.GroupBy)
 			if err != nil {
-				rv, err = s.api.GetBalanceHistory(r.Descriptor, fromTime, toTime, r.Fiat, r.GroupBy)
+				rv, err = s.api.GetBalanceHistory(r.Descriptor, fromTime, toTime, strings.ToLower(r.Fiat), r.GroupBy)
 			}
 		}
 		return
@@ -347,7 +348,7 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 		if err != nil {
 			return nil, err
 		}
-		return s.subscribeFiatRates(c, r.Currency, req)
+		return s.subscribeFiatRates(c, strings.ToLower(r.Currency), req)
 	},
 	"unsubscribeFiatRates": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		return s.unsubscribeFiatRates(c)
@@ -362,7 +363,7 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
-			rv, err = s.getCurrentFiatRates(r.Currency)
+			rv, err = s.getCurrentFiatRates(strings.ToLower(r.Currency))
 		}
 		return
 	},
@@ -373,7 +374,7 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
-			rv, err = s.getFiatRatesForTimestamps(r.Timestamps, r.Currency)
+			rv, err = s.getFiatRatesForTimestamps(r.Timestamps, strings.ToLower(r.Currency))
 		}
 		return
 	},

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -364,8 +364,8 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 	},
 	"getFiatRatesForTimestamps": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		r := struct {
-			Timestamps []string `json:"timestamps"`
-			Currency   string   `json:"currency"`
+			Timestamps []int64 `json:"timestamps"`
+			Currency   string  `json:"currency"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
@@ -375,11 +375,11 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 	},
 	"getFiatRatesTickersList": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		r := struct {
-			Date string `json:"date"`
+			Timestamp int64 `json:"timestamp"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
-			rv, err = s.getFiatRatesTickersList(r.Date)
+			rv, err = s.getFiatRatesTickersList(r.Timestamp)
 		}
 		return
 	},
@@ -833,12 +833,13 @@ func (s *WebsocketServer) getCurrentFiatRates(currency string) (interface{}, err
 	return ret, err
 }
 
-func (s *WebsocketServer) getFiatRatesForTimestamps(timestamps []string, currency string) (interface{}, error) {
+func (s *WebsocketServer) getFiatRatesForTimestamps(timestamps []int64, currency string) (interface{}, error) {
 	ret, err := s.api.GetFiatRatesForTimestamps(timestamps, currency)
 	return ret, err
 }
 
-func (s *WebsocketServer) getFiatRatesTickersList(timestamp string) (interface{}, error) {
+func (s *WebsocketServer) getFiatRatesTickersList(timestamp int64) (interface{}, error) {
+	glog.Errorf("ts: %v", timestamp)
 	ret, err := s.api.GetFiatRatesTickersList(timestamp)
 	return ret, err
 }

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -166,12 +166,14 @@
             const from = document.getElementById("getBalanceHistoryFrom").value.trim();
             const to = document.getElementById("getBalanceHistoryTo").value.trim();
             const fiat = document.getElementById("getBalanceHistoryFiat").value.trim();
+            const groupBy = parseInt(document.getElementById("getBalanceHistoryGroupBy").value);
             const method = 'getBalanceHistory';
             const params = {
                 descriptor,
                 from,
                 to,
-                fiat
+                fiat,
+                groupBy
                 // default gap=20
             };
             send(method, params, function (result) {
@@ -462,7 +464,8 @@
                 <div class="row" style="margin: 0; margin-top: 5px;">
                     <input type="text" placeholder="from YYYY-MM-DD" style="width: 30%;margin-left: 5px;margin-right: 5px;" class="form-control" id="getBalanceHistoryFrom">
                     <input type="text" placeholder="to YYYY-MM-DD" style="width: 30%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryTo">
-                    <input type="text" placeholder="fiat" style="width: 20%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryFiat">
+                    <input type="text" placeholder="fiat" style="width: 10%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryFiat">
+                    <input type="text" placeholder="group by (sec)" style="width: 20%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryGroupBy">
                 </div>
             </div>
             <div class="col form-inline"></div>

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -301,7 +301,7 @@
             const method = 'getFiatRatesForTimestamps';
             var timestamps = document.getElementById('getFiatRatesForTimestampsList').value.split(",");
             var currency = document.getElementById('getFiatRatesForTimestampsCurrency').value;
-            timestamps = timestamps.map(s => s.trim());
+            timestamps = timestamps.map(Number);
             const params = {
                 timestamps,
                 "currency": currency
@@ -324,9 +324,10 @@
 
         function getFiatRatesTickersList() {
             const method = 'getFiatRatesTickersList';
-            var date = document.getElementById('getFiatRatesTickersListDate').value;
+            var timestamp = document.getElementById('getFiatRatesTickersListDate').value;
+            timestamp = parseInt(timestamp);
             const params = {
-                date,
+                timestamp,
             };
             send(method, params, function (result) {
                 document.getElementById('getFiatRatesTickersListResult').innerText = JSON.stringify(result).replace(/,/g, ", ");

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -297,17 +297,17 @@
             });
         }
 
-        function getFiatRatesForDates() {
-            const method = 'getFiatRatesForDates';
-            var dates = document.getElementById('getFiatRatesForDatesList').value.split(",");
-            var currency = document.getElementById('getFiatRatesForDatesCurrency').value;
-            dates = dates.map(s => s.trim());
+        function getFiatRatesForTimestamps() {
+            const method = 'getFiatRatesForTimestamps';
+            var timestamps = document.getElementById('getFiatRatesForTimestampsList').value.split(",");
+            var currency = document.getElementById('getFiatRatesForTimestampsCurrency').value;
+            timestamps = timestamps.map(s => s.trim());
             const params = {
-                dates,
+                timestamps,
                 "currency": currency
             };
             send(method, params, function (result) {
-                document.getElementById('getFiatRatesForDatesResult').innerText = JSON.stringify(result).replace(/,/g, ", ");
+                document.getElementById('getFiatRatesForTimestampsResult').innerText = JSON.stringify(result).replace(/,/g, ", ");
             });
         }
 
@@ -533,24 +533,24 @@
         </div>
         <div class="row">
             <div class="col-2">
-                <input class="btn btn-secondary" type="button" value="get fiat rates for dates" onclick="getFiatRatesForDates()">
+                <input class="btn btn-secondary" type="button" value="get fiat rates for dates" onclick="getFiatRatesForTimestamps()">
             </div>
             <div class="col-1">
-                <input type="text" class="form-control" id="getFiatRatesForDatesCurrency" value="usd">
+                <input type="text" class="form-control" id="getFiatRatesForTimestampsCurrency" value="usd">
             </div>
             <div class="col-7">
-                <input type="text" class="form-control" id="getFiatRatesForDatesList" value="20191121140000,20191121143015">
+                <input type="text" class="form-control" id="getFiatRatesForTimestampsList" value="1575288000,1575550800">
             </div>
         </div>
         <div class="row">
-            <div class="col" id="getFiatRatesForDatesResult"></div>
+            <div class="col" id="getFiatRatesForTimestampsResult"></div>
         </div>
         <div class="row">
             <div class="col-2">
                 <input class="btn btn-secondary" type="button" value="get current fiat rates" onclick="getCurrentFiatRates()">
             </div>
             <div class="col-1">
-                <input type="text" class="form-control" id="getCurrentFiatRatesCurrency" value="usd">
+                <input type="text" class="form-control" id="getCurrentFiatRatesCurrency" placeholder="usd">
             </div>
         </div>
         <div class="row">
@@ -561,7 +561,7 @@
                 <input class="btn btn-secondary" type="button" value="get fiat rates tickers" onclick="getFiatRatesTickersList()">
             </div>
             <div class="col-8">
-                <input type="text" class="form-control" id="getFiatRatesTickersListDate" value="20191121140000">
+                <input type="text" class="form-control" id="getFiatRatesTickersListDate" value="1576591569" placeholder="Unix timestamp">
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
* Input & output date values as Unix timestamps
* Store rates as `float64` instead of `json.Number` in the database
* If currency is not specified, return all available rates
* Document the new APIs