### PR TITLE
Add Blocknet (BLOCK) support

### DIFF
--- a/bchain/coins/block/blocknetparser.go
+++ b/bchain/coins/block/blocknetparser.go
@@ -1,0 +1,131 @@
+package block
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/martinboehm/btcd/wire"
+	"github.com/martinboehm/btcutil/chaincfg"
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
+	"github.com/trezor/blockbook/bchain/coins/utils"
+)
+
+// constants used to indicate the message blocknet network.
+const (
+	MainnetMagic wire.BitcoinNet = 0xa3a2a0a1
+	TestnetMagic wire.BitcoinNet = 0xbb657645
+	RegtestMagic wire.BitcoinNet = 0xac7ecfa1
+)
+
+// chain parameters
+var (
+	MainNetParams chaincfg.Params
+	TestNetParams chaincfg.Params
+	RegtestParams chaincfg.Params
+)
+
+func init() {
+	MainNetParams = chaincfg.MainNetParams
+	MainNetParams.Net = MainnetMagic
+	MainNetParams.PubKeyHashAddrID = []byte{26} // base58 prefix: B
+	MainNetParams.ScriptHashAddrID = []byte{28} // base58 prefix: C
+	MainNetParams.Bech32HRPSegwit = "block"
+
+	TestNetParams = chaincfg.TestNet3Params
+	TestNetParams.Net = TestnetMagic
+	TestNetParams.PubKeyHashAddrID = []byte{139} // base58 prefix: x or y
+	TestNetParams.ScriptHashAddrID = []byte{19}  // base58 prefix: 8 or 9
+	TestNetParams.Bech32HRPSegwit = "tblock"
+
+	RegtestParams = chaincfg.RegressionNetParams
+	RegtestParams.Net = RegtestMagic
+	RegtestParams.PubKeyHashAddrID = []byte{139} // base58 prefix: x or y
+	RegtestParams.ScriptHashAddrID = []byte{19}  // base58 prefix: 8 or 9
+	RegtestParams.Bech32HRPSegwit = "blockrt"
+}
+
+// BlocknetParser handle
+type BlocknetParser struct {
+	*btc.BitcoinLikeParser
+}
+
+// NewBlocknetParser returns new BlocknetParser instance
+func NewBlocknetParser(params *chaincfg.Params, c *btc.Configuration) *BlocknetParser {
+	return &BlocknetParser{BitcoinLikeParser: btc.NewBitcoinLikeParser(params, c)}
+}
+
+// GetChainParams contains network parameters for the main Blocknet network,
+// the regression test Blocknet network, the test Blocknet network and
+// the simulation test Blocknet network
+func GetChainParams(chain string) *chaincfg.Params {
+	if !chaincfg.IsRegistered(&MainNetParams) {
+		err := chaincfg.Register(&MainNetParams)
+		if err == nil {
+			err = chaincfg.Register(&TestNetParams)
+		}
+		if err == nil {
+			err = chaincfg.Register(&RegtestParams)
+		}
+		if err != nil {
+			panic(err)
+		}
+	}
+	switch chain {
+	case "test":
+		return &TestNetParams
+	case "regtest":
+		return &RegtestParams
+	default:
+		return &MainNetParams
+	}
+}
+
+func parseBlockHeader(r io.Reader) (*wire.BlockHeader, error) {
+	h := &wire.BlockHeader{}
+	err := h.Deserialize(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Blocknet specific header elements
+	// uint256 hashStake;
+	// uint32_t nStakeIndex;
+	// int64_t nStakeAmount;
+	// uint256 hashStakeBlock;
+	buf := make([]byte, 76)
+	_, err = io.ReadFull(r, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, err
+}
+
+func (p *BlocknetParser) ParseBlock(b []byte) (*bchain.Block, error) {
+	r := bytes.NewReader(b)
+	w := wire.MsgBlock{}
+
+	h, err := parseBlockHeader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	err = utils.DecodeTransactions(r, 0, wire.WitnessEncoding, &w)
+	if err != nil {
+		return nil, err
+	}
+
+	txs := make([]bchain.Tx, len(w.Transactions))
+	for ti, t := range w.Transactions {
+		txs[ti] = p.TxFromMsgTx(t, false)
+	}
+
+	return &bchain.Block{
+		BlockHeader: bchain.BlockHeader{
+			Size: len(b),
+			Time: h.Timestamp.Unix(),
+		},
+		Txs: txs,
+	}, nil
+}

--- a/bchain/coins/block/blocknetparser_test.go
+++ b/bchain/coins/block/blocknetparser_test.go
@@ -1,0 +1,440 @@
+// +build unittest
+
+package block
+
+import (
+	"encoding/hex"
+	"math/big"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/martinboehm/btcutil/chaincfg"
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
+)
+
+func TestMain(m *testing.M) {
+	c := m.Run()
+	chaincfg.ResetParams()
+	os.Exit(c)
+}
+
+func TestGetAddrDescFromAddress(t *testing.T) {
+	type args struct {
+		address string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "P2PKH",
+			args:    args{address: "BoYhQh9zJ8Kw5grXEK4pLwpyTtEyq1bC7p"},
+			want:    "76a914d8bd5de47c77b9064d87bade0a040e217de454cb88ac",
+			wantErr: false,
+		},
+		{
+			name:    "P2SH",
+			args:    args{address: "CdbiHEWZLpVqyRTQYSMaLU3ckLdff9QFhT"},
+			want:    "a914e7d561324d0c61329db604437d2d3dd7280a3f1087",
+			wantErr: false,
+		},
+		{
+			name:    "P2WPKH",
+			args:    args{address: "block1q5n5y22txfkew99qmkppl4dkjl5pz888n22mad2"},
+			want:    "0014a4e84529664db2e2941bb043fab6d2fd02239cf3",
+			wantErr: false,
+		},
+		{
+			name:    "P2WSH",
+			args:    args{address: "block1qsa5xq0f65d28u77tt4sdlacz7fjkcausrapk4zaa83jtj04tx2nq0duxn4"},
+			want:    "00208768603d3aa3547e7bcb5d60dff702f2656c77901f436a8bbd3c64b93eab32a6",
+			wantErr: false,
+		},
+	}
+	parser := NewBlocknetParser(GetChainParams("main"), &btc.Configuration{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.GetAddrDescFromAddress(tt.args.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddrDescFromAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			h := hex.EncodeToString(got)
+			if !reflect.DeepEqual(h, tt.want) {
+				t.Errorf("GetAddrDescFromAddress() = %v, want %v", h, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAddrDescFromVout(t *testing.T) {
+	type args struct {
+		vout bchain.Vout
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "P2PKH",
+			args:    args{vout: bchain.Vout{ScriptPubKey: bchain.ScriptPubKey{Hex: "76a914be027bf3eac907bd4ac8cb9c5293b6f37662722088ac"}}},
+			want:    "76a914be027bf3eac907bd4ac8cb9c5293b6f37662722088ac",
+			wantErr: false,
+		},
+		{
+			name:    "P2PK compressed",
+			args:    args{vout: bchain.Vout{ScriptPubKey: bchain.ScriptPubKey{Hex: "21020e46e79a2a8d12b9b5d12c7a91adb4e454edfae43c0a0cb805427d2ac7613fd9ac"}}},
+			want:    "76a914f1dce4182fce875748c4986b240ff7d7bc3fffb088ac",
+			wantErr: false,
+		},
+		{
+			name:    "P2PK uncompressed",
+			args:    args{vout: bchain.Vout{ScriptPubKey: bchain.ScriptPubKey{Hex: "41041057356b91bfd3efeff5fc0fa8b865faafafb67bd653c5da2cd16ce15c7b86db0e622c8e1e135f68918a23601eb49208c1ac72c7b64a4ee99c396cf788da16ccac"}}},
+			want:    "76a914b563933904dceba5c234e978bea0e9eb8b7e721b88ac",
+			wantErr: false,
+		},
+		{
+			name:    "P2SH",
+			args:    args{vout: bchain.Vout{ScriptPubKey: bchain.ScriptPubKey{Hex: "a9140394b3cf9a44782c10105b93962daa8dba304d7f87"}}},
+			want:    "a9140394b3cf9a44782c10105b93962daa8dba304d7f87",
+			wantErr: false,
+		},
+		{
+			name:    "P2WPKH",
+			args:    args{vout: bchain.Vout{ScriptPubKey: bchain.ScriptPubKey{Hex: "00141c12afc6b2602607fdbc209f2a053c54ecd2c673"}}},
+			want:    "00141c12afc6b2602607fdbc209f2a053c54ecd2c673",
+			wantErr: false,
+		},
+		{
+			name:    "P2WSH",
+			args:    args{vout: bchain.Vout{ScriptPubKey: bchain.ScriptPubKey{Hex: "002003973a40ec94c0d10f6f6f0e7a62ba2044b7d19db6ff2bf60651e17fb29d8d29"}}},
+			want:    "002003973a40ec94c0d10f6f6f0e7a62ba2044b7d19db6ff2bf60651e17fb29d8d29",
+			wantErr: false,
+		},
+	}
+	parser := NewBlocknetParser(GetChainParams("main"), &btc.Configuration{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.GetAddrDescFromVout(&tt.args.vout)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddrDescFromVout() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			h := hex.EncodeToString(got)
+			if !reflect.DeepEqual(h, tt.want) {
+				t.Errorf("GetAddrDescFromVout() = %v, want %v", h, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetAddressesFromAddrDesc(t *testing.T) {
+	type args struct {
+		script string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		want2   bool
+		wantErr bool
+	}{
+		{
+			name:    "P2PKH",
+			args:    args{script: "76a91440f825e2eb4ecaf96edfbb4d1a38cebdca62257188ac"},
+			want:    []string{"BZiD7j4tGmKBtkiXw8qMHBoE1Eot62by4w"},
+			want2:   true,
+			wantErr: false,
+		},
+		{
+			name:    "P2PK compressed",
+			args:    args{script: "21020e46e79a2a8d12b9b5d12c7a91adb4e454edfae43c0a0cb805427d2ac7613fd9ac"},
+			want:    []string{"BqqY4q8EUWpPHTLkq3HXaQg1w8G7qyBDs9"},
+			want2:   false,
+			wantErr: false,
+		},
+		{
+			name:    "P2PK uncompressed",
+			args:    args{script: "41041057356b91bfd3efeff5fc0fa8b865faafafb67bd653c5da2cd16ce15c7b86db0e622c8e1e135f68918a23601eb49208c1ac72c7b64a4ee99c396cf788da16ccac"},
+			want:    []string{"BkKnC9JBhyA4WJsJmdRDbyTjhxw2qLWf89"},
+			want2:   false,
+			wantErr: false,
+		},
+		{
+			name:    "P2SH",
+			args:    args{script: "a914926c6dd4fb1da987d316d58d38fd0ee52f61bcf687"},
+			want:    []string{"CVp77q5EZbMg74FJF2NPEeuTxfBTVpsmmm"},
+			want2:   true,
+			wantErr: false,
+		},
+		{
+			name:    "P2WPKH",
+			args:    args{script: "0014256b96c294600d06038b70670a180b768e50f4be"},
+			want:    []string{"block1qy44eds55vqxsvqutwpns5xqtw689pa97jqux5w"},
+			want2:   true,
+			wantErr: false,
+		},
+		{
+			name:    "P2WSH",
+			args:    args{script: "0020306b3f04e29adf526463c7a71880b7afa4934adba04d465fa77fae7c62515b6c"},
+			want:    []string{"block1qxp4n7p8znt04yerrc7n33q9h47jfxjkm5px5vha807h8ccj3tdkq875ajy"},
+			want2:   true,
+			wantErr: false,
+		},
+		{
+			name:    "OP_RETURN ascii",
+			args:    args{script: "6a0461686f6a"},
+			want:    []string{"OP_RETURN (ahoj)"},
+			want2:   false,
+			wantErr: false,
+		},
+		{
+			name:    "OP_RETURN OP_PUSHDATA1 ascii",
+			args:    args{script: "6a4c0b446c6f7568792074657874"},
+			want:    []string{"OP_RETURN (Dlouhy text)"},
+			want2:   false,
+			wantErr: false,
+		},
+		{
+			name:    "OP_RETURN hex",
+			args:    args{script: "6a072020f1686f6a20"},
+			want:    []string{"OP_RETURN 2020f1686f6a20"},
+			want2:   false,
+			wantErr: false,
+		},
+	}
+
+	parser := NewBlocknetParser(GetChainParams("main"), &btc.Configuration{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, _ := hex.DecodeString(tt.args.script)
+			got, got2, err := parser.GetAddressesFromAddrDesc(b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("outputScriptToAddresses() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAddressesFromAddrDesc() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("GetAddressesFromAddrDesc() = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+var (
+	testTx1, testTx2 bchain.Tx
+	testTxPacked1    = "000a928d8bc0cfb71a01000000036ba6efd4a411cedce9cbac527437671f49305cbb50a90b9d1e432262d137f56a010000004847304402205aacd5e0d16d2b21f299ca3a53f9d9e29d16eb2decad3a55892d8a6584ab6257022039a93630696a2535acf4b6cf77db017e91a7a14aac30b3276325b1632c0ca3de01ffffffffb7b6bec11d34f44e98e71932662d3f9ee7d585cf8d8760b2f21d50f5d5848683000000006a47304402203f132c37fd68a5e67ddf7926aed2bb31cf7cb94c970fccf4d2bd17415000fc6402206c720786d0df0b83c9b52bb4148bd2ccb1d3c66358c653bc270b88bf8908c998012102713d227b8714a5986b336b4fa9821ce460f85ed3e0a43fd26e80bb05187dc919ffffffff127e121b174e10adbbe1f881b35bdb8c1babcd2b2f1d784619907c91e8bf47fa010000006a473044022014d00f28233052a24e2ff5c05f1e95eb7768b3e3db5f7bbbb94bc89c3a0fc5cd022012d0a51b2bfa02305c7ae4dff165956bf0063d25a239f134b71dddd423fdea7e012103722bd26c8ee2efcdb9e9bd59ae6e0465f16aa4446a0cfad3185bff9372f26dc6ffffffff02eef20000000000001976a914c29650971756810bdf2b34ff30d037bf9a1b10d288acc03b956c160000001976a914ccb546b5be09438cf6b868b40f086b9b261bd46988ac00000000"
+	testTxPacked2    = "0001369e8c8dc1d73c01000000017ead8519ab8848ba62ac1aff62c36ca2ec93c805ac3a072e0b38d91633b5da46010000004847304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601feffffff0206081a838b0000001976a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac00943577000000001976a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac9d360100"
+)
+
+func init() {
+	testTx1 = bchain.Tx{
+		Hex:       "01000000036ba6efd4a411cedce9cbac527437671f49305cbb50a90b9d1e432262d137f56a010000004847304402205aacd5e0d16d2b21f299ca3a53f9d9e29d16eb2decad3a55892d8a6584ab6257022039a93630696a2535acf4b6cf77db017e91a7a14aac30b3276325b1632c0ca3de01ffffffffb7b6bec11d34f44e98e71932662d3f9ee7d585cf8d8760b2f21d50f5d5848683000000006a47304402203f132c37fd68a5e67ddf7926aed2bb31cf7cb94c970fccf4d2bd17415000fc6402206c720786d0df0b83c9b52bb4148bd2ccb1d3c66358c653bc270b88bf8908c998012102713d227b8714a5986b336b4fa9821ce460f85ed3e0a43fd26e80bb05187dc919ffffffff127e121b174e10adbbe1f881b35bdb8c1babcd2b2f1d784619907c91e8bf47fa010000006a473044022014d00f28233052a24e2ff5c05f1e95eb7768b3e3db5f7bbbb94bc89c3a0fc5cd022012d0a51b2bfa02305c7ae4dff165956bf0063d25a239f134b71dddd423fdea7e012103722bd26c8ee2efcdb9e9bd59ae6e0465f16aa4446a0cfad3185bff9372f26dc6ffffffff02eef20000000000001976a914c29650971756810bdf2b34ff30d037bf9a1b10d288acc03b956c160000001976a914ccb546b5be09438cf6b868b40f086b9b261bd46988ac00000000",
+		Blocktime: 1544154573,
+		Txid:      "ef85eaf687e8a003dec557036bde92011f3c17e0a54a2a174f4e9959c6a2fbb1",
+		LockTime:  0,
+		Version:   1,
+		Vin: []bchain.Vin{
+			{
+				ScriptSig: bchain.ScriptSig{
+					Hex: "47304402205aacd5e0d16d2b21f299ca3a53f9d9e29d16eb2decad3a55892d8a6584ab6257022039a93630696a2535acf4b6cf77db017e91a7a14aac30b3276325b1632c0ca3de01",
+				},
+				Txid:     "6af537d16222431e9d0ba950bb5c30491f67377452accbe9dcce11a4d4efa66b",
+				Vout:     1,
+				Sequence: 4294967295,
+			},
+			{
+				ScriptSig: bchain.ScriptSig{
+					Hex: "47304402203f132c37fd68a5e67ddf7926aed2bb31cf7cb94c970fccf4d2bd17415000fc6402206c720786d0df0b83c9b52bb4148bd2ccb1d3c66358c653bc270b88bf8908c998012102713d227b8714a5986b336b4fa9821ce460f85ed3e0a43fd26e80bb05187dc919",
+				},
+				Txid:     "838684d5f5501df2b260878dcf85d5e79e3f2d663219e7984ef4341dc1beb6b7",
+				Vout:     0,
+				Sequence: 4294967295,
+			},
+			{
+				ScriptSig: bchain.ScriptSig{
+					Hex: "473044022014d00f28233052a24e2ff5c05f1e95eb7768b3e3db5f7bbbb94bc89c3a0fc5cd022012d0a51b2bfa02305c7ae4dff165956bf0063d25a239f134b71dddd423fdea7e012103722bd26c8ee2efcdb9e9bd59ae6e0465f16aa4446a0cfad3185bff9372f26dc6",
+				},
+				Txid:     "fa47bfe8917c901946781d2f2bcdab1b8cdb5bb381f8e1bbad104e171b127e12",
+				Vout:     1,
+				Sequence: 4294967295,
+			},
+		},
+		Vout: []bchain.Vout{
+			{
+				ValueSat: *big.NewInt(62190),
+				N:        0,
+				ScriptPubKey: bchain.ScriptPubKey{
+					Hex: "76a914c29650971756810bdf2b34ff30d037bf9a1b10d288ac",
+					Addresses: []string{
+						"BmXZm6Tjn3YoAceauPczSPHiANn3Spcszu",
+					},
+				},
+			},
+			{
+				ValueSat: *big.NewInt(96311000000),
+				N:        1,
+				ScriptPubKey: bchain.ScriptPubKey{
+					Hex: "76a914ccb546b5be09438cf6b868b40f086b9b261bd46988ac",
+					Addresses: []string{
+						"BnT5cFRK47dTxWKEmYaET23aw3sy3zj8gv",
+					},
+				},
+			},
+		},
+	}
+
+	testTx2 = bchain.Tx{
+		Hex:       "01000000017ead8519ab8848ba62ac1aff62c36ca2ec93c805ac3a072e0b38d91633b5da46010000004847304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601feffffff0206081a838b0000001976a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac00943577000000001976a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac9d360100",
+		Blocktime: 1624782302,
+		Txid:      "c69ed365e1db3490200dbca40b5137d7d85ce0c583c288fc36ad8b13e9a05602",
+		LockTime:  79517,
+		Version:   1,
+		Vin: []bchain.Vin{
+			{
+				ScriptSig: bchain.ScriptSig{
+					Hex: "47304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601",
+				},
+				Txid:     "46dab53316d9380b2e073aac05c893eca26cc362ff1aac62ba4888ab1985ad7e",
+				Vout:     1,
+				Sequence: 4294967294,
+			},
+		},
+		Vout: []bchain.Vout{
+			{
+				ValueSat: *big.NewInt(599199975430),
+				N:        0,
+				ScriptPubKey: bchain.ScriptPubKey{
+					Hex: "76a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac",
+					Addresses: []string{
+						"y14EDRC4wPJmV8q1kY66WTv262zuvmr7Ps",
+					},
+				},
+			},
+			{
+				ValueSat: *big.NewInt(2000000000),
+				N:        1,
+				ScriptPubKey: bchain.ScriptPubKey{
+					Hex: "76a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac",
+					Addresses: []string{
+						"yDaTbrLjVK2jX54JhsKtRNkDcrQ6sTdBXD",
+					},
+				},
+			},
+		},
+	}
+
+}
+
+func Test_PackTx(t *testing.T) {
+	type args struct {
+		tx        bchain.Tx
+		height    uint32
+		blockTime int64
+		parser    *BlocknetParser
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "block-1",
+			args: args{
+				tx:        testTx1,
+				height:    692877,
+				blockTime: 1544154573,
+				parser:    NewBlocknetParser(GetChainParams("main"), &btc.Configuration{}),
+			},
+			want:    testTxPacked1,
+			wantErr: false,
+		},
+		{
+			name: "testnet-1",
+			args: args{
+				tx:        testTx2,
+				height:    79518,
+				blockTime: 1624782302,
+				parser:    NewBlocknetParser(GetChainParams("test"), &btc.Configuration{}),
+			},
+			want:    testTxPacked2,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.args.parser.PackTx(&tt.args.tx, tt.args.height, tt.args.blockTime)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("packTx() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			h := hex.EncodeToString(got)
+			if !reflect.DeepEqual(h, tt.want) {
+				t.Errorf("packTx() = %v, want %v", h, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnpackTx(t *testing.T) {
+	type args struct {
+		packedTx string
+		parser   *BlocknetParser
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *bchain.Tx
+		want1   uint32
+		wantErr bool
+	}{
+		{
+			name: "block-1",
+			args: args{
+				packedTx: testTxPacked1,
+				parser:   NewBlocknetParser(GetChainParams("main"), &btc.Configuration{}),
+			},
+			want:    &testTx1,
+			want1:   692877,
+			wantErr: false,
+		},
+		{
+			name: "testnet-1",
+			args: args{
+				packedTx: testTxPacked2,
+				parser:   NewBlocknetParser(GetChainParams("test"), &btc.Configuration{}),
+			},
+			want:    &testTx2,
+			want1:   79518,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, _ := hex.DecodeString(tt.args.packedTx)
+			got, got1, err := tt.args.parser.UnpackTx(b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unpackTx() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unpackTx() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("unpackTx() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/bchain/coins/block/blocknetparser_test.go
+++ b/bchain/coins/block/blocknetparser_test.go
@@ -1,4 +1,4 @@
-// +build unittest
+//go:build unittest
 
 package block
 

--- a/bchain/coins/block/blocknetrpc.go
+++ b/bchain/coins/block/blocknetrpc.go
@@ -1,0 +1,58 @@
+package block
+
+import (
+	"encoding/json"
+
+	"github.com/golang/glog"
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
+)
+
+// BlocknetRPC is an interface to JSON-RPC blocknetd service.
+type BlocknetRPC struct {
+	*btc.BitcoinRPC
+}
+
+// NewBlocknetRPC returns new BlocknetRPC instance.
+func NewBlocknetRPC(config json.RawMessage, pushHandler func(bchain.NotificationType)) (bchain.BlockChain, error) {
+	b, err := btc.NewBitcoinRPC(config, pushHandler)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &BlocknetRPC{
+		b.(*btc.BitcoinRPC),
+	}
+	s.RPCMarshaler = btc.JSONMarshalerV1{}
+	// s.ChainConfig.SupportsEstimateFee = true
+	// s.ChainConfig.SupportsEstimateSmartFee = false
+
+	return s, nil
+}
+
+// Initialize initializes BlocknetRPC instance.
+func (b *BlocknetRPC) Initialize() error {
+	ci, err := b.GetChainInfo()
+	if err != nil {
+		return err
+	}
+	chainName := ci.Chain
+
+	params := GetChainParams(chainName)
+
+	// always create parser
+	b.Parser = NewBlocknetParser(params, b.ChainConfig)
+
+	// parameters for getInfo request
+	if params.Net == MainnetMagic {
+		b.Testnet = false
+		b.Network = "livenet"
+	} else {
+		b.Testnet = true
+		b.Network = "testnet"
+	}
+
+	glog.Info("rpc: block chain ", params.Name)
+
+	return nil
+}

--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trezor/blockbook/bchain/coins/bellcoin"
 	"github.com/trezor/blockbook/bchain/coins/bitcore"
 	"github.com/trezor/blockbook/bchain/coins/bitzeny"
+	"github.com/trezor/blockbook/bchain/coins/block"
 	"github.com/trezor/blockbook/bchain/coins/btc"
 	"github.com/trezor/blockbook/bchain/coins/btg"
 	"github.com/trezor/blockbook/bchain/coins/cpuchain"
@@ -75,6 +76,8 @@ func init() {
 	BlockChainFactories["Bcash Testnet"] = bch.NewBCashRPC
 	BlockChainFactories["Bgold"] = btg.NewBGoldRPC
 	BlockChainFactories["Bgold Testnet"] = btg.NewBGoldRPC
+	BlockChainFactories["Blocknet"] = block.NewBlocknetRPC
+	BlockChainFactories["Blocknet Testnet"] = block.NewBlocknetRPC
 	BlockChainFactories["Dash"] = dash.NewDashRPC
 	BlockChainFactories["Dash Testnet"] = dash.NewDashRPC
 	BlockChainFactories["Decred"] = dcr.NewDecredRPC

--- a/configs/coins/blocknet.json
+++ b/configs/coins/blocknet.json
@@ -6,10 +6,10 @@
     "alias": "blocknet"
   },
   "ports": {
-    "backend_rpc": 8097,
-    "backend_message_queue": 38397,
-    "blockbook_internal": 9097,
-    "blockbook_public": 9197
+    "backend_rpc": 8098,
+    "backend_message_queue": 38398,
+    "blockbook_internal": 9098,
+    "blockbook_public": 9198
   },
   "ipc": {
     "rpc_url_template": "http://127.0.0.1:{{.Ports.BackendRPC}}",

--- a/configs/coins/blocknet.json
+++ b/configs/coins/blocknet.json
@@ -1,0 +1,70 @@
+{
+  "coin": {
+    "name": "Blocknet",
+    "shortcut": "BLOCK",
+    "label": "Blocknet",
+    "alias": "blocknet"
+  },
+  "ports": {
+    "backend_rpc": 8097,
+    "backend_message_queue": 38397,
+    "blockbook_internal": 9097,
+    "blockbook_public": 9197
+  },
+  "ipc": {
+    "rpc_url_template": "http://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_user": "rpc",
+    "rpc_pass": "rpc",
+    "rpc_timeout": 25,
+    "message_queue_binding_template": "tcp://127.0.0.1:{{.Ports.BackendMessageQueue}}"
+  },
+  "backend": {
+    "package_name": "backend-blocknet",
+    "package_revision": "satoshilabs-1",
+    "system_user": "blocknet",
+    "version": "4.3.3",
+    "binary_url": "https://github.com/blocknetdx/blocknet/releases/download/v4.3.3/blocknet-4.3.3-x86_64-linux-gnu.tar.gz",
+    "verification_type": "sha256",
+    "verification_source": "fda57c0515126997509303d4bc25440a309792e3b9c92a8bd197d1312e94b49c",
+    "extract_command": "tar -C backend --strip 1 -xf",
+    "exclude_files": [
+      "bin/blocknet-qt",
+      "bin/blocknet-tx",
+      "bin/blocknet-wallet",
+      "bin/test_blocknet"
+    ],
+    "exec_command_template": "{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/bin/blocknetd -datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend -conf={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/{{.Coin.Alias}}.conf -pid=/run/{{.Coin.Alias}}/{{.Coin.Alias}}.pid",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/*.log",
+    "postinst_script_template": "",
+    "service_type": "forking",
+    "service_additional_params_template": "",
+    "protect_memory": true,
+    "mainnet": true,
+    "server_config_file": "bitcoin_like.conf",
+    "client_config_file": "bitcoin_like_client.conf",
+    "additional_params": {}
+  },
+  "blockbook": {
+    "package_name": "blockbook-blocknet",
+    "system_user": "blockbook-blocknet",
+    "internal_binding_template": ":{{.Ports.BlockbookInternal}}",
+    "public_binding_template": ":{{.Ports.BlockbookPublic}}",
+    "explorer_url": "",
+    "additional_params": "",
+    "block_chain": {
+      "parse": true,
+      "mempool_workers": 8,
+      "mempool_sub_workers": 2,
+      "block_addresses_to_keep": 300,
+      "xpub_magic": 76067358,
+      "xpub_magic_segwit_p2sh": 77429938,
+      "xpub_magic_segwit_native": 78792518,
+      "slip44": 328,
+      "additional_params": {}
+    }
+  },
+  "meta": {
+    "package_maintainer": "rikublock",
+    "package_maintainer_email": "riku.block@gmail.com"
+  }
+}

--- a/configs/coins/blocknet_testnet.json
+++ b/configs/coins/blocknet_testnet.json
@@ -1,0 +1,70 @@
+{
+  "coin": {
+    "name": "Blocknet Testnet",
+    "shortcut": "tBLOCK",
+    "label": "Blocknet Testnet",
+    "alias": "blocknet_testnet"
+  },
+  "ports": {
+    "backend_rpc": 18097,
+    "backend_message_queue": 48397,
+    "blockbook_internal": 19097,
+    "blockbook_public": 19197
+  },
+  "ipc": {
+    "rpc_url_template": "http://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_user": "rpc",
+    "rpc_pass": "rpc",
+    "rpc_timeout": 25,
+    "message_queue_binding_template": "tcp://127.0.0.1:{{.Ports.BackendMessageQueue}}"
+  },
+  "backend": {
+    "package_name": "backend-blocknet-testnet",
+    "package_revision": "satoshilabs-1",
+    "system_user": "blocknet",
+    "version": "4.3.3",
+    "binary_url": "https://github.com/blocknetdx/blocknet/releases/download/v4.3.3/blocknet-4.3.3-x86_64-linux-gnu.tar.gz",
+    "verification_type": "sha256",
+    "verification_source": "fda57c0515126997509303d4bc25440a309792e3b9c92a8bd197d1312e94b49c",
+    "extract_command": "tar -C backend --strip 1 -xf",
+    "exclude_files": [
+      "bin/blocknet-qt",
+      "bin/blocknet-tx",
+      "bin/blocknet-wallet",
+      "bin/test_blocknet"
+    ],
+    "exec_command_template": "{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/bin/blocknetd -datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend -conf={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/{{.Coin.Alias}}.conf -pid=/run/{{.Coin.Alias}}/{{.Coin.Alias}}.pid",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/testnet6/*.log",
+    "postinst_script_template": "",
+    "service_type": "forking",
+    "service_additional_params_template": "",
+    "protect_memory": true,
+    "mainnet": false,
+    "server_config_file": "bitcoin_like.conf",
+    "client_config_file": "bitcoin_like_client.conf",
+    "additional_params": {}
+  },
+  "blockbook": {
+    "package_name": "blockbook-blocknet-testnet",
+    "system_user": "blockbook-blocknet",
+    "internal_binding_template": ":{{.Ports.BlockbookInternal}}",
+    "public_binding_template": ":{{.Ports.BlockbookPublic}}",
+    "explorer_url": "",
+    "additional_params": "",
+    "block_chain": {
+      "parse": true,
+      "mempool_workers": 8,
+      "mempool_sub_workers": 2,
+      "block_addresses_to_keep": 300,
+      "xpub_magic": 70617039,
+      "xpub_magic_segwit_p2sh": 71979618,
+      "xpub_magic_segwit_native": 73342198,
+      "slip44": 1,
+      "additional_params": {}
+    }
+  },
+  "meta": {
+    "package_maintainer": "rikublock",
+    "package_maintainer_email": "riku.block@gmail.com"
+  }
+}

--- a/configs/coins/blocknet_testnet.json
+++ b/configs/coins/blocknet_testnet.json
@@ -6,10 +6,10 @@
     "alias": "blocknet_testnet"
   },
   "ports": {
-    "backend_rpc": 18097,
-    "backend_message_queue": 48397,
-    "blockbook_internal": 19097,
-    "blockbook_public": 19197
+    "backend_rpc": 18098,
+    "backend_message_queue": 48398,
+    "blockbook_internal": 19098,
+    "blockbook_public": 19198
   },
   "ipc": {
     "rpc_url_template": "http://127.0.0.1:{{.Ports.BackendRPC}}",

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -46,6 +46,7 @@
 | BitZeny                | 9095                    | 9195                  | 8095             | 38395                       |
 | Trezarcoin             | 9096                    | 9196                  | 8096             | 38396                       |
 | eCash                  | 9097                    | 9197                  | 8097             | 38397                       |
+| Blocknet               | 9098                    | 9198                  | 8098             | 38398                       |
 | Bitcoin Signet         | 19020                   | 19120                 | 18020            | 48320                       |
 | Bitcoin Regtest        | 19021                   | 19121                 | 18021            | 48321                       |
 | Ethereum Goerli        | 19026                   | 19126                 | 18026            | 48326 p2p                   |
@@ -69,5 +70,6 @@
 | Flo Testnet            | 19066                   | 19166                 | 18066            | 48366                       |
 | Qtum Testnet           | 19088                   | 19188                 | 18088            | 48388                       |
 | Omotenashicoin Testnet | 19089                   | 19189                 | 18089            | 48389                       |
+| Blocknet Testnet       | 19098                   | 19198                 | 18098            | 48398                       |
 
 > NOTE: This document is generated from coin definitions in `configs/coins`.

--- a/tests/rpc/testdata/blocknet.json
+++ b/tests/rpc/testdata/blocknet.json
@@ -1,0 +1,47 @@
+{
+    "blockHeight": 693800,
+    "blockHash": "af5c5943051e1fe17ad41646f01744bd5bf41c835624dd314a2671af22de08ea",
+    "blockTime": 1544210151,
+    "blockTxs": [
+		"8bc8ee32c45156ee5ab127ed33deca6045218ffe01433c74b41dffefce088cf7",
+		"b0dc89e0668f2bf1e89f4a41703d3b245f1903cfc07102d79a1fe55ad2a4fe8e",
+		"fbee1818d37c336ac5707f91c7886b28b30cf17254fa5386657f92eb16848e2e",
+		"77600ceb4692a56ee34834ac1c3eba466299f0097715671bd10b64f3c87f20fa"
+    ],
+    "txDetails": {
+        "77600ceb4692a56ee34834ac1c3eba466299f0097715671bd10b64f3c87f20fa": {
+            "hex": "0100000001559be19597c7ec1066f95043285d5a4094c97d10acef888abfeaf5d0c3637145010000006b48304502210082922a9178874d7cf551835c13499a46247c0654ca35c11a940c56b844442705022054e96ab5174ef0ecbbf3efae22ab1d72d2177d4de05f22ecc61b0d4a32c7a823012103a982906e78dfb2220061438b55478f7fc67e669d1d5ea48189666d50fa54fcdbffffffff02f175feeb0b0000001976a9141c7ece8045985cd2d31a78775ea63734880658d188aca7d20f3f070000001976a91405b3348518ec36c6e5e86d2f80551dcb64414eea88ac00000000",
+            "txid": "77600ceb4692a56ee34834ac1c3eba466299f0097715671bd10b64f3c87f20fa",
+            "blocktime": 1544210151,
+            "time": 1544210151,
+            "locktime": 0,
+            "version": 1,
+            "vin": [
+                {
+                    "txid": "457163c3d0f5eabf8a88efac107dc994405a5d284350f96610ecc79795e19b55",
+                    "vout": 1,
+                    "sequence": 4294967295,
+                    "scriptSig": {
+                        "hex": "48304502210082922a9178874d7cf551835c13499a46247c0654ca35c11a940c56b844442705022054e96ab5174ef0ecbbf3efae22ab1d72d2177d4de05f22ecc61b0d4a32c7a823012103a982906e78dfb2220061438b55478f7fc67e669d1d5ea48189666d50fa54fcdb"
+                    }
+                }
+            ],
+            "vout": [
+                {
+                    "value": 512.03962353,
+                    "n": 0,
+                    "scriptPubKey": {
+                        "hex": "76a9141c7ece8045985cd2d31a78775ea63734880658d188ac"
+                    }
+                },
+                {
+                    "value": 311.22772647,
+                    "n": 1,
+                    "scriptPubKey": {
+                        "hex": "76a91405b3348518ec36c6e5e86d2f80551dcb64414eea88ac"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/rpc/testdata/blocknet_testnet.json
+++ b/tests/rpc/testdata/blocknet_testnet.json
@@ -1,0 +1,46 @@
+{
+    "blockHeight": 79518,
+    "blockHash": "4fe03ccd64f80edf943f6e3708b2fbdfa78224db620ce932a912672f05aab075",
+    "blockTime": 1624782302,
+    "blockTxs": [
+        "a71ab9a308b4f9d78749ef7c8e9652d0dee8ee8a176cfdeadd9f9230c2be37fa",
+        "f838f4510b76fe25ef0304a1a0f4fa249c622f8f04c05bf301b74ada5d66ed7f",
+        "c69ed365e1db3490200dbca40b5137d7d85ce0c583c288fc36ad8b13e9a05602"
+    ],
+    "txDetails": {
+        "c69ed365e1db3490200dbca40b5137d7d85ce0c583c288fc36ad8b13e9a05602": {
+            "hex": "01000000017ead8519ab8848ba62ac1aff62c36ca2ec93c805ac3a072e0b38d91633b5da46010000004847304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601feffffff0206081a838b0000001976a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac00943577000000001976a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac9d360100",
+            "txid": "c69ed365e1db3490200dbca40b5137d7d85ce0c583c288fc36ad8b13e9a05602",
+            "blocktime": 1624782302,
+            "time": 1624782302,
+            "locktime": 79517,
+            "version": 1,
+            "vin": [
+                {
+                    "txid": "46dab53316d9380b2e073aac05c893eca26cc362ff1aac62ba4888ab1985ad7e",
+                    "vout": 1,
+                    "sequence": 4294967294,
+                    "scriptSig": {
+                        "hex": "47304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601"
+                    }
+                }
+            ],
+            "vout": [
+                {
+                    "value": 5991.99975430,
+                    "n": 0,
+                    "scriptPubKey": {
+                        "hex": "76a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac"
+                    }
+                },
+                {
+                    "value": 20.00000000,
+                    "n": 1,
+                    "scriptPubKey": {
+                        "hex": "76a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/sync/testdata/blocknet.json
+++ b/tests/sync/testdata/blocknet.json
@@ -1,0 +1,148 @@
+{
+    "connectBlocks": {
+        "syncRanges": [
+            {"lower": 1196090, "upper": 1196108}
+        ],
+        "blocks": {
+            "1196102": {
+                "height": 1196102,
+                "hash": "b665a3da69fdc61570f5c3329c79bd8d847872b0336a8c4d47f8e15e2eced9d5",
+                "noTxs": 5,
+                "txDetails": [
+                    {
+                        "hex": "0100000001ba591fe66d7498dc21b09e441cce6ba114b5f19497f7d9e753888934311891e0020000006b483045022100fd2b7b6efa010e8a49ca31d5354b26f4192b7dbcc9c1a236a19248856f28acd8022033a731c854edf1bb0c9e660e418e1eb0401851ac036247a4d881aec37b437495012102b0bf3b8be2ac7ad8af3cd9cf49f4e32969f305f370ccde85e9a2c3f9f39f9958ffffffff030000000000000000646a4c615b2232633437323631616664383363346432646430666362643137383937353966643539663361656335313233333066386538363030346137343730373839336638222c224c5443222c3131323030302c22424c4f434b222c383030303030305d60e31600000000001976a9143234abcc10507857b1bae627090a00f17abae89c88acc09b9905000000001976a9143141c5fe04d6a1af56f2ec4a0c7c0667259088fe88ac00000000",
+                        "txid": "c55c8b889414fc9e49b4d000ef17616a36db8359cb7d620071aaf0c9f42f89ee",
+                        "version": 1,
+                        "vin": [
+                            {
+                                "txid": "e091183134898853e7d9f79794f1b514a16bce1c449eb021dc98746de61f59ba",
+                                "vout": 2,
+                                "scriptSig": {
+                                    "hex": "483045022100fd2b7b6efa010e8a49ca31d5354b26f4192b7dbcc9c1a236a19248856f28acd8022033a731c854edf1bb0c9e660e418e1eb0401851ac036247a4d881aec37b437495012102b0bf3b8be2ac7ad8af3cd9cf49f4e32969f305f370ccde85e9a2c3f9f39f9958"
+                                },
+                                "sequence": 4294967295
+                            }
+                        ],
+                        "vout": [
+                            {
+                                "value": 0.00000000,
+                                "n": 0,
+                                "scriptPubKey": {
+                                    "hex": "6a4c615b2232633437323631616664383363346432646430666362643137383937353966643539663361656335313233333066386538363030346137343730373839336638222c224c5443222c3131323030302c22424c4f434b222c383030303030305d"
+                                }
+                            },
+                            {
+                                "value": 0.01500000,
+                                "n": 1,
+                                "scriptPubKey": {
+                                    "hex": "76a9143234abcc10507857b1bae627090a00f17abae89c88ac"
+                                }
+                            },
+                            {
+                                "value": 0.93952960,
+                                "n": 2,
+                                "scriptPubKey": {
+                                    "hex": "76a9143141c5fe04d6a1af56f2ec4a0c7c0667259088fe88ac"
+                                }
+                            }
+                        ],
+                        "time": 1574610144,
+                        "blocktime": 1574610144
+                    },
+                    {
+                        "hex": "01000000016d9ea2cf9d42708f4683479554f851cefbc96b5860f8b9d5d5d60a387c15ac30000000006a47304402201b8b44743371b5486c3076e5b8d9fe62b08408eb9630340bb8a74a41d2e26cb80220249e89124be1d654a1b321ef6210c3bf9566120a74e697f0e6fd377f0c3ca3f40121027b12da2580ba754956b2cffb6467906c2ae0b631a24cbb529d59715ffb4d268dffffffff022056af2f0000000017a914153062a4d104e687b498056ba6ee0dd6566d672087c0545365000000001976a914925ffda9aa7ac8d00a27a49b31ab0d170e23a34b88ac00000000",
+                        "txid": "4ca6111e9573cbe1a0640553cfda504b29321ac126252ee43021e018860100bc",
+                        "version": 1,
+                        "vin": [
+                            {
+                                "txid": "30ac157c380ad6d5d5b9f860586bc9fbce51f854954783468f70429dcfa29e6d",
+                                "vout": 0,
+                                "scriptSig": {
+                                    "hex": "47304402201b8b44743371b5486c3076e5b8d9fe62b08408eb9630340bb8a74a41d2e26cb80220249e89124be1d654a1b321ef6210c3bf9566120a74e697f0e6fd377f0c3ca3f40121027b12da2580ba754956b2cffb6467906c2ae0b631a24cbb529d59715ffb4d268d"
+                                },
+                                "sequence": 4294967295
+                            }
+                        ],
+                        "vout": [
+                            {
+                                "value": 8.00020000,
+                                "n": 0,
+                                "scriptPubKey": {
+                                    "hex": "a914153062a4d104e687b498056ba6ee0dd6566d672087"
+                                }
+                            },
+                            {
+                                "value": 16.99960000,
+                                "n": 1,
+                                "scriptPubKey": {
+                                    "hex": "76a914925ffda9aa7ac8d00a27a49b31ab0d170e23a34b88ac"
+                                }
+                            }
+                        ],
+                        "time": 1574610144,
+                        "blocktime": 1574610144
+                    },
+                    {
+                        "hex": "0100000001bc00018618e02130e42e2526c11a32294b50dacf530564a0e1cb73951e11a64c00000000e52102e80c214924e45b840efaa3d36812525a20bf30b49cdff30d135490e13f1db859473044022017d4f32740c85f3222f46dda27f9d621d83fa69e896883d485ad3aa6b7e2d6b10220523935e6f83cdd4b0b94ee210cb688b2fe66b719c7a59e8306ad96d3c41d2d7901210300faff611741a158d6cd77fd51908da332fc202ff2d1738836904ddcc38b7aef004c566303bd4012b17576a9142030175e207e34f083ea867efd2395603ff2805988ac6776a91404ebf7da670bd48ed846cbbbb2874160daca085c88ad82012188a914abfd467f86a6255c8ee52d45a96db279165340058768ffffffff010008af2f000000001976a9143141c5fe04d6a1af56f2ec4a0c7c0667259088fe88ac00000000",
+                        "txid": "5cefdcb12c581eb310b0f7ea11dd5c1ce4d29bbd2839efa46ae5e808459fa300",
+                        "version": 1,
+                        "vin": [
+                            {
+                                "txid": "4ca6111e9573cbe1a0640553cfda504b29321ac126252ee43021e018860100bc",
+                                "vout": 0,
+                                "scriptSig": {
+                                    "hex": "2102e80c214924e45b840efaa3d36812525a20bf30b49cdff30d135490e13f1db859473044022017d4f32740c85f3222f46dda27f9d621d83fa69e896883d485ad3aa6b7e2d6b10220523935e6f83cdd4b0b94ee210cb688b2fe66b719c7a59e8306ad96d3c41d2d7901210300faff611741a158d6cd77fd51908da332fc202ff2d1738836904ddcc38b7aef004c566303bd4012b17576a9142030175e207e34f083ea867efd2395603ff2805988ac6776a91404ebf7da670bd48ed846cbbbb2874160daca085c88ad82012188a914abfd467f86a6255c8ee52d45a96db279165340058768"
+                                },
+                                "sequence": 4294967295
+                            }
+                        ],
+                        "vout": [
+                            {
+                                "value": 8.00000000,
+                                "n": 0,
+                                "scriptPubKey": {
+                                    "hex": "76a9143141c5fe04d6a1af56f2ec4a0c7c0667259088fe88ac"
+                                }
+                            }
+                        ],
+                        "time": 1574610144,
+                        "blocktime": 1574610144
+                    }
+                ]
+            }
+        }
+    },
+    "handleFork": {
+        "syncRanges": [
+            {"lower": 1195652, "upper": 1195660}
+        ],
+        "fakeBlocks": {
+            "1195658": {
+                "height": 1195658,
+                "hash": "b7c7f10046845211fffd2512197e668219e09c3b62617523efcef1225b71e6fe"
+            },
+            "1195659": {
+                "height": 1195659,
+                "hash": "4c9a16248b3515d25c4f1f86cc8f94ee5adb3a70212f89b7a4453b20c8cc9c60"
+            },
+            "1195660": {
+                "height": 1195660,
+                "hash": "3d034f90d4d2cd4f3e33bfa1af2634ee137402eb3831690582e21fd995c43656"
+            }
+        },
+        "realBlocks": {
+            "1195658": {
+                "height": 1195658,
+                "hash": "a18e2a4aaa71e6fd3a340b8a244e79e4184cdd7131ff5401dfd5897f31c4e64a"
+            },
+            "1195659": {
+                "height": 1195659,
+                "hash": "33850dd8a5915e863daf05230bfb44449dc47e2a5a25be8ec73d5533dfc16bd6"
+            },
+            "1195660": {
+                "height": 1195660,
+                "hash": "11b98c5b118d65d8c5ec88983d5f02f734c13f72d86d6ce8fe39b52b590674d2"
+            }
+        }
+    }
+}

--- a/tests/sync/testdata/blocknet_testnet.json
+++ b/tests/sync/testdata/blocknet_testnet.json
@@ -1,0 +1,86 @@
+{
+    "connectBlocks": {
+        "syncRanges": [
+            {"lower": 79510, "upper": 79529}
+        ],
+        "blocks": {
+            "79518": {
+                "height": 79518,
+                "hash": "4fe03ccd64f80edf943f6e3708b2fbdfa78224db620ce932a912672f05aab075",
+                "noTxs": 3,
+                "txDetails": [
+                    {
+                        "hex": "01000000017ead8519ab8848ba62ac1aff62c36ca2ec93c805ac3a072e0b38d91633b5da46010000004847304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601feffffff0206081a838b0000001976a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac00943577000000001976a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac9d360100",
+                        "txid": "c69ed365e1db3490200dbca40b5137d7d85ce0c583c288fc36ad8b13e9a05602",
+                        "version": 1,
+                        "vin": [
+                            {
+                                "txid": "46dab53316d9380b2e073aac05c893eca26cc362ff1aac62ba4888ab1985ad7e",
+                                "vout": 1,
+                                "scriptSig": {
+                                    "hex": "47304402207970483f33f61899997d98672c2934d643f1bd35704afc31bcb8bf7b2eec70e602206e834bd611d1222bb27b84500733530ab9d5ab4f7059af4a1fd720af03d297d601"
+                                },
+                                "value": 6011.99977340,
+                                "sequence": 4294967294
+                            }
+                        ],
+                        "vout": [
+                            {
+                                "value": 5991.99975430,
+                                "valueSat": 599199975430,
+                                "n": 0,
+                                "scriptPubKey": {
+                                    "hex": "76a9142cb4d2fc255cc88d0a6fca88fb4b2ef3518e211d88ac"
+                                }
+                            },
+                            {
+                                "value": 20.00000000,
+                                "valueSat": 2000000000,
+                                "n": 1,
+                                "scriptPubKey": {
+                                    "hex": "76a914b60dfcb590be22ed373535ccdcc5eb090fbc451988ac"
+                                }
+                            }
+                        ],
+                        "time": 1624782302,
+                        "blocktime": 1624782302
+                    }
+                ]
+            }
+            
+        }
+    },
+    "connectBlocks": {
+        "syncRanges": [
+            {"lower": 112810, "upper": 112817}
+        ],
+        "fakeBlocks": {
+            "112815": {
+                "height": 112815,
+                "hash": "4079e46a180371566c3a1fb03e519dc02dcba526b9434235fe72e5ef55862b6a"
+            },
+            "112816": {
+                "height": 112816,
+                "hash": "24131539f87ae918e3dbe5a9ac2fcf87276ff7dac37c08f1b43eeb7d34792e91"
+            },
+            "112817": {
+                "height": 112817,
+                "hash": "36b43bbeccdb35f3979d1c1b10d4c86b2738a13e35543fe70edec7d4ac49af58"
+            }
+        },
+        "realBlocks": {
+            "112815": {
+                "height": 112815,
+                "hash": "e9fc303ab6c5c87722ea39e1536a6affbf8fa3e1c717fe32147e1735950b3285"
+            },
+            "112816": {
+                "height": 112816,
+                "hash": "0a86314aba717027a195e6188bbadef385fa20240145f9728c665aac97721345"
+            },
+            "112817": {
+                "height": 112817,
+                "hash": "d11159a5fe869e583c6edb985b10add31698e52e8854f2f45f53d666e7ae1fdf"
+            }
+        }
+    }
+}

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -41,7 +41,12 @@
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
-   },
+    },
+    "blocknet": {
+        "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
+                 "EstimateSmartFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
+        "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
+    },
     "cpuchain": {
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "EstimateSmartFee", "EstimateFee"],

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -47,6 +47,11 @@
                  "EstimateSmartFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
     },
+    "blocknet_testnet": {
+        "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
+                 "EstimateSmartFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
+        "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
+    },
     "cpuchain": {
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "EstimateSmartFee", "EstimateFee"],


### PR DESCRIPTION
Add Blocknet support to Blockbook.

Coin Information:
- Website: https://blocknet.co/
- Docs: https://docs.blocknet.co/
- GitHub: https://github.com/blocknetdx
- Coin Market Cap: https://coinmarketcap.com/currencies/blocknet

Projects running on Blocknet:
- BlockDX: https://blockdx.net/ (decentralized exchange)
- XQuery: https://xquery.io/ (decentralized blockchain data indexing)
