### PR TITLE
firo 0.14.11.1 → 0.14.12.0

### DIFF
--- a/bchain/coins/firo/firoparser.go
+++ b/bchain/coins/firo/firoparser.go
@@ -21,6 +21,7 @@ const (
 	OpLelantusMint      = 0xc5
 	OpLelantusJMint     = 0xc6
 	OpLelantusJoinSplit = 0xc7
+	OpLelantusJoinSplitPayload = 0xc9
 
 	MainnetMagic wire.BitcoinNet = 0xe3d9fef1
 	TestnetMagic wire.BitcoinNet = 0xcffcbeea
@@ -121,6 +122,8 @@ func (p *FiroParser) GetAddressesFromAddrDesc(addrDesc bchain.AddressDescriptor)
 		case OpLelantusJMint:
 			return []string{"LelantusJMint"}, false, nil
 		case OpLelantusJoinSplit:
+			return []string{"LelantusJoinSplit"}, false, nil
+		case OpLelantusJoinSplitPayload:
 			return []string{"LelantusJoinSplit"}, false, nil
 		}
 	}

--- a/configs/coins/firo.json
+++ b/configs/coins/firo.json
@@ -22,10 +22,10 @@
     "package_name": "backend-firo",
     "package_revision": "satoshilabs-1",
     "system_user": "firo",
-    "version": "0.14.11.1",
-    "binary_url": "https://github.com/firoorg/firo/releases/download/v0.14.11.1/firo-0.14.11.1-linux64.tar.gz",
+    "version": "0.14.12.0",
+    "binary_url": "https://github.com/firoorg/firo/releases/download/v0.14.12.0/firo-0.14.12.0-linux64.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "8669ae8ce3356deee2512a4da133eab347c704cf47c865caf9ea10b46ba8b477",
+    "verification_source": "47c7ae07f85189b6b11068848a5c8f930528e6edfff14fd3c6e6305a01e8da77",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/firo-qt",


### PR DESCRIPTION
- Update Firo binary to [v0.14.12.0.](https://github.com/firoorg/firo/releases/tag/v0.14.12.0)
- Fix parsing of MTP blocks for stripped blockchain data.
- Fix display of new joinsplit addresses.