### PR TITLE
[Zcash] Expose zcash consensus info 

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -424,18 +424,19 @@ type BlockbookInfo struct {
 
 // BackendInfo is used to get information about blockchain
 type BackendInfo struct {
-	BackendError    string  `json:"error,omitempty"`
-	Chain           string  `json:"chain,omitempty"`
-	Blocks          int     `json:"blocks,omitempty"`
-	Headers         int     `json:"headers,omitempty"`
-	BestBlockHash   string  `json:"bestBlockHash,omitempty"`
-	Difficulty      string  `json:"difficulty,omitempty"`
-	SizeOnDisk      int64   `json:"sizeOnDisk,omitempty"`
-	Version         string  `json:"version,omitempty"`
-	Subversion      string  `json:"subversion,omitempty"`
-	ProtocolVersion string  `json:"protocolVersion,omitempty"`
-	Timeoffset      float64 `json:"timeOffset,omitempty"`
-	Warnings        string  `json:"warnings,omitempty"`
+	BackendError    string      `json:"error,omitempty"`
+	Chain           string      `json:"chain,omitempty"`
+	Blocks          int         `json:"blocks,omitempty"`
+	Headers         int         `json:"headers,omitempty"`
+	BestBlockHash   string      `json:"bestBlockHash,omitempty"`
+	Difficulty      string      `json:"difficulty,omitempty"`
+	SizeOnDisk      int64       `json:"sizeOnDisk,omitempty"`
+	Version         string      `json:"version,omitempty"`
+	Subversion      string      `json:"subversion,omitempty"`
+	ProtocolVersion string      `json:"protocolVersion,omitempty"`
+	Timeoffset      float64     `json:"timeOffset,omitempty"`
+	Warnings        string      `json:"warnings,omitempty"`
+	Consensus       interface{} `json:"consensus,omitempty"`
 }
 
 // SystemInfo contains information about the running blockbook and backend instance

--- a/api/worker.go
+++ b/api/worker.go
@@ -1777,6 +1777,7 @@ func (w *Worker) GetSystemInfo(internal bool) (*SystemInfo, error) {
 		Timeoffset:      ci.Timeoffset,
 		Version:         ci.Version,
 		Warnings:        ci.Warnings,
+		Consensus:       ci.Consensus,
 	}
 	glog.Info("GetSystemInfo finished in ", time.Since(start))
 	return &SystemInfo{blockbookInfo, backendInfo}, nil

--- a/bchain/coins/zec/zcashrpc.go
+++ b/bchain/coins/zec/zcashrpc.go
@@ -7,11 +7,29 @@ import (
 	"github.com/juju/errors"
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/bchain/coins/btc"
+	"github.com/trezor/blockbook/common"
 )
 
 // ZCashRPC is an interface to JSON-RPC bitcoind service
 type ZCashRPC struct {
 	*btc.BitcoinRPC
+}
+
+type ResGetBlockChainInfo struct {
+	Error  *bchain.RPCError `json:"error"`
+	Result struct {
+		Chain         string            `json:"chain"`
+		Blocks        int               `json:"blocks"`
+		Headers       int               `json:"headers"`
+		Bestblockhash string            `json:"bestblockhash"`
+		Difficulty    common.JSONNumber `json:"difficulty"`
+		Pruned        bool              `json:"pruned"`
+		SizeOnDisk    int64             `json:"size_on_disk"`
+		Consensus     struct {
+			Chaintip  string `json:"chaintip"`
+			Nextblock string `json:"nextblock"`
+		} `json:"consensus"`
+	} `json:"result"`
 }
 
 // NewZCashRPC returns new ZCashRPC instance
@@ -52,6 +70,40 @@ func (z *ZCashRPC) Initialize() error {
 	glog.Info("rpc: block chain ", params.Name)
 
 	return nil
+}
+
+func (z *ZCashRPC) GetChainInfo() (*bchain.ChainInfo, error) {
+	chainInfo := ResGetBlockChainInfo{}
+	err := z.Call(&btc.CmdGetBlockChainInfo{Method: "getblockchaininfo"}, &chainInfo)
+	if err != nil {
+		return nil, err
+	}
+	if chainInfo.Error != nil {
+		return nil, chainInfo.Error
+	}
+
+	networkInfo := btc.ResGetNetworkInfo{}
+	err = z.Call(&btc.CmdGetNetworkInfo{Method: "getnetworkinfo"}, &networkInfo)
+	if err != nil {
+		return nil, err
+	}
+	if networkInfo.Error != nil {
+		return nil, networkInfo.Error
+	}
+
+	return &bchain.ChainInfo{
+		Bestblockhash:   chainInfo.Result.Bestblockhash,
+		Blocks:          chainInfo.Result.Blocks,
+		Chain:           chainInfo.Result.Chain,
+		Difficulty:      string(chainInfo.Result.Difficulty),
+		Headers:         chainInfo.Result.Headers,
+		SizeOnDisk:      chainInfo.Result.SizeOnDisk,
+		Version:         string(networkInfo.Result.Version),
+		Subversion:      string(networkInfo.Result.Subversion),
+		ProtocolVersion: string(networkInfo.Result.ProtocolVersion),
+		Timeoffset:      networkInfo.Result.Timeoffset,
+		Consensus:       chainInfo.Result.Consensus,
+	}, nil
 }
 
 // GetBlock returns block with given hash.

--- a/bchain/coins/zec/zcashrpc.go
+++ b/bchain/coins/zec/zcashrpc.go
@@ -103,6 +103,7 @@ func (z *ZCashRPC) GetChainInfo() (*bchain.ChainInfo, error) {
 		ProtocolVersion: string(networkInfo.Result.ProtocolVersion),
 		Timeoffset:      networkInfo.Result.Timeoffset,
 		Consensus:       chainInfo.Result.Consensus,
+		Warnings:        networkInfo.Result.Warnings,
 	}, nil
 }
 

