### PR TITLE
Add ARM64 paths to selected coins

### DIFF
--- a/configs/coins/bitcoin.json
+++ b/configs/coins/bitcoin.json
@@ -39,6 +39,12 @@
     "client_config_file": "bitcoin_client.conf",
     "additional_params": {
       "deprecatedrpc": "estimatefee"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-aarch64-linux-gnu.tar.gz",
+        "verification_source": "06f4c78271a77752ba5990d60d81b1751507f77efda1e5981b4e92fd4d9969fb"
+      }
     }
   },
   "blockbook": {

--- a/configs/coins/bitcoin_signet.json
+++ b/configs/coins/bitcoin_signet.json
@@ -41,6 +41,12 @@
     "client_config_file": "bitcoin_client.conf",
     "additional_params": {
       "deprecatedrpc": "estimatefee"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-aarch64-linux-gnu.tar.gz",
+        "verification_source": "06f4c78271a77752ba5990d60d81b1751507f77efda1e5981b4e92fd4d9969fb"
+      }
     }
   },
   "blockbook": {

--- a/configs/coins/bitcoin_testnet.json
+++ b/configs/coins/bitcoin_testnet.json
@@ -41,6 +41,12 @@
     "client_config_file": "bitcoin_client.conf",
     "additional_params": {
       "deprecatedrpc": "estimatefee"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-aarch64-linux-gnu.tar.gz",
+        "verification_source": "06f4c78271a77752ba5990d60d81b1751507f77efda1e5981b4e92fd4d9969fb"
+      }
     }
   },
   "blockbook": {

--- a/configs/coins/dogecoin.json
+++ b/configs/coins/dogecoin.json
@@ -42,6 +42,13 @@
       "rpcthreads": 16,
       "upnp": 0,
       "whitelist": "127.0.0.1"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-aarch64-linux-gnu.tar.gz",
+        "verification_source": "87419c29607b2612746fccebd694037e4be7600fc32198c4989f919be20952db",
+        "exclude_files": []
+      }
     }
   },
   "blockbook": {

--- a/configs/coins/dogecoin_testnet.json
+++ b/configs/coins/dogecoin_testnet.json
@@ -44,6 +44,13 @@
       "rpcthreads": 16,
       "upnp": 0,
       "whitelist": "127.0.0.1"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-aarch64-linux-gnu.tar.gz",
+        "verification_source": "87419c29607b2612746fccebd694037e4be7600fc32198c4989f919be20952db",
+        "exclude_files": []
+      }
     }
   },
   "blockbook": {

--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -36,7 +36,13 @@
     "protect_memory": true,
     "mainnet": true,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
   },
   "blockbook": {
     "package_name": "blockbook-ethereum",

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -36,7 +36,13 @@
     "protect_memory": true,
     "mainnet": true,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
   },
   "blockbook": {
     "package_name": "blockbook-ethereum-archive",

--- a/configs/coins/ethereum_archive_consensus.json
+++ b/configs/coins/ethereum_archive_consensus.json
@@ -33,7 +33,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
   },
   "meta": {
     "package_maintainer": "IT",

--- a/configs/coins/ethereum_consensus.json
+++ b/configs/coins/ethereum_consensus.json
@@ -33,7 +33,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
   },
   "meta": {
     "package_maintainer": "IT",

--- a/configs/coins/ethereum_testnet_goerli.json
+++ b/configs/coins/ethereum_testnet_goerli.json
@@ -36,7 +36,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
   },
   "blockbook": {
     "package_name": "blockbook-ethereum-testnet-goerli",

--- a/configs/coins/ethereum_testnet_goerli_archive.json
+++ b/configs/coins/ethereum_testnet_goerli_archive.json
@@ -36,7 +36,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
   },
   "blockbook": {
     "package_name": "blockbook-ethereum-testnet-goerli-archive",

--- a/configs/coins/ethereum_testnet_goerli_archive_consensus.json
+++ b/configs/coins/ethereum_testnet_goerli_archive_consensus.json
@@ -33,7 +33,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
   },
   "meta": {
     "package_maintainer": "IT",

--- a/configs/coins/ethereum_testnet_goerli_consensus.json
+++ b/configs/coins/ethereum_testnet_goerli_consensus.json
@@ -33,7 +33,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
   },
   "meta": {
     "package_maintainer": "IT",

--- a/configs/coins/ethereum_testnet_ropsten.json
+++ b/configs/coins/ethereum_testnet_ropsten.json
@@ -36,7 +36,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
   },
   "blockbook": {
     "package_name": "blockbook-ethereum-testnet-ropsten",

--- a/configs/coins/ethereum_testnet_ropsten_archive.json
+++ b/configs/coins/ethereum_testnet_ropsten_archive.json
@@ -36,7 +36,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
   },
   "blockbook": {
     "package_name": "blockbook-ethereum-testnet-ropsten-archive",

--- a/configs/coins/ethereum_testnet_ropsten_archive_consensus.json
+++ b/configs/coins/ethereum_testnet_ropsten_archive_consensus.json
@@ -33,7 +33,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
   },
   "meta": {
     "package_maintainer": "IT",

--- a/configs/coins/ethereum_testnet_ropsten_consensus.json
+++ b/configs/coins/ethereum_testnet_ropsten_consensus.json
@@ -33,7 +33,13 @@
     "protect_memory": true,
     "mainnet": false,
     "server_config_file": "",
-    "client_config_file": ""
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
   },
   "meta": {
     "package_maintainer": "IT",

--- a/configs/coins/litecoin.json
+++ b/configs/coins/litecoin.json
@@ -39,6 +39,12 @@
     "client_config_file": "bitcoin_like_client.conf",
     "additional_params": {
       "whitelist": "127.0.0.1"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://download.litecoin.org/litecoin-0.21.2.1/linux/litecoin-0.21.2.1-aarch64-linux-gnu.tar.gz",
+        "verification_source": "https://download.litecoin.org/litecoin-0.21.2.1/linux/litecoin-0.21.2.1-aarch64-linux-gnu.tar.gz.asc"
+      }
     }
   },
   "blockbook": {

--- a/configs/coins/litecoin_testnet.json
+++ b/configs/coins/litecoin_testnet.json
@@ -41,6 +41,12 @@
     "client_config_file": "bitcoin_like_client.conf",
     "additional_params": {
       "whitelist": "127.0.0.1"
+    },
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://download.litecoin.org/litecoin-0.21.2.1/linux/litecoin-0.21.2.1-aarch64-linux-gnu.tar.gz",
+        "verification_source": "https://download.litecoin.org/litecoin-0.21.2.1/linux/litecoin-0.21.2.1-aarch64-linux-gnu.tar.gz.asc"
+      }
     }
   },
   "blockbook": {


### PR DESCRIPTION
- arm64 binary paths added for backends: btc, btc testnet, btc signet, eth, eth ropsten, eth goerli, ltc, ltc testnet, doge, doge testnet
