### PR TITLE
Use chaincfg params(signet)

### DIFF
--- a/bchain/coins/btc/bitcoinparser.go
+++ b/bchain/coins/btc/bitcoinparser.go
@@ -4,27 +4,10 @@ import (
 	"encoding/json"
 	"math/big"
 
-	"github.com/martinboehm/btcd/wire"
 	"github.com/martinboehm/btcutil/chaincfg"
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/common"
 )
-
-// temp params for signet(wait btcd commit)
-// magic numbers
-const (
-	SignetMagic wire.BitcoinNet = 0x6a70c7f0
-)
-
-// chain parameters
-var (
-	SigNetParams chaincfg.Params
-)
-
-func init() {
-	SigNetParams = chaincfg.TestNet3Params
-	SigNetParams.Net = SignetMagic
-}
 
 // BitcoinParser handle
 type BitcoinParser struct {
@@ -51,7 +34,7 @@ func GetChainParams(chain string) *chaincfg.Params {
 	case "regtest":
 		return &chaincfg.RegressionNetParams
 	case "signet":
-		return &SigNetParams
+		return &chaincfg.SigNetParams
 	}
 	return &chaincfg.MainNetParams
 }


### PR DESCRIPTION
I remove temp params for signet.

https://signet-explorer.wakiyamap.dev/

```
$ make test-integration ARGS="-v -run=TestIntegration/bitcoin_signet=main"
Image blockbook-build is up to date
docker run -t --rm -e PACKAGER=0:0 -v "/root/blockbook:/src" --network="host" blockbook-build make test-integration ARGS="-v -run=TestIntegration/bitcoin_signet=main"rm -rf /go/src/github.com/trezor/blockbook
mkdir -p /go/src/github.com/trezor
cp -r /src /go/src/github.com/trezor/blockbook
cd /go/src/github.com/trezor/blockbook && go mod download
cd /go/src/github.com/trezor/blockbook && go test -tags 'rocksdb_6_16 integration' `go list github.com/trezor/blockbook/tests/...` -v -run=TestIntegration/bitcoin_signet=main
=== RUN   TestIntegration
=== RUN   TestIntegration/bitcoin_signet=main
=== RUN   TestIntegration/bitcoin_signet=main/rpc
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetBlock
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetBlockHash
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetTransaction
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetTransactionForMempool
=== RUN   TestIntegration/bitcoin_signet=main/rpc/MempoolSync
=== RUN   TestIntegration/bitcoin_signet=main/rpc/EstimateSmartFee
=== RUN   TestIntegration/bitcoin_signet=main/rpc/EstimateFee
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetBestBlockHash
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetBestBlockHeight
=== RUN   TestIntegration/bitcoin_signet=main/rpc/GetBlockHeader
=== RUN   TestIntegration/bitcoin_signet=main/sync
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel/verifyBlockInfo
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel/verifyTransactions
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel/verifyAddresses
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocks
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocks/verifyBlockInfo
=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocks/verifyTransactions=== RUN   TestIntegration/bitcoin_signet=main/sync/ConnectBlocks/verifyAddresses
=== RUN   TestIntegration/bitcoin_signet=main/sync/HandleFork
--- PASS: TestIntegration (0.23s)
    --- PASS: TestIntegration/bitcoin_signet=main (0.23s)
        --- PASS: TestIntegration/bitcoin_signet=main/rpc (0.02s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetBlock (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetBlockHash (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetTransaction (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetTransactionForMempool (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/MempoolSync (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/EstimateSmartFee (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/EstimateFee (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetBestBlockHash (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetBestBlockHeight (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/rpc/GetBlockHeader (0.00s)
        --- PASS: TestIntegration/bitcoin_signet=main/sync (0.19s)
            --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel (0.06s)
                --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel/verifyBlockInfo (0.00s)
                --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel/verifyTransactions (0.00s)
                --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocksParallel/verifyAddresses (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocks (0.06s)
                --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocks/verifyBlockInfo (0.00s)
                --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocks/verifyTransactions (0.00s)
                --- PASS: TestIntegration/bitcoin_signet=main/sync/ConnectBlocks/verifyAddresses (0.00s)
            --- PASS: TestIntegration/bitcoin_signet=main/sync/HandleFork (0.07s)
PASS
ok      github.com/trezor/blockbook/tests       0.319s
?       github.com/trezor/blockbook/tests/dbtestdata    [no test files]
?       github.com/trezor/blockbook/tests/rpc   [no test files]
?       github.com/trezor/blockbook/tests/sync  [no test files]
```

