### PR TITLE
Fiat rates & Balance history tune-up

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -299,12 +299,12 @@ func (a Utxos) Less(i, j int) bool {
 
 // BalanceHistory contains info about one point in time of balance history
 type BalanceHistory struct {
-	Time        uint32  `json:"time"`
-	Txs         uint32  `json:"txs"`
-	ReceivedSat *Amount `json:"received"`
-	SentSat     *Amount `json:"sent"`
-	FiatRate    float64 `json:"fiatRate,omitempty"`
-	Txid        string  `json:"txid,omitempty"`
+	Time        uint32             `json:"time"`
+	Txs         uint32             `json:"txs"`
+	ReceivedSat *Amount            `json:"received"`
+	SentSat     *Amount            `json:"sent"`
+	FiatRates   map[string]float64 `json:"rates,omitempty"`
+	Txid        string             `json:"txid,omitempty"`
 }
 
 // BalanceHistories is array of BalanceHistory

--- a/api/worker.go
+++ b/api/worker.go
@@ -925,7 +925,9 @@ func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, curre
 		} else if ticker == nil {
 			continue
 		}
-		if len(currencies) > 0 {
+		if len(currencies) == 0 {
+			bh.FiatRates = ticker.Rates
+		} else {
 			rates := make(map[string]float64)
 			for _, currency := range currencies {
 				currency = strings.ToLower(currency)
@@ -967,11 +969,9 @@ func (w *Worker) GetBalanceHistory(address string, fromTimestamp, toTimestamp in
 		}
 	}
 	bha := bhs.SortAndAggregate(groupBy)
-	if len(currencies) > 0 {
-		err = w.setFiatRateToBalanceHistories(bha, currencies)
-		if err != nil {
-			return nil, err
-		}
+	err = w.setFiatRateToBalanceHistories(bha, currencies)
+	if err != nil {
+		return nil, err
 	}
 	glog.Info("GetBalanceHistory ", address, ", blocks ", fromHeight, "-", toHeight, ", count ", len(bha), " finished in ", time.Since(start))
 	return bha, nil

--- a/api/worker.go
+++ b/api/worker.go
@@ -1247,6 +1247,7 @@ func (w *Worker) GetFiatRatesForTimestamps(timestamps []int64, currencies []stri
 	if len(timestamps) == 0 {
 		return nil, NewAPIError("No timestamps provided", true)
 	}
+	currencies = removeEmpty(currencies)
 
 	ret := &db.ResultTickersAsString{}
 	for _, timestamp := range timestamps {

--- a/api/worker.go
+++ b/api/worker.go
@@ -1273,7 +1273,7 @@ func (w *Worker) GetFiatRatesTickersList(timestamp int64) (*db.ResultTickerListA
 	sort.Strings(keys) // sort to get deterministic results
 
 	return &db.ResultTickerListAsString{
-		Timestamp: timestamp,
+		Timestamp: ticker.Timestamp.Unix(),
 		Tickers:   keys,
 	}, nil
 }

--- a/api/worker.go
+++ b/api/worker.go
@@ -801,17 +801,17 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 	return r, nil
 }
 
-func (w *Worker) balanceHistoryHeightsFromTo(fromTime, toTime time.Time) (uint32, uint32, uint32, uint32) {
+func (w *Worker) balanceHistoryHeightsFromTo(fromTimestamp, toTimestamp int64) (uint32, uint32, uint32, uint32) {
 	fromUnix := uint32(0)
 	toUnix := maxUint32
 	fromHeight := uint32(0)
 	toHeight := maxUint32
-	if !fromTime.IsZero() {
-		fromUnix = uint32(fromTime.Unix())
+	if fromTimestamp != 0 {
+		fromUnix = uint32(fromTimestamp)
 		fromHeight = w.is.GetBlockHeightOfTime(fromUnix)
 	}
-	if !toTime.IsZero() {
-		toUnix = uint32(toTime.Unix())
+	if toTimestamp != 0 {
+		toUnix = uint32(toTimestamp)
 		toHeight = w.is.GetBlockHeightOfTime(toUnix)
 	}
 	return fromUnix, fromHeight, toUnix, toHeight
@@ -932,14 +932,14 @@ func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, fiat 
 }
 
 // GetBalanceHistory returns history of balance for given address
-func (w *Worker) GetBalanceHistory(address string, fromTime, toTime time.Time, fiat string, groupBy uint32) (BalanceHistories, error) {
+func (w *Worker) GetBalanceHistory(address string, fromTimestamp, toTimestamp int64, fiat string, groupBy uint32) (BalanceHistories, error) {
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
 	addrDesc, _, err := w.getAddrDescAndNormalizeAddress(address)
 	if err != nil {
 		return nil, err
 	}
-	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTime, toTime)
+	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTimestamp, toTimestamp)
 	if fromHeight >= toHeight {
 		return bhs, nil
 	}
@@ -1208,7 +1208,7 @@ func (w *Worker) GetFiatRatesForBlockID(bid string, currency string) (*db.Result
 	return result, nil
 }
 
-// GetCurrentFiatRates returns current fiat rates
+// GetCurrentFiatRates returns last available fiat rates
 func (w *Worker) GetCurrentFiatRates(currency string) (*db.ResultTickerAsString, error) {
 	ticker, err := w.db.FiatRatesFindLastTicker()
 	if err != nil {

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -591,10 +591,10 @@ func (w *Worker) GetXpubUtxo(xpub string, onlyConfirmed bool, gap int) (Utxos, e
 }
 
 // GetXpubBalanceHistory returns history of balance for given xpub
-func (w *Worker) GetXpubBalanceHistory(xpub string, fromTime, toTime time.Time, fiat string, gap int, groupBy uint32) (BalanceHistories, error) {
+func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp int64, fiat string, gap int, groupBy uint32) (BalanceHistories, error) {
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
-	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTime, toTime)
+	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTimestamp, toTimestamp)
 	if fromHeight >= toHeight {
 		return bhs, nil
 	}

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -591,7 +591,7 @@ func (w *Worker) GetXpubUtxo(xpub string, onlyConfirmed bool, gap int) (Utxos, e
 }
 
 // GetXpubBalanceHistory returns history of balance for given xpub
-func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp int64, fiat string, gap int, groupBy uint32) (BalanceHistories, error) {
+func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp int64, currencies []string, gap int, groupBy uint32) (BalanceHistories, error) {
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
 	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTimestamp, toTimestamp)
@@ -623,8 +623,8 @@ func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp i
 		}
 	}
 	bha := bhs.SortAndAggregate(groupBy)
-	if fiat != "" {
-		err = w.setFiatRateToBalanceHistories(bha, fiat)
+	if len(currencies) > 0 {
+		err = w.setFiatRateToBalanceHistories(bha, currencies)
 		if err != nil {
 			return nil, err
 		}

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -623,11 +623,9 @@ func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp i
 		}
 	}
 	bha := bhs.SortAndAggregate(groupBy)
-	if len(currencies) > 0 {
-		err = w.setFiatRateToBalanceHistories(bha, currencies)
-		if err != nil {
-			return nil, err
-		}
+	err = w.setFiatRateToBalanceHistories(bha, currencies)
+	if err != nil {
+		return nil, err
 	}
 	glog.Info("GetUtxoBalanceHistory ", xpub[:16], ", blocks ", fromHeight, "-", toHeight, ", count ", len(bha), ", finished in ", time.Since(start))
 	return bha, nil

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -43,8 +43,7 @@ type CurrencyRatesTicker struct {
 // ResultTickerAsString contains formatted CurrencyRatesTicker data
 type ResultTickerAsString struct {
 	Timestamp int64              `json:"ts,omitempty"`
-	Rates     map[string]float64 `json:"rates,omitempty"`
-	Rate      float64            `json:"rate,omitempty"`
+	Rates     map[string]float64 `json:"rates"`
 	Error     string             `json:"error,omitempty"`
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -580,14 +580,14 @@ or in case of error
 
 #### Tickers list
 
-Returns a list of available currency rate tickers for the specified timestamp.
+Returns a list of available currency rate tickers for the specified date, along with an actual data timestamp.
 
 ```
 GET /api/v2/tickers-list/?timestamp=<timestamp>
 ```
 
 The query parameters:
-- *timestamp*: specifies a UNIX timestamp to return available tickers for.
+- *timestamp*: specifies a Unix timestamp to return available tickers for.
 
 Example response:
 
@@ -603,7 +603,7 @@ Example response:
 
 #### Tickers
 
-Returns currency rate for the specified currency and date. If the currency is not available for that specific timestamp, the closest rate will be returned.
+Returns currency rate for the specified currency and date. If the currency is not available for that specific timestamp, the next closest rate will be returned.
 All responses contain an actual rate timestamp.
 
 ```
@@ -612,7 +612,7 @@ GET /api/v2/tickers/[?currency=<currency>&timestamp=<timestamp>]
 
 The optional query parameters:
 - *currency*: specifies a currency of returned rate ("usd", "eur", "eth"...). If not specified, all available currencies will be returned.
-- *timestamp*: a UNIX timestamp that specifies a date to return currency rates for. If not specified, the last available rate will be returned.
+- *timestamp*: a Unix timestamp that specifies a date to return currency rates for. If not specified, the last available rate will be returned.
 
 Example response (no parameters):
 
@@ -652,11 +652,11 @@ GET /api/v2/balancehistory/<XPUB | address>?from=<dateFrom>&to=<dateTo>[&fiatcur
 ```
 
 Query parameters:
-- *from*: specifies a start date, format is YYYY-MM-DD.
-- *to*: specifies an end date, same format. 
+- *from*: specifies a start date as a Unix timestamp
+- *to*: specifies an end date as a Unix timestamp
 
 The optional query parameters:
-- *fiatcurrency*: if specified, the response will contain calculated fiat amounts at the time of transaction.
+- *fiatcurrency*: if specified, the response will contain fiat rate at the time of transaction.
 - *groupBy*: an interval in seconds, to group results by. Default is 3600 seconds.
 
 Example response (fiatcurrency=usd):
@@ -664,32 +664,38 @@ Example response (fiatcurrency=usd):
 ```javascript
 [
   {
-    "time":1397768400,
-    "txs":1,
-    "received":"6169114",
-    "sent":"0",
-    "fiatRate":478.2312
+    "time": 1578391200,
+    "txs": 5,
+    "received": "5000000",
+    "sent": "0",
+    "rates": {
+      "usd": 7855.9
+    }
   },
   {
-    "time":1397772000,
-    "txs":1,
-    "received":"0",
-    "sent":"6169114",
-    "fiatRate":479.1233
+    "time": 1578488400,
+    "txs": 1,
+    "received": "0",
+    "sent": "5000000",
+    "rates": {
+      "usd": 8283.11
+    }
   }
 ]
 ```
 
-Example response (fiatcurrency=usd&groupBy=86400):
+Example response (fiatcurrency=usd&groupBy=172800):
 
 ```javascript
 [
   {
-    "time":1397700000,
-    "txs":2,
-    "received":"6169114",
-    "sent":"6169114",
-    "fiatRate":478.2312
+    "time": 1578355200,
+    "txs": 6,
+    "received": "5000000",
+    "sent": "5000000",
+    "rates": {
+      "usd": 7734.45
+    }
   }
 ]
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -656,8 +656,36 @@ Query parameters:
 - *to*: specifies an end date as a Unix timestamp
 
 The optional query parameters:
-- *fiatcurrency*: if specified, the response will contain fiat rate at the time of transaction.
+- *fiatcurrency*: if specified, the response will contain fiat rate at the time of transaction. If not, all available currencies will be returned.
 - *groupBy*: an interval in seconds, to group results by. Default is 3600 seconds.
+
+Example response (fiatcurrency not specified):
+```javascript
+[
+  {
+    "time": 1578391200,
+    "txs": 5,
+    "received": "5000000",
+    "sent": "0",
+    "rates": {
+      "usd": 7855.9,
+      "eur": 6838.13,
+      ...
+    }
+  },
+  {
+    "time": 1578488400,
+    "txs": 1,
+    "received": "0",
+    "sent": "5000000",
+    "rates": {
+      "usd": 8283.11,
+      "eur": 7464.45,
+      ...
+    }
+  }
+]
+```
 
 Example response (fiatcurrency=usd):
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -618,10 +618,10 @@ Example response (no parameters):
 
 ```javascript
 {
-  "ts":1574346615,
+  "ts": 1574346615,
   "rates": {
-    "eur":7134.1,
-    "usd":7914.5
+    "eur": 7134.1,
+    "usd": 7914.5
     }
 }
 ```
@@ -630,8 +630,10 @@ Example response (currency=usd):
 
 ```javascript
 {
-  "ts":1574346615,
-  "rate":7914.5
+  "ts": 1574346615,
+  "rates": {
+    "usd": 7914.5
+  }
 }
 ```
 
@@ -639,7 +641,9 @@ Example error response (e.g. rate unavailable, incorrect currency...):
 ```javascript
 {
   "ts":7980386400,
-  "rate":-1
+  "rates": {
+    "usd": -1
+  }
 }
 ```
 

--- a/server/public.go
+++ b/server/public.go
@@ -1069,11 +1069,15 @@ func (s *PublicServer) apiBalanceHistory(r *http.Request, apiVersion int) (inter
 			groupBy = 3600
 		}
 		fiat := r.URL.Query().Get("fiatcurrency")
-		history, err = s.api.GetXpubBalanceHistory(r.URL.Path[i+1:], fromTimestamp, toTimestamp, fiat, gap, uint32(groupBy))
+		var fiatArray []string
+		if fiat != "" {
+			fiatArray = []string{fiat}
+		}
+		history, err = s.api.GetXpubBalanceHistory(r.URL.Path[i+1:], fromTimestamp, toTimestamp, fiatArray, gap, uint32(groupBy))
 		if err == nil {
 			s.metrics.ExplorerViews.With(common.Labels{"action": "api-xpub-balancehistory"}).Inc()
 		} else {
-			history, err = s.api.GetBalanceHistory(r.URL.Path[i+1:], fromTimestamp, toTimestamp, fiat, uint32(groupBy))
+			history, err = s.api.GetBalanceHistory(r.URL.Path[i+1:], fromTimestamp, toTimestamp, fiatArray, uint32(groupBy))
 			s.metrics.ExplorerViews.With(common.Labels{"action": "api-address-balancehistory"}).Inc()
 		}
 	}

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -789,8 +789,8 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 		},
 		{
-			name:        "apiBalanceHistory Addr2 v2 from=2018-03-20&to=2018-03-21",
-			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/mtGXQvBowMkBpnhLckhxhbwYK44Gs9eEtz?from=2018-03-20&to=2018-03-21"),
+			name:        "apiBalanceHistory Addr2 v2 from=1521504000&to=1521590400",
+			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/mtGXQvBowMkBpnhLckhxhbwYK44Gs9eEtz?from=1521504000&to=1521590400"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
@@ -807,8 +807,8 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 		},
 		{
-			name:        "apiBalanceHistory xpub v2 from=2018-03-20&to=2018-03-21",
-			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/" + dbtestdata.Xpub + "?from=2018-03-20&to=2018-03-21"),
+			name:        "apiBalanceHistory xpub v2 from=1521504000&to=1521590400",
+			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/" + dbtestdata.Xpub + "?from=1521504000&to=1521590400"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
@@ -816,8 +816,8 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 		},
 		{
-			name:        "apiBalanceHistory xpub v2 from=2018-03-20&to=2018-03-21&fiatcurrency=usd",
-			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/" + dbtestdata.Xpub + "?from=2018-03-20&to=2018-03-21&fiatcurrency=usd"),
+			name:        "apiBalanceHistory xpub v2 from=1521504000&to=1521590400&fiatcurrency=usd",
+			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/" + dbtestdata.Xpub + "?from=1521504000&to=1521590400&fiatcurrency=usd"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
@@ -825,8 +825,8 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 		},
 		{
-			name:        "apiBalanceHistory xpub v2 from=2018-03-21",
-			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/" + dbtestdata.Xpub + "?from=2018-03-21"),
+			name:        "apiBalanceHistory xpub v2 from=1521590400",
+			r:           newGetRequest(ts.URL + "/api/v2/balancehistory/" + dbtestdata.Xpub + "?from=1521590400"),
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
@@ -1340,7 +1340,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamp": 1570346615,
 				},
 			},
-			want: `{"id":"30","data":{"ts":1570346615,"available_currencies":["eur","usd"]}}`,
+			want: `{"id":"30","data":{"ts":1574344800,"available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",
@@ -1363,13 +1363,13 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			want: `{"id":"32","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0"},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1"}]}`,
 		},
 		{
-			name: "websocket getBalanceHistory xpub from=2018-03-20&to=2018-03-21&fiat=usd",
+			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400&fiat=usd",
 			req: websocketReq{
 				Method: "getBalanceHistory",
 				Params: map[string]interface{}{
 					"descriptor": dbtestdata.Xpub,
-					"from":       "2018-03-20",
-					"to":         "2018-03-21",
+					"from":       1521504000,
+					"to":         1521590400,
 					"fiat":       "usd",
 				},
 			},

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -564,6 +564,15 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 		},
 		{
+			name:        "apiFiatRates future timestamp, all currencies",
+			r:           newGetRequest(ts.URL + "/api/v2/tickers?timestamp=7980386400"),
+			status:      http.StatusOK,
+			contentType: "application/json; charset=utf-8",
+			body: []string{
+				`{"ts":7980386400,"rates":{}}`,
+			},
+		},
+		{
 			name:        "apiFiatRates get EUR rate (exact timestamp)",
 			r:           newGetRequest(ts.URL + "/api/v2/tickers?timestamp=1574344800&currency=eur"),
 			status:      http.StatusOK,

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -1,4 +1,4 @@
-// build unittest
+// +build unittest
 
 package server
 
@@ -1195,11 +1195,11 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			want: `{"id":"16","data":{}}`,
 		},
 		{
-			name: "websocket getCurrentFiatRates no currency",
+			name: "websocket getCurrentFiatRates all currencies",
 			req: websocketReq{
 				Method: "getCurrentFiatRates",
 				Params: map[string]interface{}{
-					"": "",
+					"currencies": []string{},
 				},
 			},
 			want: `{"id":"17","data":{"ts":1574346615,"rates":{"eur":7134.1,"usd":7914.5}}}`,
@@ -1209,7 +1209,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getCurrentFiatRates",
 				Params: map[string]interface{}{
-					"currency": "usd",
+					"currencies": []string{"usd"},
 				},
 			},
 			want: `{"id":"18","data":{"ts":1574346615,"rate":7914.5}}`,
@@ -1219,7 +1219,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getCurrentFiatRates",
 				Params: map[string]interface{}{
-					"currency": "eur",
+					"currencies": []string{"eur"},
 				},
 			},
 			want: `{"id":"19","data":{"ts":1574346615,"rate":7134.1}}`,
@@ -1229,7 +1229,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getCurrentFiatRates",
 				Params: map[string]interface{}{
-					"currency": "does-not-exist",
+					"currencies": []string{"does-not-exist"},
 				},
 			},
 			want: `{"id":"20","data":{"error":{"message":"Currency \"does-not-exist\" is not available for timestamp 1574346615."}}}`,
@@ -1239,7 +1239,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency": "usd",
+					"currencies": []string{"usd"},
 				},
 			},
 			want: `{"id":"21","data":{"error":{"message":"No timestamps provided"}}}`,
@@ -1249,7 +1249,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "usd",
+					"currencies": []string{"usd"},
 					"timestamps": []string{"yesterday"},
 				},
 			},
@@ -1260,7 +1260,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "usd",
+					"currencies": []string{"usd"},
 					"timestamps": []int64{7885693815},
 				},
 			},
@@ -1271,7 +1271,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "usd",
+					"currencies": []string{"usd"},
 					"timestamps": []int64{1574346615},
 				},
 			},
