### PR TITLE
Removal of mentions of obsolete/discontinued dh-systemd

### DIFF
--- a/build/docker/deb/Dockerfile
+++ b/build/docker/deb/Dockerfile
@@ -4,7 +4,7 @@ FROM blockbook-build:latest
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y devscripts debhelper make dh-systemd dh-exec && \
+    apt-get install -y devscripts debhelper make dh-exec && \
     apt-get clean
 
 ADD gpg-keys /tmp/gpg-keys

--- a/build/templates/backend/debian/control
+++ b/build/templates/backend/debian/control
@@ -3,7 +3,7 @@ Source: backend
 Section: satoshilabs
 Priority: optional
 Maintainer: {{.Meta.PackageMaintainerEmail}}
-Build-Depends: debhelper, wget, tar, gzip, make, dh-systemd, dh-exec
+Build-Depends: debhelper, wget, tar, gzip, make, dh-exec
 Standards-Version: 3.9.5
 
 Package: {{.Backend.PackageName}}

--- a/build/templates/blockbook/debian/control
+++ b/build/templates/blockbook/debian/control
@@ -3,7 +3,7 @@ Source: blockbook
 Section: satoshilabs
 Priority: optional
 Maintainer: {{.Meta.PackageMaintainerEmail}}
-Build-Depends: debhelper, dh-systemd, dh-exec
+Build-Depends: debhelper, dh-exec
 Standards-Version: 3.9.5
 
 Package: {{.Blockbook.PackageName}}


### PR DESCRIPTION
Removed all mentions of `dh-systemd` which was a transitional package for quite a while and has been removed completely in Debian 11 (Bullseye) which caused the build to fail. The necessary functionality is in the `debhelper`-package which was already in the affected files. Closes #738 