### PR TITLE
Websocket new transaction

### DIFF
--- a/blockbook.go
+++ b/blockbook.go
@@ -73,6 +73,8 @@ var (
 
 	noTxCache = flag.Bool("notxcache", false, "disable tx cache")
 
+	enableSubNewTx = flag.Bool("enablesubnewtx", false, "enable support for subscribing to all new transactions")
+
 	computeColumnStats  = flag.Bool("computedbstats", false, "compute column stats and exit")
 	computeFeeStatsFlag = flag.Bool("computefeestats", false, "compute fee stats for blocks in blockheight-blockuntil range and exit")
 	dbStatsPeriodHours  = flag.Int("dbstatsperiod", 24, "period of db stats collection in hours, 0 disables stats collection")
@@ -405,7 +407,7 @@ func startInternalServer() (*server.InternalServer, error) {
 
 func startPublicServer() (*server.PublicServer, error) {
 	// start public server in limited functionality, extend it after sync is finished by calling ConnectFullPublicInterface
-	publicServer, err := server.NewPublicServer(*publicBinding, *certFiles, index, chain, mempool, txCache, *explorerURL, metrics, internalState, *debugMode)
+	publicServer, err := server.NewPublicServer(*publicBinding, *certFiles, index, chain, mempool, txCache, *explorerURL, metrics, internalState, *debugMode, *enableSubNewTx)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -764,9 +764,10 @@ The websocket interface provides the following requests:
 
 The client can subscribe to the following events:
 
-- `subscribeNewBlock` - new block added to blockchain
-- `subscribeAddresses` - new transaction for given address (list of addresses)
-- `subscribeFiatRates` - new currency rate ticker
+- `subscribeNewBlock`       - new block added to blockchain
+- `subscribeNewTransaction` - new transaction added to blockchain (mempool for all addresses)
+- `subscribeAddresses`      - new transaction for given address (list of addresses)
+- `subscribeFiatRates`      - new currency rate ticker
 
 There can be always only one subscription of given event per connection, i.e. new list of addresses replaces previous list of addresses.
 
@@ -791,5 +792,3 @@ Example for subscribing to an address (or multiple addresses)
    }
 }
 ```
-
-

--- a/docs/api.md
+++ b/docs/api.md
@@ -765,7 +765,7 @@ The websocket interface provides the following requests:
 The client can subscribe to the following events:
 
 - `subscribeNewBlock`       - new block added to blockchain
-- `subscribeNewTransaction` - new transaction added to blockchain (mempool for all addresses)
+- `subscribeNewTransaction` - new transaction added to blockchain (all addresses)
 - `subscribeAddresses`      - new transaction for given address (list of addresses)
 - `subscribeFiatRates`      - new currency rate ticker
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -771,6 +771,8 @@ The client can subscribe to the following events:
 
 There can be always only one subscription of given event per connection, i.e. new list of addresses replaces previous list of addresses.
 
+The subscribeNewTransaction event is not enabled by default. To enable support, blockbook must be run with the `-enablesubnewtx` flag.
+
 _Note: If there is reorg on the backend (blockchain), you will get a new block hash with the same or even smaller height if the reorg is deeper_
 
 Websocket communication format

--- a/server/public.go
+++ b/server/public.go
@@ -58,7 +58,7 @@ type PublicServer struct {
 
 // NewPublicServer creates new public server http interface to blockbook and returns its handle
 // only basic functionality is mapped, to map all functions, call
-func NewPublicServer(binding string, certFiles string, db *db.RocksDB, chain bchain.BlockChain, mempool bchain.Mempool, txCache *db.TxCache, explorerURL string, metrics *common.Metrics, is *common.InternalState, debugMode bool) (*PublicServer, error) {
+func NewPublicServer(binding string, certFiles string, db *db.RocksDB, chain bchain.BlockChain, mempool bchain.Mempool, txCache *db.TxCache, explorerURL string, metrics *common.Metrics, is *common.InternalState, debugMode bool, enableSubNewTx bool) (*PublicServer, error) {
 
 	api, err := api.NewWorker(db, chain, mempool, txCache, is)
 	if err != nil {
@@ -70,7 +70,7 @@ func NewPublicServer(binding string, certFiles string, db *db.RocksDB, chain bch
 		return nil, err
 	}
 
-	websocket, err := NewWebsocketServer(db, chain, mempool, txCache, metrics, is)
+	websocket, err := NewWebsocketServer(db, chain, mempool, txCache, metrics, is, enableSubNewTx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -109,7 +109,7 @@ func setupPublicHTTPServer(t *testing.T) (*PublicServer, string) {
 	}
 
 	// s.Run is never called, binding can be to any port
-	s, err := NewPublicServer("localhost:12345", "", d, chain, mempool, txCache, "", metrics, is, false)
+	s, err := NewPublicServer("localhost:12345", "", d, chain, mempool, txCache, "", metrics, is, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1426,14 +1426,14 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			req: websocketReq{
 				Method: "subscribeNewTransaction",
 			},
-			want: `{"id":"37","data":{"subscribed":true}}`,
+			want: `{"id":"37","data":{"subscribed":false,"message":"subscribeNewTransaction not enabled, use -enablesubnewtx flag to enable."}}`,
 		},
 		{
 			name: "websocket unsubscribeNewTransaction",
 			req: websocketReq{
 				Method: "unsubscribeNewTransaction",
 			},
-			want: `{"id":"38","data":{"subscribed":false}}`,
+			want: `{"id":"38","data":{"subscribed":false,"message":"unsubscribeNewTransaction not enabled, use -enablesubnewtx flag to enable."}}`,
 		},
 	}
 

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -1421,6 +1421,20 @@ func websocketTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 			want: `{"id":"36","data":[{"time":1521514800,"txs":1,"received":"1","sent":"0","sentToSelf":"0","rates":{"eur":1301,"usd":2001}}]}`,
 		},
+		{
+			name: "websocket subscribeNewTransaction",
+			req: websocketReq{
+				Method: "subscribeNewTransaction",
+			},
+			want: `{"id":"37","data":{"subscribed":true}}`,
+		},
+		{
+			name: "websocket unsubscribeNewTransaction",
+			req: websocketReq{
+				Method: "unsubscribeNewTransaction",
+			},
+			want: `{"id":"38","data":{"subscribed":false}}`,
+		},
 	}
 
 	// send all requests at once

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -246,6 +246,7 @@ func (s *WebsocketServer) onConnect(c *websocketChannel) {
 
 func (s *WebsocketServer) onDisconnect(c *websocketChannel) {
 	s.unsubscribeNewBlock(c)
+	s.unsubscribeNewTransaction(c)
 	s.unsubscribeAddresses(c)
 	s.unsubscribeFiatRates(c)
 	glog.Info("Client disconnected ", c.id, ", ", c.ip)
@@ -684,7 +685,6 @@ func (s *WebsocketServer) unsubscribeNewBlock(c *websocketChannel) (res interfac
 func (s *WebsocketServer) subscribeNewTransaction(c *websocketChannel, req *websocketReq) (res interface{}, err error) {
 	s.newTransactionSubscriptionsLock.Lock()
 	defer s.newTransactionSubscriptionsLock.Unlock()
-	glog.Infof("subscribeNewTransaction: %+v\n%v\n", c, req.ID)
 	s.newTransactionSubscriptions[c] = req.ID
 	return &subscriptionResponse{true}, nil
 }
@@ -692,7 +692,6 @@ func (s *WebsocketServer) subscribeNewTransaction(c *websocketChannel, req *webs
 func (s *WebsocketServer) unsubscribeNewTransaction(c *websocketChannel) (res interface{}, err error) {
 	s.newTransactionSubscriptionsLock.Lock()
 	defer s.newTransactionSubscriptionsLock.Unlock()
-	glog.Infof("unsubscribeNewTransaction: %+v\n", c)
 	delete(s.newTransactionSubscriptions, c)
 	return &subscriptionResponse{false}, nil
 }

--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -55,6 +55,7 @@
             pendingMessages = {};
             subscriptions = {};
             subscribeNewBlockId = "";
+            subscribeNewTransactionId = "";
             subscribeAddressesId = "";
             if (server.startsWith("http")) {
                 server = server.replace("http", "ws");
@@ -266,6 +267,33 @@
                 document.getElementById('subscribeNewBlockResult').innerText += JSON.stringify(result).replace(/,/g, ", ") + "\n";
                 document.getElementById('subscribeNewBlockId').innerText = "";
                 document.getElementById('unsubscribeNewBlockButton').setAttribute("style", "display: none;");
+            });
+        }
+
+        function subscribeNewTransaction() {
+            const method = 'subscribeNewTransaction';
+            const params = {
+            };
+            if (subscribeNewTransactionId) {
+                delete subscriptions[subscribeNewTransactionId];
+                subscribeNewTransactionId = "";
+            }
+            subscribeNewTransactionId = subscribe(method, params, function (result) {
+                document.getElementById('subscribeNewTransactionResult').innerText += JSON.stringify(result).replace(/,/g, ", ") + "\n";
+            });
+            document.getElementById('subscribeNewTransactionId').innerText = subscribeNewTransactionId;
+            document.getElementById('unsubscribeNewTransactionButton').setAttribute("style", "display: inherit;");
+        }
+
+        function unsubscribeNewTransaction() {
+            const method = 'unsubscribeNewTransaction';
+            const params = {
+            };
+            unsubscribe(method, subscribeNewTransactionId, params, function (result) {
+                subscribeNewTransactionId = "";
+                document.getElementById('subscribeNewTransactionResult').innerText += JSON.stringify(result).replace(/,/g, ", ") + "\n";
+                document.getElementById('subscribeNewTransactionId').innerText = "";
+                document.getElementById('unsubscribeNewTransactionButton').setAttribute("style", "display: none;");
             });
         }
 
@@ -584,6 +612,20 @@
         </div>
         <div class="row">
             <div class="col" id="subscribeNewBlockResult"></div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <input class="btn btn-secondary" type="button" value="subscribe new transaction" onclick="subscribeNewTransaction()">
+            </div>
+            <div class="col-4">
+                <span id="subscribeNewTransactionId"></span>
+            </div>
+            <div class="col">
+                <input class="btn btn-secondary" id="unsubscribeNewTransactionButton" style="display: none;" type="button" value="unsubscribe" onclick="unsubscribeNewTransaction()">
+            </div>
+        </div>
+        <div class="row">
+            <div class="col" id="subscribeNewTransactionResult"></div>
         </div>
         <div class="row">
             <div class="col">


### PR DESCRIPTION
Add functionality to subscribe to all new pending transactions. This will allow the flexibility to either filter by address as already existed or receive all messages published to mempool depending on the use case.

Documentation and tests have been updated to reflect the new subscription.

The other option I thought about was passing a `*` wildcard string to the `subscribeNewAddresses` endpoint which would inform the filter to return all transactions, but adding a new endpoint to handle this case separately made more sense to me and felt cleaner.

Let me know your thoughts on this feature update. Thank you!