### PR TITLE
Fix issues found by staticcheck

### DIFF
--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -157,11 +157,9 @@ func (b *EthereumRPC) Initialize() error {
 	case MainNet:
 		b.Testnet = false
 		b.Network = "livenet"
-		break
 	case TestNet:
 		b.Testnet = true
 		b.Network = "testnet"
-		break
 	case TestNetGoerli:
 		b.Testnet = true
 		b.Network = "goerli"

--- a/bchain/mq.go
+++ b/bchain/mq.go
@@ -97,10 +97,8 @@ func (mq *MQ) run(callback func(NotificationType)) {
 			switch string(msg[0]) {
 			case "hashblock":
 				nt = NotificationNewBlock
-				break
 			case "hashtx":
 				nt = NotificationNewTx
-				break
 			default:
 				nt = NotificationUnknown
 				glog.Infof("MQ: NotificationUnknown %v", string(msg[0]))

--- a/bchain/mq.go
+++ b/bchain/mq.go
@@ -92,7 +92,7 @@ func (mq *MQ) run(callback func(NotificationType)) {
 		} else {
 			repeatedError = false
 		}
-		if msg != nil && len(msg) >= 3 {
+		if len(msg) >= 3 {
 			var nt NotificationType
 			switch string(msg[0]) {
 			case "hashblock":

--- a/tests/dbtestdata/fakechain.go
+++ b/tests/dbtestdata/fakechain.go
@@ -188,7 +188,7 @@ func (c *fakeBlockChain) GetTransactionForMempool(txid string) (v *bchain.Tx, er
 }
 
 func (c *fakeBlockChain) EstimateSmartFee(blocks int, conservative bool) (v big.Int, err error) {
-	if conservative == false {
+	if !conservative {
 		v.SetInt64(int64(blocks)*100 - 1)
 	} else {
 		v.SetInt64(int64(blocks) * 100)


### PR DESCRIPTION
Found by running the latest `staticcheck` from https://github.com/dominikh/go-tools

All found issues are mostly nits, great work! 

Feel free to close this PR if you think that addressed issues are not worth fixing - they are nits as well.

Full report below:

```
$ staticcheck ./...
bchain/basechain.go:44:14: error strings should not be capitalized (ST1005)
bchain/basechain.go:49:12: error strings should not be capitalized (ST1005)
bchain/basechain.go:54:12: error strings should not be capitalized (ST1005)
bchain/basechain.go:59:14: error strings should not be capitalized (ST1005)
bchain/basechain.go:64:14: error strings should not be capitalized (ST1005)
bchain/coins/bch/bcashparser.go:71:15: error strings should not be capitalized (ST1005)
bchain/coins/bch/bcashrpc.go:78:6: type cmdEstimateSmartFee is unused (U1000)
bchain/coins/btc/codec.go:27:23: error strings should not be capitalized (ST1005)
bchain/coins/dcr/decredrpc.go:598:21: func (*DecredRPC).decodeRawTransaction is unused (U1000)
bchain/coins/ecash/ecashparser.go:71:15: error strings should not be capitalized (ST1005)
bchain/coins/ecash/ecashrpc.go:78:6: type cmdEstimateSmartFee is unused (U1000)
bchain/coins/eth/erc20.go:18:5: var erc20abi is unused (U1000)
bchain/coins/eth/ethparser.go:9:2: "github.com/golang/protobuf/proto" is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (SA1019)
bchain/coins/eth/ethrpc.go:160:3: redundant break statement (S1023)
bchain/coins/eth/ethrpc.go:164:3: redundant break statement (S1023)
bchain/coins/eth/ethtx.pb.go:225:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/coins/eth/ethtx.pb.go:226:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/coins/eth/ethtx.pb.go:227:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/coins/eth/ethtx.pb.go:228:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/coins/eth/ethtx.pb.go:231:15: proto.RegisterFile is deprecated: Use protoregistry.GlobalFiles.RegisterFile instead.  (SA1019)
bchain/coins/koto/kotorpc.go:112:6: func isErrBlockNotFound is unused (U1000)
bchain/coins/snowgem/snowgemrpc.go:113:6: func isErrBlockNotFound is unused (U1000)
bchain/coins/trezarcoin/trezarcoinrpc.go:111:6: func isErrBlockNotFound is unused (U1000)
bchain/mq.go:95:6: should omit nil check; len() for [][]byte is defined as zero (S1009)
bchain/mq.go:100:5: redundant break statement (S1023)
bchain/mq.go:103:5: redundant break statement (S1023)
bchain/tx.pb.go:199:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/tx.pb.go:200:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/tx.pb.go:201:2: proto.RegisterType is deprecated: Use protoregistry.GlobalTypes.RegisterMessage instead.  (SA1019)
bchain/tx.pb.go:204:15: proto.RegisterFile is deprecated: Use protoregistry.GlobalFiles.RegisterFile instead.  (SA1019)
bchain/types.go:32:22: error strings should not be capitalized (ST1005)
bchain/types.go:35:19: error strings should not be capitalized (ST1005)
build/tools/templates.go:170:16: error strings should not be capitalized (ST1005)
build/tools/templates.go:179:16: error strings should not be capitalized (ST1005)
tests/dbtestdata/fakechain.go:187:14: error strings should not be capitalized (ST1005)
tests/dbtestdata/fakechain.go:191:5: should omit comparison to bool constant, can be simplified to !conservative (S1002)
tests/dbtestdata/fakechain.go:208:13: error strings should not be capitalized (ST1005)
tests/dbtestdata/fakechain.go:218:14: error strings should not be capitalized (ST1005)
```
