### PR TITLE
Update links in the main template (header and footer)

### DIFF
--- a/api/embed/tos_link
+++ b/api/embed/tos_link
@@ -1,1 +1,1 @@
-https://wallet.trezor.io/tos.pdf
+https://shop.trezor.io/static/shared/about/terms-of-use.pdf

--- a/static/templates/base.html
+++ b/static/templates/base.html
@@ -52,13 +52,13 @@
                     {{- end -}}
                     <ul class="navbar-nav ml-md-auto">
                         <li class="nav-item">
-                            <a href="https://trezor.io/" class="nav-link">Trezor</a>
+                            <a class="nav-link" href="https://trezor.io/" target="_blank" rel="noopener noreferrer">Trezor</a>
                         </li>
                         <li class="nav-item">
-                            <a href="https://wallet.trezor.io/" class="nav-link">Wallet</a>
+                            <a class="nav-link" href="https://suite.trezor.io/" target="_blank" rel="noopener noreferrer">Suite</a>
                         </li>
                         <li class="nav-item">
-                            <a href="https://trezor.io/support" class="nav-link">Support</a>
+                            <a class="nav-link" href="https://trezor.io/support" target="_blank" rel="noopener noreferrer">Support</a>
                         </li>
                     </ul>
                 </div>
@@ -74,16 +74,16 @@
         <div class="container">
             <nav class="navbar navbar-expand-lg navbar-dark bg-trezor">
                 <span class="navbar-nav">
-                    <a class="nav-link" href="https://satoshilabs.com/" target="_blank" rel="noopener noreferrer">© 2021 SatoshiLabs</a>
+                    <a class="nav-link" href="https://satoshilabs.com/" target="_blank" rel="noopener noreferrer">© 2017-2022 SatoshiLabs</a>
                 </span>
                 <span class="navbar-nav ml-md-auto">
-                    <a class="nav-link" href="{{- .TOSLink -}}" target="_blank" rel="noopener noreferrer">Terms</a>
+                    <a class="nav-link" href="{{- .TOSLink -}}" target="_blank" rel="noopener noreferrer">Terms of Use</a>
                 </span>
                 <span class="navbar-nav ml-md-auto">
-                    <a href="/sendtx" class="nav-link">Send Transaction</a>
+                    <a class="nav-link" href="/sendtx">Send Transaction</a>
                 </span>
                 <span class="navbar-nav ml-md-auto d-md-flex d-none">
-                    <a class="nav-link active" rel="noopener noreferrer" href="http://shop.trezor.io">Don't have a Trezor? Get one!</a>
+                    <a class="nav-link active" href="http://shop.trezor.io" target="_blank" rel="noopener noreferrer">Don't have a Trezor? Get one!</a>
                 </span>
             </nav>
         </div>


### PR DESCRIPTION
While playing with Blockbook I noticed there are some obsoleted links in the header and footer.

This PR updates them.

We do not need to deploy these ASAP so feel free to deploy whenever you plan the next update to production.