@@ -1282,7 +1282,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "eur",
+					"currencies": []string{"eur"},
 					"timestamps": []int64{1521507600},
 				},
 			},
@@ -1293,7 +1293,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "usd",
+					"currencies": []string{"usd"},
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
@@ -1304,7 +1304,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "eur",
+					"currencies": []string{"eur"},
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
@@ -1315,7 +1315,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "usd",
+					"currencies": []string{"usd"},
 					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
@@ -1326,7 +1326,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
 				Params: map[string]interface{}{
-					"currency":   "usd",
+					"currencies": []string{"usd"},
 					"timestamps": []int64{7832854800, 2000000000},
 				},
 			},

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -785,7 +785,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"9876","sent":"0","fiatRate":1301},{"time":1521594000,"txs":1,"received":"9000","sent":"9876","fiatRate":1303}]`,
+				`[{"time":1521514800,"txs":1,"received":"9876","sent":"0","rates":{"eur":1301}},{"time":1521594000,"txs":1,"received":"9000","sent":"9876","rates":{"eur":1303}}]`,
 			},
 		},
 		{
@@ -821,7 +821,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"1","sent":"0","fiatRate":2001}]`,
+				`[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"usd":2001}}]`,
 			},
 		},
 		{
@@ -1363,17 +1363,43 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			want: `{"id":"32","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0"},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1"}]}`,
 		},
 		{
-			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400&fiat=usd",
+			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[usd]",
 			req: websocketReq{
 				Method: "getBalanceHistory",
 				Params: map[string]interface{}{
 					"descriptor": dbtestdata.Xpub,
 					"from":       1521504000,
 					"to":         1521590400,
-					"fiat":       "usd",
+					"currencies": []string{"usd"},
 				},
 			},
-			want: `{"id":"33","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","fiatRate":2001}]}`,
+			want: `{"id":"33","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"usd":2001}}]}`,
+		},
+		{
+			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[usd, eur, incorrect]",
+			req: websocketReq{
+				Method: "getBalanceHistory",
+				Params: map[string]interface{}{
+					"descriptor": dbtestdata.Xpub,
+					"from":       1521504000,
+					"to":         1521590400,
+					"currencies": []string{"usd", "eur", "incorrect"},
+				},
+			},
+			want: `{"id":"34","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"incorrect":-1,"usd":2001}}]}`,
+		},
+		{
+			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[]",
+			req: websocketReq{
+				Method: "getBalanceHistory",
+				Params: map[string]interface{}{
+					"descriptor": dbtestdata.Xpub,
+					"from":       1521504000,
+					"to":         1521590400,
+					"currencies": []string{},
+				},
+			},
+			want: `{"id":"35","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0"}]}`,
 		},
 	}
 

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -533,7 +533,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574346615,"rate":7914.5}`,
+				`{"ts":1574346615,"rates":{"usd":7914.5}}`,
 			},
 		},
 		{
@@ -542,7 +542,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574344800,"rate":7814.5}`,
+				`{"ts":1574344800,"rates":{"usd":7814.5}}`,
 			},
 		},
 		{
@@ -560,7 +560,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":7980386400,"rate":-1}`,
+				`{"ts":7980386400,"rates":{"usd":-1}}`,
 			},
 		},
 		{
@@ -569,7 +569,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574344800,"rate":7100}`,
+				`{"ts":1574344800,"rates":{"eur":7100}}`,
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1521511200,"rate":2000}`,
+				`{"ts":1521511200,"rates":{"usd":2000}}`,
 			},
 		},
 		{
@@ -587,7 +587,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1521611721,"rate":2003}`,
+				`{"ts":1521611721,"rates":{"usd":2003}}`,
 			},
 		},
 		{
@@ -596,7 +596,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574346615,"rate":7134.1}`,
+				`{"ts":1574346615,"rates":{"eur":7134.1}}`,
 			},
 		},
 		{
@@ -605,7 +605,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"ts":1574346615,"rate":-1}`,
+				`{"ts":1574346615,"rates":{"does_not_exist":-1}}`,
 			},
 		},
 		{
@@ -1212,7 +1212,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{"usd"},
 				},
 			},
-			want: `{"id":"18","data":{"ts":1574346615,"rate":7914.5}}`,
+			want: `{"id":"18","data":{"ts":1574346615,"rates":{"usd":7914.5}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates eur",
@@ -1222,7 +1222,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{"eur"},
 				},
 			},
