### PR TITLE
Change symbol for Sepolia

### DIFF
--- a/configs/coins/ethereum_testnet_sepolia.json
+++ b/configs/coins/ethereum_testnet_sepolia.json
@@ -1,7 +1,7 @@
 {
     "coin": {
         "name": "Ethereum Testnet Sepolia",
-        "shortcut": "gSEP",
+        "shortcut": "tETH",
         "label": "Ethereum Sepolia",
         "alias": "ethereum_testnet_sepolia"
     },

--- a/configs/coins/ethereum_testnet_sepolia_archive.json
+++ b/configs/coins/ethereum_testnet_sepolia_archive.json
@@ -1,7 +1,7 @@
 {
     "coin": {
         "name": "Ethereum Testnet Sepolia Archive",
-        "shortcut": "gSEP",
+        "shortcut": "tETH",
         "label": "Ethereum Sepolia",
         "alias": "ethereum_testnet_sepolia_archive"
     },

--- a/configs/coins/ethereum_testnet_sepolia_archive_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_archive_consensus.json
@@ -1,7 +1,7 @@
 {
   "coin": {
     "name": "Ethereum Testnet Sepolia Archive",
-    "shortcut": "gSEP",
+    "shortcut": "tETH",
     "label": "Ethereum Sepolia",
     "alias": "ethereum_testnet_sepolia_archive_consensus",
     "execution_alias": "ethereum_testnet_sepolia_archive"

--- a/configs/coins/ethereum_testnet_sepolia_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_consensus.json
@@ -1,7 +1,7 @@
 {
   "coin": {
     "name": "Ethereum Testnet Sepolia",
-    "shortcut": "gSEP",
+    "shortcut": "tETH",
     "label": "Ethereum Sepolia",
     "alias": "ethereum_testnet_sepolia_consensus",
     "execution_alias": "ethereum_testnet_sepolia"


### PR DESCRIPTION
Adding a new testnet to Suite and after a discussion with guys from product (@sime, @Hannsek) we would like to have `tETH` symbol for Sepolia testnet.