### PR TITLE
Fixing the name of the Bitcoin Gold Testnet

### DIFF
--- a/configs/coins/bgold_testnet.json
+++ b/configs/coins/bgold_testnet.json
@@ -1,6 +1,6 @@
 {
     "coin": {
-      "name": "Bgold-Testnet",
+      "name": "Bgold Testnet",
       "shortcut": "TBTG",
       "label": "Bitcoin Gold Testnet",
       "alias": "bgold_testnet"


### PR DESCRIPTION
The name should not have `-` symbol separating the words Bgold and Testnet