-			want: `{"id":"19","data":{"ts":1574346615,"rate":7134.1}}`,
+			want: `{"id":"19","data":{"ts":1574346615,"rates":{"eur":7134.1}}}`,
 		},
 		{
 			name: "websocket getCurrentFiatRates incorrect currency",
@@ -1232,7 +1232,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{"does-not-exist"},
 				},
 			},
-			want: `{"id":"20","data":{"error":{"message":"Currency \"does-not-exist\" is not available for timestamp 1574346615."}}}`,
+			want: `{"id":"20","data":{"ts":1574346615,"rates":{"does-not-exist":-1}}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps missing date",
@@ -1264,7 +1264,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7885693815},
 				},
 			},
-			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"rate":-1}]}}`,
+			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"rates":{"usd":-1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps exact date",
@@ -1275,7 +1275,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1574346615},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"ts":1574346615,"rate":7914.5}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps closest date, eur",
@@ -1286,7 +1286,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1521507600},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rate":1300}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1297,7 +1297,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"ts":1574344800,"rate":7814.5},{"ts":1574346615,"rate":7914.5}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
@@ -1308,7 +1308,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rate":7100},{"ts":1574346615,"rate":7134.1}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1319,7 +1319,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rate":7814.5},{"ts":1574346615,"rate":7914.5},{"ts":2000000000,"rate":-1}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}},{"ts":2000000000,"rates":{"usd":-1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple errors",
@@ -1330,7 +1330,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7832854800, 2000000000},
 				},
 			},
