### PR TITLE
Remove empty map on address unsubscribe

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -684,10 +684,13 @@ func (s *WebsocketServer) subscribeAddresses(c *websocketChannel, addrDesc []bch
 func (s *WebsocketServer) unsubscribeAddresses(c *websocketChannel) (res interface{}, err error) {
 	s.addressSubscriptionsLock.Lock()
 	defer s.addressSubscriptionsLock.Unlock()
-	for _, sa := range s.addressSubscriptions {
+	for ads, sa := range s.addressSubscriptions {
 		for sc := range sa {
 			if sc == c {
 				delete(sa, c)
+				if len(sa) == 0 {
+					delete(s.addressSubscriptions, ads)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
It is possible subscribe to a lot of not exists addresses and then unsubscribe (or disconnect). If repeat this in loop, `addressSubscriptions` will have a lot of empty maps what should cause OOM in the end.
(Not sure about this, never write code on go for real apps)