### PR TITLE
fix: litecoin aka ltc and litecoin testnet aka tltc rpc port config update. closes #488 and partially fixes #433.

### DIFF
--- a/configs/coins/litecoin.json
+++ b/configs/coins/litecoin.json
@@ -37,8 +37,8 @@
     "service_additional_params_template": "",
     "protect_memory": true,
     "mainnet": true,
-    "server_config_file": "bitcoin_like.conf",
-    "client_config_file": "bitcoin_like_client.conf",
+    "server_config_file": "bitcoin.conf",
+    "client_config_file": "bitcoin_client.conf",
     "additional_params": {
       "whitelist": "127.0.0.1"
     }

--- a/configs/coins/litecoin_testnet.json
+++ b/configs/coins/litecoin_testnet.json
@@ -37,8 +37,8 @@
     "service_additional_params_template": "",
     "protect_memory": true,
     "mainnet": false,
-    "server_config_file": "bitcoin_like.conf",
-    "client_config_file": "bitcoin_like_client.conf",
+    "server_config_file": "bitcoin.conf",
+    "client_config_file": "bitcoin_client.conf",
     "additional_params": {
       "whitelist": "127.0.0.1"
     }


### PR DESCRIPTION
this fixes #488 that describes the issue well.

this partially fixes #433 as it only addresses litecoin and litecoin testnet.
