### PR TITLE
Ubuntu 20.04 doesn't work without this patch

### DIFF
--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -1,6 +1,7 @@
 # initialize from the image defined by BASE_IMAGE
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
The problem was described here:

https://github.com/trezor/blockbook/issues/568