### PR TITLE
Add UnmarshalJSON method to Amount

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -3,8 +3,10 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/trezor/blockbook/bchain"
@@ -85,6 +87,21 @@ func (a *Amount) MarshalJSON() (out []byte, err error) {
 		return []byte(`"0"`), nil
 	}
 	return []byte(`"` + (*big.Int)(a).String() + `"`), nil
+}
+
+func (a *Amount) UnmarshalJSON(data []byte) error {
+	s := strings.Trim(string(data), "\"")
+	if len(s) > 0 {
+		bigValue, parsed := new(big.Int).SetString(s, 10)
+		if !parsed {
+			return fmt.Errorf("couldn't parse number: %s", s)
+		}
+		*a = Amount(*bigValue)
+	} else {
+		// assuming empty string means zero
+		*a = Amount{}
+	}
+	return nil
 }
 
 func (a *Amount) String() string {

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -47,6 +47,15 @@ func TestAmount_MarshalJSON(t *testing.T) {
 			if !reflect.DeepEqual(string(b), tt.want) {
 				t.Errorf("json.Marshal() = %v, want %v", string(b), tt.want)
 			}
+			var parsed amounts
+			err = json.Unmarshal(b, &parsed)
+			if err != nil {
+				t.Errorf("json.Unmarshal() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(parsed, tt.a) {
+				t.Errorf("json.Unmarshal() = %v, want %v", parsed, tt.a)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Hey, I've tried to use the api.Address type in an application I write,
however the api.Amount was missing the JSON unmarshal function:

`json: cannot unmarshal string into Go struct field Address.balance of type api.Amount`

This small mod (+test) solves this issue.