### PR TITLE
Correct btc regtest logfolder

### DIFF
--- a/configs/coins/bitcoin_regtest.json
+++ b/configs/coins/bitcoin_regtest.json
@@ -31,7 +31,7 @@
       "bin/bitcoin-qt"
     ],
     "exec_command_template": "{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/bin/bitcoind -datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend -conf={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/{{.Coin.Alias}}.conf -pid=/run/{{.Coin.Alias}}/{{.Coin.Alias}}.pid",
-    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/regtest3/*.log",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/regtest/*.log",
     "postinst_script_template": "",
     "service_type": "forking",
     "service_additional_params_template": "",


### PR DESCRIPTION
I assume it was copied from testnet template which uses testnet3. There is no such thing as regtest3.