### PR TITLE
Proposal for mempool API (issue #397)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -447,3 +447,12 @@ type MempoolTxids struct {
 	Mempool     []MempoolTxid `json:"mempool"`
 	MempoolSize int           `json:"mempoolSize"`
 }
+
+// MempoolTxs contains information about mempool transactions
+type MempoolTxs struct {
+	Paging
+	LastTime     uint32 `json:"lastTime"`
+	MempoolSize  int    `json:"mempoolSize"`
+	TxCount      int    `json:"txCount"`
+	Transactions []*Tx  `json:"txs,omitempty"`
+}

--- a/api/worker.go
+++ b/api/worker.go
@@ -1633,3 +1633,26 @@ func (w *Worker) GetMempool(page int, itemsOnPage int) (*MempoolTxids, error) {
 	}
 	return r, nil
 }
+
+// GetMempoolNew returns a page of mempool txids, newer than fromTime
+func (w *Worker) GetMempoolNew(timeFrom uint32, page, itemsOnPage int) (*MempoolTxids, error) {
+	page--
+	if page < 0 {
+		page = 0
+	}
+	entries := w.mempool.GetNewEntries(timeFrom)
+	pg, from, to, _ := computePaging(len(entries), page, itemsOnPage)
+	r := &MempoolTxids{
+		Paging:      pg,
+		MempoolSize: len(entries),
+	}
+	r.Mempool = make([]MempoolTxid, to-from)
+	for i := from; i < to; i++ {
+		entry := &entries[i]
+		r.Mempool[i-from] = MempoolTxid{
+			Txid: entry.Txid,
+			Time: int64(entry.Time),
+		}
+	}
+	return r, nil
+}

--- a/bchain/basemempool.go
+++ b/bchain/basemempool.go
@@ -103,6 +103,32 @@ func (m *BaseMempool) GetAllEntries() MempoolTxidEntries {
 	return entries
 }
 
