### PR TITLE
New subscribeAnyAddress() method on websocket (issue #397)

### DIFF
--- a/server/public_test.go
+++ b/server/public_test.go
@@ -1421,6 +1421,20 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 			want: `{"id":"36","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","rates":{"eur":1301,"usd":2001}}]}`,
 		},
+		{
+			name: "websocket subscribeAnyAddresses",
+			req: websocketReq{
+				Method: "subscribeAnyAddresses",
+			},
+			want: `{"id":"37","data":{"subscribed":true}}`,
+		},
+		{
+			name: "websocket unsubscribeAnyAddresses",
+			req: websocketReq{
+				Method: "unsubscribeAnyAddresses",
+			},
+			want: `{"id":"38","data":{"subscribed":false}}`,
+		},
 	}
 
 	// send all requests at once

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -56,6 +56,7 @@
             subscriptions = {};
             subscribeNewBlockId = "";
             subscribeAddressesId = "";
+            subscribeAnyAddressesId = "";
             if (server.startsWith("http")) {
                 server = server.replace("http", "ws");
             }
@@ -296,6 +297,36 @@
                 document.getElementById('subscribeAddressesResult').innerText += JSON.stringify(result).replace(/,/g, ", ") + "\n";
                 document.getElementById('subscribeAddressesIds').innerText = "";
                 document.getElementById('unsubscribeAddressesButton').setAttribute("style", "display: none;");
+            });
+        }
+
+        function subscribeAnyAddresses() {
+            const method = 'subscribeAnyAddresses';
+            var addresses = document.getElementById('subscribeAnyAddressesName').value.split(",");
+            addresses = addresses.map(s => s.trim());
+            const params = {
+                addresses
+            };
+            if (subscribeAnyAddressesId) {
+                delete subscriptions[subscribeAnyAddressesId];
+                subscribeAnyAddressesId = "";
+            }
+            subscribeAnyAddressesId = subscribe(method, params, function (result) {
+                document.getElementById('subscribeAnyAddressesResult').innerText += JSON.stringify(result).replace(/,/g, ", ") + "\n";
+            });
+            document.getElementById('subscribeAnyAddressesIds').innerText = subscribeAnyAddressesId;
+            document.getElementById('unsubscribeAnyAddressesButton').setAttribute("style", "display: inherit;");
+        }
+
+        function unsubscribeAnyAddresses() {
+            const method = 'unsubscribeAnyAddresses';
+            const params = {
+            };
+            unsubscribe(method, subscribeAnyAddressesId, params, function (result) {
+                subscribeAnyAddressesId = "";
+                document.getElementById('subscribeAnyAddressesResult').innerText += JSON.stringify(result).replace(/,/g, ", ") + "\n";
+                document.getElementById('subscribeAnyAddressesIds').innerText = "";
+                document.getElementById('unsubscribeAnyAddressesButton').setAttribute("style", "display: none;");
             });
         }
 
@@ -601,6 +632,23 @@
         </div>
         <div class="row">
             <div class="col" id="subscribeAddressesResult"></div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <input class="btn btn-secondary" type="button" value="subscribe address" onclick="subscribeAnyAddresses()">
+            </div>
+            <div class="col-8">
+                <input type="text" class="form-control" id="subscribeAnyAddressesName" value="0xba98d6a5ac827632e3457de7512d211e4ff7e8bd,0x73d0385f4d8e00c5e6504c6030f47bf6212736a8">
+            </div>
+            <div class="col">
+                <span id="subscribeAnyAddressesIds"></span>
+            </div>
+            <div class="col">
+                <input class="btn btn-secondary" id="unsubscribeAnyAddressesButton" style="display: none;" type="button" value="unsubscribe" onclick="unsubscribeAnyAddresses()">
+            </div>
+        </div>
+        <div class="row">
+            <div class="col" id="subscribeAnyAddressesResult"></div>
         </div>
         <div class="row">
             <div class="col-3">


### PR DESCRIPTION
New subscribeAnyAddress() method on websocket.  With this it is possible to subscribe to any address.  A TX notification is sent to clients subscribed to that address, and/or to clients subscribed to any address.

This allows prompt notification of new mempool transactions for clients who need to observe a high number of addresses, whereby address-based watching is not feasible.

See issue #397 .