### PR TITLE
Add BASE_IMAGE and TCMALLOC options to the build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BIN_IMAGE = blockbook-build
 DEB_IMAGE = blockbook-build-deb
 PACKAGER = $(shell id -u):$(shell id -g)
 NO_CACHE = false
+TCMALLOC = 
 ARGS ?=
 
 TARGETS=$(subst .json,, $(shell ls configs/coins))
@@ -44,7 +45,7 @@ build-images: clean-images
 .bin-image:
 	@if [ $$(build/tools/image_status.sh $(BIN_IMAGE):latest build/docker) != "ok" ]; then \
 		echo "Building image $(BIN_IMAGE)..."; \
-		docker build --no-cache=$(NO_CACHE) -t $(BIN_IMAGE) build/docker/bin; \
+		docker build --no-cache=$(NO_CACHE) --build-arg TCMALLOC=$(TCMALLOC) -t $(BIN_IMAGE) build/docker/bin; \
 	else \
 		echo "Image $(BIN_IMAGE) is up to date"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BIN_IMAGE = blockbook-build
 DEB_IMAGE = blockbook-build-deb
 PACKAGER = $(shell id -u):$(shell id -g)
+BASE_IMAGE = $$(awk -F= '$$1=="ID" { print $$2 ;}' /etc/os-release):$$(awk -F= '$$1=="VERSION_ID" { print $$2 ;}' /etc/os-release | tr -d '"')
 NO_CACHE = false
 TCMALLOC = 
 ARGS ?=
@@ -44,8 +45,8 @@ build-images: clean-images
 
 .bin-image:
 	@if [ $$(build/tools/image_status.sh $(BIN_IMAGE):latest build/docker) != "ok" ]; then \
-		echo "Building image $(BIN_IMAGE)..."; \
-		docker build --no-cache=$(NO_CACHE) --build-arg TCMALLOC=$(TCMALLOC) -t $(BIN_IMAGE) build/docker/bin; \
+		echo "Building image $(BIN_IMAGE) from $(BASE_IMAGE)"; \
+		docker build --no-cache=$(NO_CACHE) --build-arg TCMALLOC=$(TCMALLOC) --build-arg BASE_IMAGE=$(BASE_IMAGE) -t $(BIN_IMAGE) build/docker/bin; \
 	else \
 		echo "Image $(BIN_IMAGE) is up to date"; \
 	fi

--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -15,8 +15,15 @@ ENV GOPATH=/go
 ENV PATH=$PATH:$GOPATH/bin
 ENV CGO_CFLAGS="-I/opt/rocksdb/include"
 ENV CGO_LDFLAGS="-L/opt/rocksdb -ldl -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
+ARG TCMALLOC
 
 RUN mkdir /build
+
+RUN if [ -n "${TCMALLOC}" ]; then \
+    echo "Using TCMALLOC"; \
+    apt-get install -y google-perftools; \
+    ln -s /usr/lib/libtcmalloc.so.4 /usr/lib/libtcmalloc.so;\
+fi
 
 # install and configure go
 RUN cd /opt && wget https://dl.google.com/go/$GOLANG_VERSION.tar.gz && \

--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -1,6 +1,6 @@
-# initialize from the image
-
-FROM debian:9
+# initialize from the image defined by BASE_IMAGE
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/docs/build.md
+++ b/docs/build.md
@@ -43,10 +43,10 @@ mandatory, of course.
 > back-end configuration and Blockbook configuration as well. There were many options that were duplicated across
 > configuration files and therefore error prone.
 >
-> Actually all configuration options and also build options for both Blockbook and back-end are defined in single JSON
+> Now, all configuration options and also build options for both Blockbook and back-end are defined in single JSON
 > file and all stuff required during build is generated dynamically.
 
-Makefile targets follow simple pattern, there are few prefixes that define what to build.
+Makefile targets follow simple pattern, there are a few prefixes that define what to build.
 
 * *deb-blockbook-&lt;coin&gt;* – Build Blockbook package for given coin.
 
@@ -59,39 +59,34 @@ Makefile targets follow simple pattern, there are few prefixes that define what 
 
 * *all* – Build both Blockbook and back-end packages for all coins.
 
