### PR TITLE
bch(+testnet): 0.22.6 -> 22.1.0 (switch to Bitcoin Cash Node)

### DIFF
--- a/configs/coins/bcash.json
+++ b/configs/coins/bcash.json
@@ -22,10 +22,10 @@
     "package_name": "backend-bcash",
     "package_revision": "satoshilabs-1",
     "system_user": "bcash",
-    "version": "0.22.6",
-    "binary_url": "https://download.bitcoinabc.org/bchn/0.22.6/linux/bitcoin-abc-0.22.6-x86_64-linux-gnu.tar.gz",
+    "version": "22.1.0",
+    "binary_url": "https://github.com/bitcoin-cash-node/bitcoin-cash-node/releases/download/v22.1.0/bitcoin-cash-node-22.1.0-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "5ca44134bfada01530aa7e7ba17dda2a946f417d9be1114473dd9c63f41d6b78",
+    "verification_source": "aa1002d51833b0de44084bde09951223be4f9c455427aef277f91dacd2f0f657",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/bitcoin-qt"
@@ -49,7 +49,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Bitcoin ABC:0.22.6/",
+      "subversion": "/Bitcoin ABC Cash Node:22.1.0/",
       "address_format": "cashaddr",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,

--- a/configs/coins/bcash_testnet.json
+++ b/configs/coins/bcash_testnet.json
@@ -22,10 +22,10 @@
     "package_name": "backend-bcash-testnet",
     "package_revision": "satoshilabs-1",
     "system_user": "bcash",
-    "version": "0.22.6",
-    "binary_url": "https://download.bitcoinabc.org/bchn/0.22.6/linux/bitcoin-abc-0.22.6-x86_64-linux-gnu.tar.gz",
+    "version": "22.1.0",
+    "binary_url": "https://github.com/bitcoin-cash-node/bitcoin-cash-node/releases/download/v22.1.0/bitcoin-cash-node-22.1.0-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "5ca44134bfada01530aa7e7ba17dda2a946f417d9be1114473dd9c63f41d6b78",
+    "verification_source": "aa1002d51833b0de44084bde09951223be4f9c455427aef277f91dacd2f0f657",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/bitcoin-qt"
@@ -49,7 +49,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Bitcoin ABC:0.22.6/",
+      "subversion": "/Bitcoin ABC Cash Node:22.1.0/",
       "address_format": "cashaddr",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,


### PR DESCRIPTION
Switch from Bitcoin ABC to Bitcoin Cash Node