### PR TITLE
Handle Fujicoin vout addresses after upgrade to fujicoind 22.0

### DIFF
--- a/bchain/coins/fujicoin/fujicoinparser.go
+++ b/bchain/coins/fujicoin/fujicoinparser.go
@@ -38,12 +38,12 @@ func init() {
 
 // FujicoinParser handle
 type FujicoinParser struct {
-	*btc.BitcoinLikeParser
+	*btc.BitcoinParser
 }
 
 // NewFujicoinParser returns new FujicoinParser instance
 func NewFujicoinParser(params *chaincfg.Params, c *btc.Configuration) *FujicoinParser {
-	return &FujicoinParser{BitcoinLikeParser: btc.NewBitcoinLikeParser(params, c)}
+	return &FujicoinParser{BitcoinParser: btc.NewBitcoinParser(params, c)}
 }
 
 // GetChainParams contains network parameters for the main Fujicoin network,


### PR DESCRIPTION
This is a PR related to https://github.com/trezor/blockbook/issues/678 

Fujicoin has updated core to v22.0.
Please merge if this commit is required.