-Which coins are possible to build is defined in *configs/coins*. Particular coin has to have JSON config file there.
+Which coins are possible to build is defined in *configs/coins*. Each coin has to have JSON config file there.
 
 For example we want to build some packages for Bitcoin and Bitcoin Testnet.
 
 ```bash
-# make all-bitcoin deb-backend-bitcoin_testnet
+# make all-bitcoin deb-blockbook-bitcoin_testnet
 ...
 # ls build/*.deb
-build/backend-bitcoin_0.16.1-satoshilabs-1_amd64.deb  build/backend-bitcoin-testnet_0.16.1-satoshilabs-1_amd64.deb  build/blockbook-bitcoin_0.0.6_amd64.deb
+build/backend-bitcoin_0.21.0-satoshilabs-1_amd64.deb  build/blockbook-bitcoin_0.3.5_amd64.deb  build/blockbook-bitcoin-testnet_0.3.5_amd64.deb
 ```
 
-We have built two back-end packages – for Bitcoin and Testnet – and Blockbook package for Bitcoin. Before build have
-been performed there was cleaned build directory and rebuilt Docker image.
+We have built one back-end package, for Bitcoin, and two Blockbook packages, for Bitcoin and Bitcoin Testnet. The `all-bitcoin` initially cleaned the build directory and rebuilt the Docker build image.
 
 ### Extra variables
 
-There are few variables that can be passed to make in order to modify build process.
+There are few variables that can be passed to `make` in order to modify build process:
 
-In general, build of Blockbook binary require some dependencies. They are downloaded automatically during build process
-but if you need to build binary repeatedly it consumes a lot of time. Here comes variable *UPDATE_VENDOR* that if is
-unset says that build process uses *vendor* (i.e. dependencies) from your local repository. For example:
-`make deb-bitcoin UPDATE_VENDOR=0`. But before the command is executed there must be *vendor* directory populated,
-you can do it by calling `go mod vendor`. See [Manual build](#manual-build) instructions below.
+`BASE_IMAGE`: Specifies the base image of the Docker build image. By default, it chooses the same Linux distro as the host machine but you can override it this way `make BASE_IMAGE=debian:10 all-bitcoin` to make a build for Debian 10.
 
-All build targets allow pass additional parameters to underlying command inside container. It is possible via ARGS
-variable. For example if you want run only subset of unit-tests, you will perform it by calling:
-`make test ARGS='-run TestBitcoinRPC' UPDATE_VENDOR=0`
+*Please be aware that we are running our Blockbooks on Debian 9 and Debian 10 and do not offer support with running it on other distros.*
 
-Common behaviour of Docker image build is that build steps are cached and next time they are executed much faster.
+`NO_CACHE`: Common behaviour of Docker image build is that build steps are cached and next time they are executed much faster.
 Although this is a good idea, when something went wrong you will need to override this behaviour somehow. Execute this
-command: `make build-images NO_CACHE=true`.
+command: `make NO_CACHE=true all-bitcoin`.
 
-### On naming conventions and versioning
+`TCMALLOC`: RocksDB, the storage engine used by Blockbook, allows to use alternative memory allocators. Use the `TCMALLOC` variable to specify Google's TCMalloc allocator `make TCMALLOC=true all-bitcoin`. To run Blockbook built with TCMalloc, the library must be installed on the target server, for example by `sudo apt-get install google-perftools`.
+
+### Naming conventions and versioning
 
 All configuration keys described below are in coin definition file in *configs/coins*.
 
@@ -138,7 +133,7 @@ and revision both defined in coin definition file in *backend.version* and *back
 
 Blockbook versioning is much simpler. There is only one version defined in *configs/environ.json*.
 
-### On back-end building
+### Back-end building
 
 Because we don't keep back-end archives inside out repository we download them during build process. Build steps
 are these: download, verify and extract archive, prepare distribution and make package.
@@ -268,4 +263,4 @@ Blockbook logs to stderr (option *-logtostderr*) or to directory specified by pa
 by command line parameters *-v* and *-vmodule*, for details see https://godoc.org/github.com/golang/glog.
 
 You can check that Blockbook is running by simple HTTP request: `curl https://localhost:9130`. Returned data is JSON with some
-run-time information. If port is closed, Blockbook is syncing data.
+run-time information. If the port is closed, Blockbook is syncing data.


### PR DESCRIPTION
1) add a possibility to specify a base image of the build image to be able to build for different distributions than Debian 9
2) add a possibility to use TcMalloc memory allocator for RocksDB