-			want: `{"id":"29","data":{"tickers":[{"ts":7832854800,"rate":-1},{"ts":2000000000,"rate":-1}]}}`,
+			want: `{"id":"29","data":{"tickers":[{"ts":7832854800,"rates":{"usd":-1}},{"ts":2000000000,"rates":{"usd":-1}}]}}`,
 		},
 		{
 			name: "websocket getTickersList",

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -1265,6 +1265,17 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			want: `{"id":"22","data":{"error":{"message":"json: cannot unmarshal string into Go struct field .timestamps of type int64"}}}`,
 		},
 		{
+			name: "websocket getFiatRatesForTimestamps empty currency",
+			req: websocketReq{
+				Method: "getFiatRatesForTimestamps",
+				Params: map[string]interface{}{
+					"timestamps": []int64{7885693815},
+					"currencies": []string{""},
+				},
+			},
+			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"rates":{}}]}}`,
+		},
+		{
 			name: "websocket getFiatRatesForTimestamps incorrect (future) date",
 			req: websocketReq{
 				Method: "getFiatRatesForTimestamps",
@@ -1273,7 +1284,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7885693815},
 				},
 			},
-			want: `{"id":"23","data":{"tickers":[{"ts":7885693815,"rates":{"usd":-1}}]}}`,
+			want: `{"id":"24","data":{"tickers":[{"ts":7885693815,"rates":{"usd":-1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps exact date",
@@ -1284,7 +1295,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1574346615},
 				},
 			},
-			want: `{"id":"24","data":{"tickers":[{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
+			want: `{"id":"25","data":{"tickers":[{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps closest date, eur",
@@ -1295,7 +1306,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1521507600},
 				},
 			},
-			want: `{"id":"25","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300}}]}}`,
+			want: `{"id":"26","data":{"tickers":[{"ts":1521511200,"rates":{"eur":1300}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps usd",
@@ -1306,7 +1317,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"26","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
+			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps eur",
@@ -1317,7 +1328,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615},
 				},
 			},
-			want: `{"id":"27","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
+			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rates":{"eur":7100}},{"ts":1574346615,"rates":{"eur":7134.1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple timestamps with an error",
@@ -1328,7 +1339,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{1570346615, 1574346615, 2000000000},
 				},
 			},
-			want: `{"id":"28","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}},{"ts":2000000000,"rates":{"usd":-1}}]}}`,
+			want: `{"id":"29","data":{"tickers":[{"ts":1574344800,"rates":{"usd":7814.5}},{"ts":1574346615,"rates":{"usd":7914.5}},{"ts":2000000000,"rates":{"usd":-1}}]}}`,
 		},
 		{
 			name: "websocket getFiatRatesForTimestamps multiple errors",
@@ -1339,7 +1350,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamps": []int64{7832854800, 2000000000},
 				},
 			},
