### PR TITLE
Add gcc into shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
     snappy
     zeromq
     zlib
+    gcc
   ];
   shellHook = ''
     export CGO_LDFLAGS="-L${stdenv.cc.cc.lib}/lib -lrocksdb -lz -lbz2 -lsnappy -llz4 -lm -lstdc++"


### PR DESCRIPTION
So that `nix-shell` command will completely setup the development environment on `NixOS`