### PR TITLE
[Dash] Enable estimatesmartfee

### DIFF
--- a/bchain/coins/dash/dashrpc.go
+++ b/bchain/coins/dash/dashrpc.go
@@ -27,7 +27,6 @@ func NewDashRPC(config json.RawMessage, pushHandler func(bchain.NotificationType
 		b.(*btc.BitcoinRPC),
 	}
 	s.RPCMarshaler = btc.JSONMarshalerV1{}
-	s.ChainConfig.SupportsEstimateSmartFee = false
 
 	return s, nil
 }

--- a/configs/coins/dash.json
+++ b/configs/coins/dash.json
@@ -22,10 +22,10 @@
     "package_name": "backend-dash",
     "package_revision": "satoshilabs-1",
     "system_user": "dash",
-    "version": "0.16.0.1",
-    "binary_url": "https://github.com/dashpay/dash/releases/download/v0.16.0.1/dashcore-0.16.0.1-x86_64-linux-gnu.tar.gz",
+    "version": "0.17.0.3",
+    "binary_url": "https://github.com/dashpay/dash/releases/download/v0.17.0.3/dashcore-0.17.0.3-x86_64-linux-gnu.tar.gz",
     "verification_type": "gpg-sha256",
-    "verification_source": "https://github.com/dashpay/dash/releases/download/v0.16.0.1/SHA256SUMS.asc",
+    "verification_source": "https://github.com/dashpay/dash/releases/download/v0.17.0.3/SHA256SUMS.asc",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/dash-qt"
@@ -52,7 +52,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Dash Core:0.14.0.5/",
+      "subversion": "/Dash Core:0.17.0.3/",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,
       "block_addresses_to_keep": 300,

--- a/configs/coins/dash_testnet.json
+++ b/configs/coins/dash_testnet.json
@@ -22,10 +22,10 @@
     "package_name": "backend-dash-testnet",
     "package_revision": "satoshilabs-1",
     "system_user": "dash",
-    "version": "0.16.0.1",
-    "binary_url": "https://github.com/dashpay/dash/releases/download/v0.16.0.1/dashcore-0.16.0.1-x86_64-linux-gnu.tar.gz",
+    "version": "0.17.0.3",
+    "binary_url": "https://github.com/dashpay/dash/releases/download/v0.17.0.3/dashcore-0.17.0.3-x86_64-linux-gnu.tar.gz",
     "verification_type": "gpg-sha256",
-    "verification_source": "https://github.com/dashpay/dash/releases/download/v0.16.0.1/SHA256SUMS.asc",
+    "verification_source": "https://github.com/dashpay/dash/releases/download/v0.17.0.3/SHA256SUMS.asc",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/dash-qt"
@@ -52,7 +52,7 @@
     "additional_params": "",
     "block_chain": {
       "parse": true,
-      "subversion": "/Dash Core:0.14.0.5/",
+      "subversion": "/Dash Core:0.17.0.3/",
       "mempool_workers": 8,
       "mempool_sub_workers": 2,
       "block_addresses_to_keep": 300,

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -49,12 +49,12 @@
     },
     "dash": {
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
-                "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
+                "EstimateSmartFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
     },
     "dash_testnet": {
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
-                "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
+                "EstimateSmartFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
     },
     "decred": {


### PR DESCRIPTION
Trying to fix https://github.com/trezor/blockbook/issues/621:
- Upgrade Dash core to v0.17.0.3
- Remove `SupportsEstimateSmartFee` override