-			want: `{"id":"29","data":{"tickers":[{"ts":7832854800,"rates":{"usd":-1}},{"ts":2000000000,"rates":{"usd":-1}}]}}`,
+			want: `{"id":"30","data":{"tickers":[{"ts":7832854800,"rates":{"usd":-1}},{"ts":2000000000,"rates":{"usd":-1}}]}}`,
 		},
 		{
 			name: "websocket getTickersList",
@@ -1349,7 +1360,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"timestamp": 1570346615,
 				},
 			},
-			want: `{"id":"30","data":{"ts":1574344800,"available_currencies":["eur","usd"]}}`,
+			want: `{"id":"31","data":{"ts":1574344800,"available_currencies":["eur","usd"]}}`,
 		},
 		{
 			name: "websocket getBalanceHistory Addr2",
@@ -1359,7 +1370,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"descriptor": "mtGXQvBowMkBpnhLckhxhbwYK44Gs9eEtz",
 				},
 			},
-			want: `{"id":"31","data":[{"time":1521514800,"txs":1,"received":"12345","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"0","sent":"12345","rates":{"eur":1303,"usd":2003}}]}`,
+			want: `{"id":"32","data":[{"time":1521514800,"txs":1,"received":"12345","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"0","sent":"12345","rates":{"eur":1303,"usd":2003}}]}`,
 		},
 		{
 			name: "websocket getBalanceHistory xpub",
@@ -1369,7 +1380,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"descriptor": dbtestdata.Xpub,
 				},
 			},
