### PR TITLE
Updating the documentation for POST of sendtx

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ GET /api/v1/utxo/<address>
 GET /api/v1/block/<block height | block hash>
 GET /api/v1/estimatefee/<number of blocks>
 GET /api/v1/sendtx/<hex tx data>
-POST /api/v1/sendtx (hex tx data in request body)  
+POST /api/v1/sendtx/ (hex tx data in request body)  
 ```
 
 ### Socket.io API
@@ -579,7 +579,7 @@ Sends new transaction to backend.
 
 ```
 GET /api/v2/sendtx/<hex tx data>
-POST /api/v2/sendtx (hex tx data in request body)  
+POST /api/v2/sendtx/ (hex tx data in request body)  NB: the '/' symbol at the end is mandatory.
 ```
 
 Response:


### PR DESCRIPTION
The POST sendtx has a trailing '/' character at the end. Without it, blockbook returns aways "missing inputs". With that PR I'm adding the information.