### PR TITLE
Update type for `gasPrice`

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -231,7 +231,7 @@ type EthereumSpecific struct {
 	Nonce             uint64                                 `json:"nonce"`
 	GasLimit          *big.Int                               `json:"gasLimit"`
 	GasUsed           *big.Int                               `json:"gasUsed,omitempty"`
-	GasPrice          *Amount                                `json:"gasPrice"`
+	GasPrice          *Amount                                `json:"gasPrice,omitempty"`
 	Data              string                                 `json:"data,omitempty"`
 	ParsedData        *bchain.EthereumParsedInputData        `json:"parsedData,omitempty"`
 	InternalTransfers []EthereumInternalTransfer             `json:"internalTransfers,omitempty"`

--- a/blockbook-api.ts
+++ b/blockbook-api.ts
@@ -32,7 +32,7 @@ export interface EthereumSpecific {
     nonce: number;
     gasLimit: number;
     gasUsed?: number;
-    gasPrice: string;
+    gasPrice?: string;
     data?: string;
     parsedData?: EthereumParsedInputData;
     internalTransfers?: EthereumInternalTransfer[];


### PR DESCRIPTION
Changed type for `gasPrice` because it can be undefined.