### PR TITLE
PIVX (+testnet) 5.5.0 → 5.6.1

### DIFF
--- a/configs/coins/pivx.json
+++ b/configs/coins/pivx.json
@@ -22,10 +22,10 @@
     "package_name": "backend-pivx",
     "package_revision": "satoshilabs-1",
     "system_user": "pivx",
-    "version": "5.5.0",
-    "binary_url": "https://github.com/PIVX-Project/PIVX/releases/download/v5.5.0/pivx-5.5.0-x86_64-linux-gnu.tar.gz",
+    "version": "5.6.1",
+    "binary_url": "https://github.com/PIVX-Project/PIVX/releases/download/v5.6.1/pivx-5.6.1-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "4a56e2cdaa12eaf30aab4acf676770181b46545d3cf6deb25b50bc81c55fb2b3",
+    "verification_source": "6704625c63ff73da8c57f0fbb1dab6f1e4bd8f62c17467e05f52a64012a0ee2f",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/pivx-qt"

--- a/configs/coins/pivx_testnet.json
+++ b/configs/coins/pivx_testnet.json
@@ -22,10 +22,10 @@
     "package_name": "backend-pivx",
     "package_revision": "satoshilabs-1",
     "system_user": "pivx",
-    "version": "5.5.0",
-    "binary_url": "https://github.com/PIVX-Project/PIVX/releases/download/v5.5.0/pivx-5.5.0-x86_64-linux-gnu.tar.gz",
+    "version": "5.6.1",
+    "binary_url": "https://github.com/PIVX-Project/PIVX/releases/download/v5.6.1/pivx-5.6.1-x86_64-linux-gnu.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "4a56e2cdaa12eaf30aab4acf676770181b46545d3cf6deb25b50bc81c55fb2b3",
+    "verification_source": "6704625c63ff73da8c57f0fbb1dab6f1e4bd8f62c17467e05f52a64012a0ee2f",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/pivx-qt"


### PR DESCRIPTION
This pull request updates the PIVX json config with the latest PIVX node version, which is a mandatory update.

Release page: https://github.com/PIVX-Project/PIVX/releases

> The mandatory update is v5.6.0, but v5.6.1 was already released, so I'm updating directly to it.