+// GetNewEntries returns mempool entries newer than a threshold, sorted by fist seen time in descending order
+func (m *BaseMempool) GetNewEntries(timeFrom uint32) MempoolTxidEntries {
+	m.mux.Lock()
+	count := 0
+	// first count, second collect
+	for _, entry := range m.txEntries {
+		if entry.time >= timeFrom {
+			count++
+		}
+	}
+	entries := make(MempoolTxidEntries, count)
+	i := 0
+	for txid, entry := range m.txEntries {
+		if entry.time >= timeFrom {
+			entries[i] = MempoolTxidEntry{
+				Txid: txid,
+				Time: entry.time,
+			}
+			i++
+		}		
+	}
+	m.mux.Unlock()
+	sort.Sort(entries)
+	return entries
+}
+
 // GetTransactionTime returns first seen time of a transaction
 func (m *BaseMempool) GetTransactionTime(txid string) uint32 {
 	m.mux.Lock()

--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -350,6 +350,11 @@ func (c *mempoolWithMetrics) GetAllEntries() (v bchain.MempoolTxidEntries) {
 	return c.mempool.GetAllEntries()
 }
 
+func (c *mempoolWithMetrics) GetNewEntries(fromTime uint32) (v bchain.MempoolTxidEntries) {
+	defer func(s time.Time) { c.observeRPCLatency("GetNewEntries", s, nil) }(time.Now())
+	return c.mempool.GetNewEntries(fromTime)
+}
+
 func (c *mempoolWithMetrics) GetTransactionTime(txid string) uint32 {
 	return c.mempool.GetTransactionTime(txid)
 }

--- a/bchain/types.go
+++ b/bchain/types.go
@@ -303,5 +303,6 @@ type Mempool interface {
 	GetTransactions(address string) ([]Outpoint, error)
 	GetAddrDescTransactions(addrDesc AddressDescriptor) ([]Outpoint, error)
 	GetAllEntries() MempoolTxidEntries
+	GetNewEntries(timeFrom uint32) MempoolTxidEntries
 	GetTransactionTime(txid string) uint32
 }

--- a/server/public.go
+++ b/server/public.go
@@ -1108,6 +1108,22 @@ func (s *PublicServer) apiBlock(r *http.Request, apiVersion int) (interface{}, e
 	return block, err
 }
 
+func (s *PublicServer) apiMempool(r *http.Request, apiVersion int) (interface{}, error) {
+	s.metrics.ExplorerViews.With(common.Labels{"action": "api-mempool"}).Inc()
+	var mempool *api.MempoolTxids
+	var err error
+	if i := strings.LastIndexByte(r.URL.Path, '/'); i > 0 {
+		page, ec := strconv.Atoi(r.URL.Query().Get("page"))
+		if ec != nil {
+			page = 0
+		}
+		// TODO: returns only TxIDs
+		mempool, err = s.api.GetMempool(page, txsInAPI)
+		// note: no V1 support
+	}
+	return mempool, err
+}
+
 func (s *PublicServer) apiFeeStats(r *http.Request, apiVersion int) (interface{}, error) {
 	var feeStats *api.FeeStats
 	var err error

--- a/server/public.go
+++ b/server/public.go
@@ -1117,8 +1117,11 @@ func (s *PublicServer) apiMempool(r *http.Request, apiVersion int) (interface{},
 		if ec != nil {
 			page = 0
 		}
-		// TODO: returns only TxIDs
-		mempool, err = s.api.GetMempool(page, txsInAPI)
+		fromTime, err := strconv.Atoi(r.URL.Path[i+1:])
+		if err != nil {
+			fromTime = 0
+		}
+		mempool, err = s.api.GetMempoolNew(uint32(fromTime), page, txsInAPI)
 		// note: no V1 support
 	}
 	return mempool, err

--- a/server/public.go
+++ b/server/public.go
@@ -184,6 +184,7 @@ func (s *PublicServer) ConnectFullPublicInterface() {
 	serveMux.HandleFunc(path+"api/v2/xpub/", s.jsonHandler(s.apiXpub, apiV2))
 	serveMux.HandleFunc(path+"api/v2/utxo/", s.jsonHandler(s.apiUtxo, apiV2))
 	serveMux.HandleFunc(path+"api/v2/block/", s.jsonHandler(s.apiBlock, apiV2))
+	serveMux.HandleFunc(path+"api/v2/mempool/", s.jsonHandler(s.apiMempool, apiV2))
 	serveMux.HandleFunc(path+"api/v2/sendtx/", s.jsonHandler(s.apiSendTx, apiV2))
 	serveMux.HandleFunc(path+"api/v2/estimatefee/", s.jsonHandler(s.apiEstimateFee, apiV2))
 	serveMux.HandleFunc(path+"api/v2/feestats/", s.jsonHandler(s.apiFeeStats, apiV2))

--- a/server/public.go
+++ b/server/public.go
@@ -1110,7 +1110,7 @@ func (s *PublicServer) apiBlock(r *http.Request, apiVersion int) (interface{}, e
 
 func (s *PublicServer) apiMempool(r *http.Request, apiVersion int) (interface{}, error) {
 	s.metrics.ExplorerViews.With(common.Labels{"action": "api-mempool"}).Inc()
-	var mempool *api.MempoolTxids
+	var mempool *api.MempoolTxs
 	var err error
 	if i := strings.LastIndexByte(r.URL.Path, '/'); i > 0 {
 		page, ec := strconv.Atoi(r.URL.Query().Get("page"))

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -887,6 +887,16 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 				`{"page":1,"totalPages":1,"itemsOnPage":1000,"hash":"0000000076fbbed90fd75b0e18856aa35baa984e9c9d444cf746ad85e94e2997","nextBlockHash":"00000000eb0443fd7dc4a1ed5c686a8e995057805f9a161d9a5a77a95e72b7b6","height":225493,"confirmations":2,"size":1234567,"time":1521515026,"version":0,"merkleRoot":"","nonce":"","bits":"","difficulty":"","txCount":2,"txs":[{"txid":"00b2c06055e5e90e9c82bd4181fde310104391a7fa4f289b1704e5d90caa3840","vin":[],"vout":[{"value":"100000000","n":0,"addresses":["mfcWp7DB6NuaZsExybTTXpVgWz559Np4Ti"],"isAddress":true},{"value":"12345","n":1,"spent":true,"addresses":["mtGXQvBowMkBpnhLckhxhbwYK44Gs9eEtz"],"isAddress":true},{"value":"12345","n":2,"addresses":["mtGXQvBowMkBpnhLckhxhbwYK44Gs9eEtz"],"isAddress":true}],"blockHash":"0000000076fbbed90fd75b0e18856aa35baa984e9c9d444cf746ad85e94e2997","blockHeight":225493,"confirmations":2,"blockTime":1521515026,"value":"100024690","valueIn":"0","fees":"0"},{"txid":"effd9ef509383d536b1c8af5bf434c8efbf521a4f2befd4022bbd68694b4ac75","vin":[],"vout":[{"value":"1234567890123","n":0,"spent":true,"addresses":["mv9uLThosiEnGRbVPS7Vhyw6VssbVRsiAw"],"isAddress":true},{"value":"1","n":1,"spent":true,"addresses":["2MzmAKayJmja784jyHvRUW1bXPget1csRRG"],"isAddress":true},{"value":"9876","n":2,"spent":true,"addresses":["2NEVv9LJmAnY99W1pFoc5UJjVdypBqdnvu1"],"isAddress":true}],"blockHash":"0000000076fbbed90fd75b0e18856aa35baa984e9c9d444cf746ad85e94e2997","blockHeight":225493,"confirmations":2,"blockTime":1521515026,"value":"1234567900000","valueIn":"0","fees":"0"}]}`,
 			},
 		},
+		{
+			// TODO: fill mempool with some test data
+			name:        "apiMempool",
+			r:           newGetRequest(ts.URL + "/api/v2/mempool/0"),
+			status:      http.StatusOK,
+			contentType: "application/json; charset=utf-8",
+			body: []string{
+				`{"page":1,"totalPages":1,"itemsOnPage":1000,"lastTime":0,"mempoolSize":0,"txCount":0}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Proposed implementation for mempool API, for retrieving mempool transactions, in one go, independent of affected addresses, filtered by time.  This allows periodic retrieval of new mempool transactions, to be able to notify users, in the usage case when a very large number of addresses are being watched.  Address-based watching is not feasible in this case, but full blocks are retrieved.  See issue #397 .