-			want: `{"id":"32","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1","rates":{"eur":1303,"usd":2003}}]}`,
+			want: `{"id":"33","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1","rates":{"eur":1303,"usd":2003}}]}`,
 		},
 		{
 			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[usd]",
@@ -1382,7 +1393,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{"usd"},
 				},
 			},
-			want: `{"id":"33","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"usd":2001}}]}`,
+			want: `{"id":"34","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"usd":2001}}]}`,
 		},
 		{
 			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[usd, eur, incorrect]",
@@ -1395,7 +1406,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{"usd", "eur", "incorrect"},
 				},
 			},
-			want: `{"id":"34","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"incorrect":-1,"usd":2001}}]}`,
+			want: `{"id":"35","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"incorrect":-1,"usd":2001}}]}`,
 		},
 		{
 			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[]",
@@ -1408,7 +1419,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{},
 				},
 			},
-			want: `{"id":"35","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}}]}`,
+			want: `{"id":"36","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}}]}`,
 		},
 	}
 

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -1,4 +1,4 @@
-// +build unittest
+// build unittest
 
 package server
 
@@ -767,7 +767,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"12345","sent":"0"},{"time":1521594000,"txs":1,"received":"0","sent":"12345"}]`,
+				`[{"time":1521514800,"txs":1,"received":"12345","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"0","sent":"12345","rates":{"eur":1303,"usd":2003}}]`,
 			},
 		},
 		{
@@ -776,7 +776,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"9876","sent":"0"},{"time":1521594000,"txs":1,"received":"9000","sent":"9876"}]`,
+				`[{"time":1521514800,"txs":1,"received":"9876","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"9000","sent":"9876","rates":{"eur":1303,"usd":2003}}]`,
 			},
 		},
 		{
@@ -794,7 +794,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"12345","sent":"0"}]`,
+				`[{"time":1521514800,"txs":1,"received":"12345","sent":"0","rates":{"eur":1301,"usd":2001}}]`,
 			},
 		},
 		{
@@ -803,7 +803,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"1","sent":"0"},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1"}]`,
+				`[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1","rates":{"eur":1303,"usd":2003}}]`,
 			},
 		},
 		{
@@ -812,7 +812,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521514800,"txs":1,"received":"1","sent":"0"}]`,
+				`[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}}]`,
 			},
 		},
 		{
@@ -830,7 +830,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`[{"time":1521594000,"txs":1,"received":"118641975500","sent":"1"}]`,
+				`[{"time":1521594000,"txs":1,"received":"118641975500","sent":"1","rates":{"eur":1303,"usd":2003}}]`,
 			},
 		},
 		{
@@ -1350,7 +1350,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"descriptor": "mtGXQvBowMkBpnhLckhxhbwYK44Gs9eEtz",
 				},
 			},
-			want: `{"id":"31","data":[{"time":1521514800,"txs":1,"received":"12345","sent":"0"},{"time":1521594000,"txs":1,"received":"0","sent":"12345"}]}`,
+			want: `{"id":"31","data":[{"time":1521514800,"txs":1,"received":"12345","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"0","sent":"12345","rates":{"eur":1303,"usd":2003}}]}`,
 		},
 		{
 			name: "websocket getBalanceHistory xpub",
@@ -1360,7 +1360,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"descriptor": dbtestdata.Xpub,
 				},
 			},
-			want: `{"id":"32","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0"},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1"}]}`,
+			want: `{"id":"32","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}},{"time":1521594000,"txs":1,"received":"118641975500","sent":"1","rates":{"eur":1303,"usd":2003}}]}`,
 		},
 		{
 			name: "websocket getBalanceHistory xpub from=1521504000&to=1521590400 currencies=[usd]",
@@ -1399,7 +1399,7 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 					"currencies": []string{},
 				},
 			},