--- a/bchain/types.go
+++ b/bchain/types.go
@@ -161,17 +161,18 @@ type MempoolEntry struct {
 
 // ChainInfo is used to get information about blockchain
 type ChainInfo struct {
-	Chain           string  `json:"chain"`
-	Blocks          int     `json:"blocks"`
-	Headers         int     `json:"headers"`
-	Bestblockhash   string  `json:"bestblockhash"`
-	Difficulty      string  `json:"difficulty"`
-	SizeOnDisk      int64   `json:"size_on_disk"`
-	Version         string  `json:"version"`
-	Subversion      string  `json:"subversion"`
-	ProtocolVersion string  `json:"protocolversion"`
-	Timeoffset      float64 `json:"timeoffset"`
-	Warnings        string  `json:"warnings"`
+	Chain           string      `json:"chain"`
+	Blocks          int         `json:"blocks"`
+	Headers         int         `json:"headers"`
+	Bestblockhash   string      `json:"bestblockhash"`
+	Difficulty      string      `json:"difficulty"`
+	SizeOnDisk      int64       `json:"size_on_disk"`
+	Version         string      `json:"version"`
+	Subversion      string      `json:"subversion"`
+	ProtocolVersion string      `json:"protocolversion"`
+	Timeoffset      float64     `json:"timeoffset"`
+	Warnings        string      `json:"warnings"`
+	Consensus       interface{} `json:"consensus,omitempty"`
 }
 
 // RPCError defines rpc error returned by backend


### PR DESCRIPTION
Zcash network upgrade usually introduces consensus branch ID change (e.g. Canopy upgrade: https://zips.z.cash/zip-0251), it would be very nice that we could check this in api, here is an example response: 

```
{
  "blockbook": {
    "coin": "Zcash",
    "host": "6ed22437e533",
    "version": "unknown",
    "gitCommit": "unknown",
    "buildTime": "unknown",
    "syncMode": false,
    "initialSync": false,
    "inSync": false,
    "bestHeight": 0,
    "lastBlockTime": "0001-01-01T00:00:00Z",
    "inSyncMempool": false,
    "lastMempoolTime": "0001-01-01T00:00:00Z",
    "mempoolSize": 0,
    "decimals": 8,
    "dbSize": 8921706,
    "about": "Blockbook - blockchain indexer for Trezor wallet https://trezor.io/. Do not use for any other purpose."
  },
  "backend": {
    "chain": "regtest",
    "bestBlockHash": "029f11d80ef9765602235e1bc9727e3eb6ba20839319f761fee920d63401e327",
    "difficulty": "1",
    "sizeOnDisk": 390,
    "version": "4000050",
    "subversion": "/MagicBean:4.0.0/",
    "protocolVersion": "170013",
    "consensus": {
      "chaintip": "00000000",
      "nextblock": "00000000"
    }
  }
}
```

Changes: 

- Add `Consensus interface{}` to `BackendInfo` and `bchain.ChainInfo`, `consensus` is a very common variable name, so its type is defined as `interface{}`
- Implement `GetChainInfo` for `ZCashRPC`