```
$ make test
Image blockbook-build is up to date
docker run -t --rm -e PACKAGER=0:0 -v "/root/blockbook:/src" --network="host" blockbook-build make test ARGS=""
rm -rf /go/src/github.com/trezor/blockbook
mkdir -p /go/src/github.com/trezor
cp -r /src /go/src/github.com/trezor/blockbook
cd /go/src/github.com/trezor/blockbook && go mod download
cd /go/src/github.com/trezor/blockbook && go test -tags 'rocksdb_6_16 unittest' `go list ./... | grep -vP '^github.com/trezor/blockbook/(contrib|tests)'` 
?       github.com/trezor/blockbook     [no test files]
ok      github.com/trezor/blockbook/api 0.046s
ok      github.com/trezor/blockbook/bchain      0.019s
?       github.com/trezor/blockbook/bchain/coins        [no test files]
ok      github.com/trezor/blockbook/bchain/coins/bch    0.050s
ok      github.com/trezor/blockbook/bchain/coins/bellcoin       0.032s
ok      github.com/trezor/blockbook/bchain/coins/bitcore        0.039s
ok      github.com/trezor/blockbook/bchain/coins/bitzeny        0.028s
ok      github.com/trezor/blockbook/bchain/coins/btc    0.034s
ok      github.com/trezor/blockbook/bchain/coins/btg    0.049s
?       github.com/trezor/blockbook/bchain/coins/cpuchain       [no test files]
ok      github.com/trezor/blockbook/bchain/coins/dash   0.037s
ok      github.com/trezor/blockbook/bchain/coins/dcr    0.114s
ok      github.com/trezor/blockbook/bchain/coins/deeponion      0.037s
ok      github.com/trezor/blockbook/bchain/coins/digibyte       0.113s
ok      github.com/trezor/blockbook/bchain/coins/divi   0.055s
ok      github.com/trezor/blockbook/bchain/coins/dogecoin       0.033s
ok      github.com/trezor/blockbook/bchain/coins/eth    0.083s
ok      github.com/trezor/blockbook/bchain/coins/firo   0.085s
ok      github.com/trezor/blockbook/bchain/coins/flo    0.075s
ok      github.com/trezor/blockbook/bchain/coins/fujicoin       0.035s
ok      github.com/trezor/blockbook/bchain/coins/gamecredits    0.053s
ok      github.com/trezor/blockbook/bchain/coins/grs    0.052s
ok      github.com/trezor/blockbook/bchain/coins/koto   0.057s
ok      github.com/trezor/blockbook/bchain/coins/liquid 0.056s
ok      github.com/trezor/blockbook/bchain/coins/litecoin       0.055s
ok      github.com/trezor/blockbook/bchain/coins/monacoin       0.041s
ok      github.com/trezor/blockbook/bchain/coins/monetaryunit   0.037s
ok      github.com/trezor/blockbook/bchain/coins/myriad 0.039s
ok      github.com/trezor/blockbook/bchain/coins/namecoin       0.029s
ok      github.com/trezor/blockbook/bchain/coins/nuls   0.059s
ok      github.com/trezor/blockbook/bchain/coins/omotenashicoin 0.048s
ok      github.com/trezor/blockbook/bchain/coins/pivx   0.040s
ok      github.com/trezor/blockbook/bchain/coins/polis  0.061s
ok      github.com/trezor/blockbook/bchain/coins/qtum   0.064s
ok      github.com/trezor/blockbook/bchain/coins/ravencoin      0.059s
ok      github.com/trezor/blockbook/bchain/coins/ritocoin       0.046s
ok      github.com/trezor/blockbook/bchain/coins/snowgem        0.047s
ok      github.com/trezor/blockbook/bchain/coins/trezarcoin     0.049s
ok      github.com/trezor/blockbook/bchain/coins/unobtanium     0.049s
?       github.com/trezor/blockbook/bchain/coins/utils  [no test files]
ok      github.com/trezor/blockbook/bchain/coins/vertcoin       0.044s
ok      github.com/trezor/blockbook/bchain/coins/viacoin        0.068s
ok      github.com/trezor/blockbook/bchain/coins/vipstarcoin    0.046s
ok      github.com/trezor/blockbook/bchain/coins/zec    0.077s
?       github.com/trezor/blockbook/build/templates     [no test files]
?       github.com/trezor/blockbook/build/tools [no test files]
?       github.com/trezor/blockbook/build/tools/trezor-common   [no test files]
ok      github.com/trezor/blockbook/common      0.011s
ok      github.com/trezor/blockbook/db  0.268s
ok      github.com/trezor/blockbook/fiat        2.163s
ok      github.com/trezor/blockbook/server      0.193s
```