### PR TITLE
You have to link against libdl on Linux

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -218,7 +218,7 @@ Setup variables for gorocksdb: https://github.com/tecbot/gorocksdb
 
 ```
 export CGO_CFLAGS="-I/path/to/rocksdb/include"
-export CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
+export CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -ldl -lbz2 -lsnappy -llz4"
 ```
 
 Install ZeroMQ: https://github.com/zeromq/libzmq


### PR DESCRIPTION
Otherwise there will be linking error because rocksdb is importing ```dlclose```, ```dlopen``` and other functions from libdl.so.