### PR TITLE
fix: properly set custom rpc port for bitcoin-like testnets

### DIFF
--- a/build/templates/backend/config/bitcoin_like.conf
+++ b/build/templates/backend/config/bitcoin_like.conf
@@ -5,7 +5,7 @@ server=1
 nolisten=1
 rpcuser={{.IPC.RPCUser}}
 rpcpassword={{.IPC.RPCPass}}
-rpcport={{.Ports.BackendRPC}}
+{{if .Backend.Mainnet}}rpcport={{.Ports.BackendRPC}}{{end}}
 txindex=1
 
 zmqpubhashtx={{template "IPC.MessageQueueBindingTemplate" .}}
@@ -27,4 +27,10 @@ addnode={{$node}}
 {{- end}}
 {{- end}}
 {{- end}}
+
+{{if not .Backend.Mainnet}}
+[test]
+rpcport={{.Ports.BackendRPC}}
+{{end}}
+
 {{end}}


### PR DESCRIPTION
Currently, bitcoin-like clients started in testnet mode ignore the `rpcport` option (revert to default port) set in `bitcoin_like.conf` as the option isn't set in the appropriate section, see [here](https://github.com/bitcoin/bitcoin/blob/master/share/examples/bitcoin.conf#L178-L179)

"The options addnode, connect, port, bind, rpcport, rpcbind and wallet
only apply to mainnet unless they appear in the appropriate section."

Related to issue #433 