### PR TITLE
bch(+testnet): 0.22.0 -> 0.22.6 (switch to BCHN)

### DIFF
--- a/configs/coins/bcash.json
+++ b/configs/coins/bcash.json
@@ -22,10 +22,10 @@
     "package_name": "backend-bcash",
     "package_revision": "satoshilabs-1",
     "system_user": "bcash",
-    "version": "0.22.0",
-    "binary_url": "https://download.bitcoinabc.org/0.22.0/linux/bitcoin-abc-0.22.0-x86_64-linux-gnu.tar.gz",
+    "version": "0.22.6",
+    "binary_url": "https://download.bitcoinabc.org/bchn/0.22.6/linux/bitcoin-abc-0.22.6-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "9d3718cbaf0516cc1e2bff40bd9ff708e61b6ed2469afb18e87e9fc1de3c4d5c",
+    "verification_source": "5ca44134bfada01530aa7e7ba17dda2a946f417d9be1114473dd9c63f41d6b78",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/bitcoin-qt"
@@ -49,7 +49,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Bitcoin ABC:0.22.0/",
+      "subversion": "/Bitcoin ABC:0.22.6/",
       "address_format": "cashaddr",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,

--- a/configs/coins/bcash_testnet.json
+++ b/configs/coins/bcash_testnet.json
@@ -22,10 +22,10 @@
     "package_name": "backend-bcash-testnet",
     "package_revision": "satoshilabs-1",
     "system_user": "bcash",
-    "version": "0.22.0",
-    "binary_url": "https://download.bitcoinabc.org/0.22.0/linux/bitcoin-abc-0.22.0-x86_64-linux-gnu.tar.gz",
+    "version": "0.22.6",
+    "binary_url": "https://download.bitcoinabc.org/bchn/0.22.6/linux/bitcoin-abc-0.22.6-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "9d3718cbaf0516cc1e2bff40bd9ff708e61b6ed2469afb18e87e9fc1de3c4d5c",
+    "verification_source": "5ca44134bfada01530aa7e7ba17dda2a946f417d9be1114473dd9c63f41d6b78",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/bitcoin-qt"
@@ -49,7 +49,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Bitcoin ABC:0.22.0/",
+      "subversion": "/Bitcoin ABC:0.22.6/",
       "address_format": "cashaddr",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,


### PR DESCRIPTION
It seems that according to https://cash.coin.dance/ BCHN network is winning over BCHA network.

Let's follow the development and if the trend stays the same, we'll merge this and deploy to our servers.