### PR TITLE
Support for Firo ProgPow blocks

### DIFF
--- a/bchain/coins/firo/firoparser.go
+++ b/bchain/coins/firo/firoparser.go
@@ -28,6 +28,8 @@ const (
 
 	GenesisBlockTime       = 1414776286
 	SwitchToMTPBlockHeader = 1544443200
+	SwitchToProgPowBlockHeaderTestnet = 1630069200
+	SwitchToProgPowBlockHeaderMainnet = 1635228000
 	MTPL                   = 64
 
 	SpendTxID = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -156,38 +158,48 @@ func (p *FiroParser) ParseBlock(b []byte) (*bchain.Block, error) {
 		return nil, err
 	}
 
-	// then MTP header
-	if isMTP(header) {
-		mtpHeader := MTPBlockHeader{}
-		mtpHashData := MTPHashData{}
+	// then ProgPow or MTP header
+	if(isProgPow(header, p.Params.Net == TestnetMagic)){
+		progPowHeader := ProgPowBlockHeader{}
 
 		// header
-		err = binary.Read(reader, binary.LittleEndian, &mtpHeader)
+		err = binary.Read(reader, binary.LittleEndian, &progPowHeader)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		if isMTP(header) {
+			mtpHeader := MTPBlockHeader{}
+			mtpHashData := MTPHashData{}
 
-		// hash data
-		err = binary.Read(reader, binary.LittleEndian, &mtpHashData)
-		if err != nil {
-			return nil, err
-		}
-
-		// proof
-		for i := 0; i < MTPL*3; i++ {
-			var numberProofBlocks uint8
-
-			err = binary.Read(reader, binary.LittleEndian, &numberProofBlocks)
+			// header
+			err = binary.Read(reader, binary.LittleEndian, &mtpHeader)
 			if err != nil {
 				return nil, err
 			}
 
-			for j := uint8(0); j < numberProofBlocks; j++ {
-				var mtpData [16]uint8
+			// hash data
+			err = binary.Read(reader, binary.LittleEndian, &mtpHashData)
+			if err != nil {
+				return nil, err
+			}
 
-				err = binary.Read(reader, binary.LittleEndian, mtpData[:])
+			// proof
+			for i := 0; i < MTPL*3; i++ {
+				var numberProofBlocks uint8
+
+				err = binary.Read(reader, binary.LittleEndian, &numberProofBlocks)
 				if err != nil {
 					return nil, err
+				}
+
+				for j := uint8(0); j < numberProofBlocks; j++ {
+					var mtpData [16]uint8
+
+					err = binary.Read(reader, binary.LittleEndian, mtpData[:])
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 		}
@@ -299,6 +311,13 @@ func isMTP(h *wire.BlockHeader) bool {
 	return epoch > GenesisBlockTime && epoch >= SwitchToMTPBlockHeader
 }
 
+func isProgPow(h *wire.BlockHeader, isTestNet bool) bool {
+	epoch := h.Timestamp.Unix()
+
+	// the genesis block never be MTP block
+	return isTestNet && epoch >= SwitchToProgPowBlockHeaderTestnet || !isTestNet && epoch >= SwitchToProgPowBlockHeaderMainnet
+}
+
 type MTPHashData struct {
 	HashRootMTP [16]uint8
 	BlockMTP    [128][128]uint64
@@ -309,4 +328,9 @@ type MTPBlockHeader struct {
 	MTPHashValue chainhash.Hash
 	Reserved1    chainhash.Hash
 	Reserved2    chainhash.Hash
+}
+
+type ProgPowBlockHeader struct {
+	Nonce64 int64
+	MixHash chainhash.Hash
 }

--- a/configs/coins/firo.json
+++ b/configs/coins/firo.json
@@ -22,10 +22,10 @@
     "package_name": "backend-firo",
     "package_revision": "satoshilabs-1",
     "system_user": "firo",
-    "version": "0.14.1.2",
-    "binary_url": "https://github.com/firoorg/firo/releases/download/v0.14.1.2/firo-0.14.1.2-linux64.tar.gz",
+    "version": "0.14.9.1",
+    "binary_url": "https://github.com/firoorg/firo/releases/download/v0.14.9.1/firo-0.14.9.1-linux64.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "f2f3e92d891cfcea3b9232bdaf104fd1c7b6d21997a4e2c1297c7e8130c2e3e3",
+    "verification_source": "6384cc13ba193df3d44d2923b20fa562061b4e204ff8e0180147575fc3a1a588",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/tor",


### PR DESCRIPTION
Starting from 0.14.9 version of Firo, block headers parsing must be changed to support ProgPow block headers.