-			want: `{"id":"35","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0"}]}`,
+			want: `{"id":"35","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}}]}`,
 		},
 	}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -352,22 +352,22 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 	},
 	"getCurrentFiatRates": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		r := struct {
-			Currency string `json:"currency"`
+			Currencies []string `json:"currencies"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
-			rv, err = s.getCurrentFiatRates(strings.ToLower(r.Currency))
+			rv, err = s.getCurrentFiatRates(r.Currencies)
 		}
 		return
 	},
 	"getFiatRatesForTimestamps": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		r := struct {
-			Timestamps []int64 `json:"timestamps"`
-			Currency   string  `json:"currency"`
+			Timestamps []int64  `json:"timestamps"`
+			Currencies []string `json:"currencies"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
-			rv, err = s.getFiatRatesForTimestamps(r.Timestamps, strings.ToLower(r.Currency))
+			rv, err = s.getFiatRatesForTimestamps(r.Timestamps, r.Currencies)
 		}
 		return
 	},
@@ -826,13 +826,13 @@ func (s *WebsocketServer) OnNewFiatRatesTicker(ticker *db.CurrencyRatesTicker) {
 	s.broadcastTicker(allFiatRates, ticker.Rates)
 }
 
-func (s *WebsocketServer) getCurrentFiatRates(currency string) (interface{}, error) {
-	ret, err := s.api.GetCurrentFiatRates(currency)
+func (s *WebsocketServer) getCurrentFiatRates(currencies []string) (interface{}, error) {
+	ret, err := s.api.GetCurrentFiatRates(currencies)
 	return ret, err
 }
 
-func (s *WebsocketServer) getFiatRatesForTimestamps(timestamps []int64, currency string) (interface{}, error) {
-	ret, err := s.api.GetFiatRatesForTimestamps(timestamps, currency)
+func (s *WebsocketServer) getFiatRatesForTimestamps(timestamps []int64, currencies []string) (interface{}, error) {
+	ret, err := s.api.GetFiatRatesForTimestamps(timestamps, currencies)
 	return ret, err
 }
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -260,33 +260,26 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 	"getBalanceHistory": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		r := struct {
 			Descriptor string `json:"descriptor"`
-			From       string `json:"from"`
-			To         string `json:"to"`
+			From       int64  `json:"from"`
+			To         int64  `json:"to"`
 			Fiat       string `json:"fiat"`
 			Gap        int    `json:"gap"`
 			GroupBy    uint32 `json:"groupBy"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
-			var fromTime, toTime time.Time
-			if r.From != "" {
-				fromTime, err = time.Parse("2006-01-02", r.From)
-				if err != nil {
-					return
-				}
+			if r.From <= 0 {
+				r.From = 0
 			}
-			if r.To != "" {
-				toTime, err = time.Parse("2006-01-02", r.To)
-				if err != nil {
-					return
-				}
+			if r.To <= 0 {
+				r.To = 0
 			}
 			if r.GroupBy <= 0 {
 				r.GroupBy = 3600
 			}
-			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, fromTime, toTime, strings.ToLower(r.Fiat), r.Gap, r.GroupBy)
+			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, r.From, r.To, strings.ToLower(r.Fiat), r.Gap, r.GroupBy)
 			if err != nil {
-				rv, err = s.api.GetBalanceHistory(r.Descriptor, fromTime, toTime, strings.ToLower(r.Fiat), r.GroupBy)
+				rv, err = s.api.GetBalanceHistory(r.Descriptor, r.From, r.To, strings.ToLower(r.Fiat), r.GroupBy)
 			}
 		}
 		return

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -259,12 +259,12 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 	},
 	"getBalanceHistory": func(s *WebsocketServer, c *websocketChannel, req *websocketReq) (rv interface{}, err error) {
 		r := struct {
-			Descriptor string `json:"descriptor"`
-			From       int64  `json:"from"`
-			To         int64  `json:"to"`
-			Fiat       string `json:"fiat"`
-			Gap        int    `json:"gap"`
-			GroupBy    uint32 `json:"groupBy"`
+			Descriptor string   `json:"descriptor"`
+			From       int64    `json:"from"`
+			To         int64    `json:"to"`
+			Currencies []string `json:"currencies"`
+			Gap        int      `json:"gap"`
+			GroupBy    uint32   `json:"groupBy"`
 		}{}
 		err = json.Unmarshal(req.Params, &r)
 		if err == nil {
@@ -277,9 +277,9 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *webs
 			if r.GroupBy <= 0 {
 				r.GroupBy = 3600
 			}
-			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, r.From, r.To, strings.ToLower(r.Fiat), r.Gap, r.GroupBy)
+			rv, err = s.api.GetXpubBalanceHistory(r.Descriptor, r.From, r.To, r.Currencies, r.Gap, r.GroupBy)
 			if err != nil {
-				rv, err = s.api.GetBalanceHistory(r.Descriptor, r.From, r.To, strings.ToLower(r.Fiat), r.GroupBy)
+				rv, err = s.api.GetBalanceHistory(r.Descriptor, r.From, r.To, r.Currencies, r.GroupBy)
 			}
 		}
 		return

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -302,11 +302,12 @@
         function getFiatRatesForTimestamps() {
             const method = 'getFiatRatesForTimestamps';
             var timestamps = document.getElementById('getFiatRatesForTimestampsList').value.split(",");
-            var currency = document.getElementById('getFiatRatesForTimestampsCurrency').value;
+            var currencies = document.getElementById('getFiatRatesForTimestampsCurrency').value.split(",");
+            console.log(currencies);
             timestamps = timestamps.map(Number);
             const params = {
                 timestamps,
-                "currency": currency
+                'currencies': currencies
             };
             send(method, params, function (result) {
                 document.getElementById('getFiatRatesForTimestampsResult').innerText = JSON.stringify(result).replace(/,/g, ", ");
@@ -315,9 +316,9 @@
 
         function getCurrentFiatRates() {
             const method = 'getCurrentFiatRates';
-            var currency = document.getElementById('getCurrentFiatRatesCurrency').value;
+            var currencies = document.getElementById('getCurrentFiatRatesCurrency').value.split(",");
             const params = {
-                "currency": currency
+                "currencies": currencies
             };
             send(method, params, function (result) {
                 document.getElementById('getCurrentFiatRatesResult').innerText = JSON.stringify(result).replace(/,/g, ", ");
@@ -540,7 +541,7 @@
                 <input class="btn btn-secondary" type="button" value="get fiat rates for dates" onclick="getFiatRatesForTimestamps()">
             </div>
             <div class="col-1">
-                <input type="text" class="form-control" id="getFiatRatesForTimestampsCurrency" value="usd">
+                <input type="text" class="form-control" id="getFiatRatesForTimestampsCurrency" placeholder="usd,eur">
             </div>
             <div class="col-7">
                 <input type="text" class="form-control" id="getFiatRatesForTimestampsList" value="1575288000,1575550800">

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -165,14 +165,14 @@
             const descriptor = document.getElementById('getBalanceHistoryDescriptor').value.trim();
             const from = parseInt(document.getElementById("getBalanceHistoryFrom").value.trim());
             const to = parseInt(document.getElementById("getBalanceHistoryTo").value.trim());
-            const fiat = document.getElementById("getBalanceHistoryFiat").value.trim();
+            const currencies = document.getElementById('getBalanceHistoryFiat').value.split(",");
             const groupBy = parseInt(document.getElementById("getBalanceHistoryGroupBy").value);
             const method = 'getBalanceHistory';
             const params = {
                 descriptor,
                 from,
                 to,
-                fiat,
+                currencies,
                 groupBy
                 // default gap=20
             };
@@ -462,9 +462,9 @@
                     <input type="text" placeholder="descriptor" class="form-control" id="getBalanceHistoryDescriptor" value="0xba98d6a5ac827632e3457de7512d211e4ff7e8bd">
                 </div>
                 <div class="row" style="margin: 0; margin-top: 5px;">
-                    <input type="text" placeholder="from YYYY-MM-DD" style="width: 30%;margin-left: 5px;margin-right: 5px;" class="form-control" id="getBalanceHistoryFrom">
-                    <input type="text" placeholder="to YYYY-MM-DD" style="width: 30%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryTo">
-                    <input type="text" placeholder="fiat" style="width: 10%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryFiat">
+                    <input type="text" placeholder="from Unix TS" style="width: 20%;margin-left: 5px;margin-right: 5px;" class="form-control" id="getBalanceHistoryFrom">
+                    <input type="text" placeholder="to Unix TS" style="width: 20%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryTo">
+                    <input type="text" placeholder="usd,eur" style="width: 20%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryFiat">
                     <input type="text" placeholder="group by (sec)" style="width: 20%; margin-left: 5px; margin-right: 5px;" class="form-control" id="getBalanceHistoryGroupBy">
                 </div>
             </div>

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -303,7 +303,6 @@
             const method = 'getFiatRatesForTimestamps';
             var timestamps = document.getElementById('getFiatRatesForTimestampsList').value.split(",");
             var currencies = document.getElementById('getFiatRatesForTimestampsCurrency').value.split(",");
-            console.log(currencies);
             timestamps = timestamps.map(Number);
             const params = {
                 timestamps,

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -163,8 +163,8 @@
 
         function getBalanceHistory() {
             const descriptor = document.getElementById('getBalanceHistoryDescriptor').value.trim();
-            const from = document.getElementById("getBalanceHistoryFrom").value.trim();
-            const to = document.getElementById("getBalanceHistoryTo").value.trim();
+            const from = parseInt(document.getElementById("getBalanceHistoryFrom").value.trim());
+            const to = parseInt(document.getElementById("getBalanceHistoryTo").value.trim());
             const fiat = document.getElementById("getBalanceHistoryFiat").value.trim();
             const groupBy = parseInt(document.getElementById("getBalanceHistoryGroupBy").value);
             const method = 'getBalanceHistory';


### PR DESCRIPTION
getFiatRatesTickersList:
* return the actual data timestamp

getBalanceHistory:
* accept Unix timestamps instead of date strings

websocket API:
* accept a list of fiat currencies everywhere
* if the list is empty, return all available currency rates