### PR TITLE
Remove Ropsten

### DIFF
--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -73,8 +73,6 @@ func init() {
 	BlockChainFactories["Ethereum"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Classic"] = eth.NewEthereumRPC
-	BlockChainFactories["Ethereum Testnet Ropsten"] = eth.NewEthereumRPC
-	BlockChainFactories["Ethereum Testnet Ropsten Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Goerli"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Goerli Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Sepolia"] = eth.NewEthereumRPC

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -30,8 +30,6 @@ type Network uint32
 const (
 	// MainNet is production network
 	MainNet Network = 1
-	// TestNet is Ropsten test network
-	TestNet Network = 3
 	// TestNetGoerli is Goerli test network
 	TestNetGoerli Network = 5
 	// TestNetSepolia is Sepolia test network
@@ -143,9 +141,6 @@ func (b *EthereumRPC) Initialize() error {
 	case MainNet:
 		b.Testnet = false
 		b.Network = "livenet"
-	case TestNet:
-		b.Testnet = true
-		b.Network = "testnet"
 	case TestNetGoerli:
 		b.Testnet = true
 		b.Network = "goerli"


### PR DESCRIPTION
Ropsten testnet is depracted as of Q4 2022 so no need to have it (and it's also not in Trezor Suite).