### PR TITLE
Enable API Before Sync and Return 503 When Not Synced

### DIFF
--- a/blockbook.go
+++ b/blockbook.go
@@ -415,7 +415,7 @@ func startInternalServer() (*server.InternalServer, error) {
 
 func startPublicServer() (*server.PublicServer, error) {
 	// start public server in limited functionality, extend it after sync is finished by calling ConnectFullPublicInterface
-	publicServer, err := server.NewPublicServer(*publicBinding, *certFiles, index, chain, mempool, txCache, *explorerURL, metrics, internalState, fiatRates, *debugMode)
+	publicServer, err := server.NewPublicServer(*publicBinding, *certFiles, index, chain, mempool, txCache, *explorerURL, metrics, internalState, fiatRates, *debugMode, *enableAPIBeforeSyncFlag)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description:
This PR introduces two changes to improve API behavior during synchronization:

1. **Return HTTP 503 When Not Synced**
API endpoints now return a 503 status if Blockbook is unsynced, helping clients detect incomplete synchronization. Status of the Blockbook in the response was preserved.

2. **Allow API Access Before Sync Completes**
Added an `enableAPIBeforeSync` flag to optionally allow API access before full sync, useful in read-only scenarios.

## Changes:

Updated `jsonHandler` to return 503 if not synced.
Added `enableAPIBeforeSync` flag for optional API access during sync.
## Impact:
Improves API flexibility for clients by providing better control over sync-dependent responses.