### PR TITLE
feat: add ethereum_testnet_sepolia

### DIFF
--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -74,6 +74,8 @@ func init() {
 	BlockChainFactories["Ethereum Testnet Ropsten Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Goerli"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Goerli Archive"] = eth.NewEthereumRPC
+	BlockChainFactories["Ethereum Testnet Sepolia"] = eth.NewEthereumRPC
+	BlockChainFactories["Ethereum Testnet Sepolia Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Bcash"] = bch.NewBCashRPC
 	BlockChainFactories["Bcash Testnet"] = bch.NewBCashRPC
 	BlockChainFactories["Bgold"] = btg.NewBGoldRPC

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -34,6 +34,8 @@ const (
 	TestNet EthereumNet = 3
 	// TestNetGoerli is Goerli test network
 	TestNetGoerli EthereumNet = 5
+	// TestNetSepolia is Sepolia test network
+	TestNetSepolia EthereumNet = 11155111
 )
 
 // Configuration represents json config file
@@ -175,6 +177,9 @@ func (b *EthereumRPC) Initialize() error {
 	case TestNetGoerli:
 		b.Testnet = true
 		b.Network = "goerli"
+	case TestNetSepolia:
+		b.Testnet = true
+		b.Network = "sepolia"
 	default:
 		return errors.Errorf("Unknown network id %v", id)
 	}

--- a/configs/coins/ethereum_testnet_sepolia.json
+++ b/configs/coins/ethereum_testnet_sepolia.json
@@ -1,0 +1,70 @@
+{
+  "coin": {
+    "name": "Ethereum Testnet Sepolia",
+    "shortcut": "gSEP",
+    "label": "Ethereum Sepolia",
+    "alias": "ethereum_testnet_sepolia"
+  },
+  "ports": {
+    "backend_rpc": 18076,
+    "backend_message_queue": 0,
+    "backend_p2p": 48376,
+    "backend_http": 18176,
+    "backend_authrpc": 18576,
+    "blockbook_internal": 19076,
+    "blockbook_public": 19176
+  },
+  "ipc": {
+    "rpc_url_template": "ws://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_timeout": 25
+  },
+  "backend": {
+    "package_name": "backend-ethereum-testnet-sepolia",
+    "package_revision": "satoshilabs-1",
+    "system_user": "ethereum",
+    "version": "1.10.23-d901d853",
+    "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.23-d901d853.tar.gz",
+    "verification_type": "gpg",
+    "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.23-d901d853.tar.gz.asc",
+    "extract_command": "tar -C backend --strip 1 -xf",
+    "exclude_files": [],
+    "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/geth --sepolia --syncmode full --txlookuplimit 0 --ipcdisable --cache 1024 --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --port {{.Ports.BackendP2P}} --ws --ws.addr 127.0.0.1 --ws.port {{.Ports.BackendRPC}} --ws.origins \"*\" --ws.api \"eth,net,web3,debug,txpool\" --http --http.port {{.Ports.BackendHttp}} -http.addr 127.0.0.1 --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --authrpc.port {{.Ports.BackendAuthRpc}} 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log",
+    "postinst_script_template": "",
+    "service_type": "simple",
+    "service_additional_params_template": "",
+    "protect_memory": true,
+    "mainnet": false,
+    "server_config_file": "",
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
+  },
+  "blockbook": {
+    "package_name": "blockbook-ethereum-testnet-sepolia",
+    "system_user": "blockbook-ethereum",
+    "internal_binding_template": ":{{.Ports.BlockbookInternal}}",
+    "public_binding_template": ":{{.Ports.BlockbookPublic}}",
+    "explorer_url": "",
+    "additional_params": "",
+    "block_chain": {
+      "parse": true,
+      "mempool_workers": 8,
+      "mempool_sub_workers": 2,
+      "block_addresses_to_keep": 3000,
+      "additional_params": {
+        "consensusNodeVersion": "http://localhost:17576/eth/v1/node/version",
+        "mempoolTxTimeoutHours": 12,
+        "queryBackendOnMempoolResync": false
+      }
+    }
+  },
+  "meta": {
+    "package_maintainer": "IT",
+    "package_maintainer_email": "it@satoshilabs.com"
+  }
+}

--- a/configs/coins/ethereum_testnet_sepolia_archive.json
+++ b/configs/coins/ethereum_testnet_sepolia_archive.json
@@ -1,0 +1,75 @@
+{
+  "coin": {
+    "name": "Ethereum Testnet Sepolia Archive",
+    "shortcut": "gSEP",
+    "label": "Ethereum Sepolia",
+    "alias": "ethereum_testnet_sepolia_archive"
+  },
+  "ports": {
+    "backend_rpc": 18086,
+    "backend_message_queue": 0,
+    "backend_p2p": 48386,
+    "backend_http": 18186,
+    "backend_authrpc": 18586,
+    "blockbook_internal": 19086,
+    "blockbook_public": 19186
+  },
+  "ipc": {
+    "rpc_url_template": "ws://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_timeout": 25
+  },
+  "backend": {
+    "package_name": "backend-ethereum-testnet-sepolia-archive",
+    "package_revision": "satoshilabs-1",
+    "system_user": "ethereum",
+    "version": "1.10.23-d901d853",
+    "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.23-d901d853.tar.gz",
+    "verification_type": "gpg",
+    "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.23-d901d853.tar.gz.asc",
+    "extract_command": "tar -C backend --strip 1 -xf",
+    "exclude_files": [],
+    "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/geth --sepolia --syncmode full --gcmode archive --txlookuplimit 0 --ipcdisable --cache 1024 --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --port {{.Ports.BackendP2P}} --ws --ws.addr 127.0.0.1 --ws.port {{.Ports.BackendRPC}} --ws.origins \"*\" --ws.api \"eth,net,web3,debug,txpool\" --http --http.port {{.Ports.BackendHttp}} -http.addr 127.0.0.1 --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --authrpc.port {{.Ports.BackendAuthRpc}} 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log",
+    "postinst_script_template": "",
+    "service_type": "simple",
+    "service_additional_params_template": "",
+    "protect_memory": true,
+    "mainnet": false,
+    "server_config_file": "",
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz",
+        "verification_source": "https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.10.23-d901d853.tar.gz.asc"
+      }
+    }
+  },
+  "blockbook": {
+    "package_name": "blockbook-ethereum-testnet-sepolia-archive",
+    "system_user": "blockbook-ethereum",
+    "internal_binding_template": ":{{.Ports.BlockbookInternal}}",
+    "public_binding_template": ":{{.Ports.BlockbookPublic}}",
+    "explorer_url": "",
+    "additional_params": "-workers=16",
+    "block_chain": {
+      "parse": true,
+      "mempool_workers": 8,
+      "mempool_sub_workers": 2,
+      "block_addresses_to_keep": 3000,
+      "additional_params": {
+        "consensusNodeVersion": "http://localhost:17586/eth/v1/node/version",
+        "address_aliases": true,
+        "mempoolTxTimeoutHours": 12,
+        "processInternalTransactions": true,
+        "queryBackendOnMempoolResync": false,
+        "fiat_rates-disabled": "coingecko",
+        "fiat_rates_params": "{\"url\": \"https://api.coingecko.com/api/v3\", \"coin\": \"ethereum\",\"platformIdentifier\": \"ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",
+        "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+      }
+    }
+  },
+  "meta": {
+    "package_maintainer": "IT",
+    "package_maintainer_email": "it@satoshilabs.com"
+  }
+}

--- a/configs/coins/ethereum_testnet_sepolia_archive_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_archive_consensus.json
@@ -1,0 +1,52 @@
+{
+  "coin": {
+    "name": "Ethereum Testnet Sepolia Archive",
+    "shortcut": "gSEP",
+    "label": "Ethereum Sepolia",
+    "alias": "ethereum_testnet_sepolia_archive_consensus",
+    "execution_alias": "ethereum_testnet_sepolia_archive"
+  },
+  "ports": {
+    "backend_rpc": 18086,
+    "backend_message_queue": 0,
+    "backend_p2p": 48386,
+    "backend_http": 18186,
+    "backend_authrpc": 18586,
+    "blockbook_internal": 19086,
+    "blockbook_public": 19186
+  },
+  "ipc": {
+    "rpc_url_template": "ws://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_timeout": 25
+  },
+  "backend": {
+    "package_name": "backend-ethereum-testnet-sepolia-archive-consensus",
+    "package_revision": "satoshilabs-1",
+    "system_user": "ethereum",
+    "version": "3.1.1",
+    "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-amd64",
+    "verification_type": "sha256",
+    "verification_source": "917c37f41506182da7061aa2e9a15bdecc5d30eaafdc2688c9b0fba7073a7d05",
+    "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
+    "exclude_files": [],
+    "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --sepolia --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17586 --rpc-port=17587 --monitoring-port=17548 --p2p-tcp-port=13676 --p2p-udp-port=12676 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_sepolia_archive/backend/geth/jwtsecret --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log",
+    "postinst_script_template": "wget https://github.com/eth-clients/merge-testnets/raw/302fe27afdc7a9d15b1766a0c0a9d64319140255/sepolia/genesis.ssz -O {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz",
+    "service_type": "simple",
+    "service_additional_params_template": "",
+    "protect_memory": true,
+    "mainnet": false,
+    "server_config_file": "",
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
+  },
+  "meta": {
+    "package_maintainer": "IT",
+    "package_maintainer_email": "it@satoshilabs.com"
+  }
+}

--- a/configs/coins/ethereum_testnet_sepolia_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_consensus.json
@@ -1,0 +1,52 @@
+{
+  "coin": {
+    "name": "Ethereum Testnet Sepolia",
+    "shortcut": "gSEP",
+    "label": "Ethereum Sepolia",
+    "alias": "ethereum_testnet_sepolia_consensus",
+    "execution_alias": "ethereum_testnet_sepolia"
+  },
+  "ports": {
+    "backend_rpc": 18076,
+    "backend_message_queue": 0,
+    "backend_p2p": 48376,
+    "backend_http": 18176,
+    "backend_authrpc": 18576,
+    "blockbook_internal": 19076,
+    "blockbook_public": 19176
+  },
+  "ipc": {
+    "rpc_url_template": "ws://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_timeout": 25
+  },
+  "backend": {
+    "package_name": "backend-ethereum-testnet-sepolia-consensus",
+    "package_revision": "satoshilabs-1",
+    "system_user": "ethereum",
+    "version": "3.1.1",
+    "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-amd64",
+    "verification_type": "sha256",
+    "verification_source": "917c37f41506182da7061aa2e9a15bdecc5d30eaafdc2688c9b0fba7073a7d05",
+    "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
+    "exclude_files": [],
+    "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --sepolia --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17576 --rpc-port=17577 --monitoring-port=17578 --p2p-tcp-port=13576 --p2p-udp-port=12576 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_sepolia/backend/geth/jwtsecret --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
+    "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log",
+    "postinst_script_template": "wget https://github.com/eth-clients/merge-testnets/raw/302fe27afdc7a9d15b1766a0c0a9d64319140255/sepolia/genesis.ssz -O {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz",
+    "service_type": "simple",
+    "service_additional_params_template": "",
+    "protect_memory": true,
+    "mainnet": false,
+    "server_config_file": "",
+    "client_config_file": "",
+    "platforms": {
+      "arm64": {
+        "binary_url": "https://github.com/prysmaticlabs/prysm/releases/download/v3.1.1/beacon-chain-v3.1.1-linux-arm64",
+        "verification_source": "97665ac0ff54c9f8f97c99949519d13eea964a09decc17e2830b14c9d6dc1b24"
+      }
+    }
+  },
+  "meta": {
+    "package_maintainer": "IT",
+    "package_maintainer_email": "it@satoshilabs.com"
+  }
+}

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -49,6 +49,7 @@
 | Bitcoin Signet         | 19020                   | 19120                 | 18020            | 48320                       |
 | Bitcoin Regtest        | 19021                   | 19121                 | 18021            | 48321                       |
 | Ethereum Goerli        | 19026                   | 19126                 | 18026            | 48326 p2p                   |
+| Ethereum Sepolia       | 19176                   | 19176                 | 18076            | 48376 p2p                   |
 | Bitcoin Testnet        | 19030                   | 19130                 | 18030            | 48330                       |
 | Bitcoin Cash Testnet   | 19031                   | 19131                 | 18031            | 48331                       |
 | Zcash Testnet          | 19032                   | 19132                 | 18032            | 48332                       |


### PR DESCRIPTION
I've added support for Ethereum Sepolia Testnet. Pls check if this is OK with you, I allocated ports at my discretion so it does not clash with anything in the project.

Sepolia is lightweight post-merge testnet chain, easy to sync. Quite good for dev environments as Goerli is huge and sometimes clogged. 

I've compiled it and the whole system works.