### PR TITLE
Run apt-get noninteractive mode in the dockerfile

### DIFF
--- a/build/docker/deb/Dockerfile
+++ b/build/docker/deb/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM blockbook-build:latest
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y devscripts debhelper make dh-systemd dh-exec && \


### PR DESCRIPTION
This ensures that the `apt-get` command will not get stuck waiting for interactive user input during package installation.
I'm seeing this problem on Ubuntu 20.04, with `make all-ecash` being stuck because  `tzdata` is asking for my time zone.