### PR TITLE
Update: Using mempool.space fee estimation for bitcoin testnet

### DIFF
--- a/configs/coins/bitcoin_testnet.json
+++ b/configs/coins/bitcoin_testnet.json
@@ -64,6 +64,8 @@
             "xpub_magic_segwit_native": 73342198,
             "slip44": 1,
             "additional_params": {
+                "alternative_estimate_fee": "mempoolspace",
+                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/testnet/api/v1/fees/recommended\", \"periodSeconds\": 20}",
                 "block_golomb_filter_p": 20,
                 "block_filter_scripts": "taproot-noordinals",
                 "block_filter_use_zeroed_key": true,


### PR DESCRIPTION
This merge request updates the Bitcoin testnet configuration to use mempool.space for fee estimation, aligning it with the Bitcoin mainnet configuration.