### PR TITLE
Support no-compression on rocksdb for Windows

### DIFF
--- a/db/dboptions.go
+++ b/db/dboptions.go
@@ -2,6 +2,7 @@ package db
 
 // #include "rocksdb/c.h"
 import "C"
+import "flag"
 import "github.com/linxGnu/grocksdb"
 
 /*
@@ -38,6 +39,10 @@ func boolToChar(b bool) C.uchar {
 }
 */
 
+var (
+        noCompression = flag.Bool("noCompression", false, "disable rocksdb compression when rocksdb library can't find compression library linked with binary")
+)
+
 func createAndSetDBOptions(bloomBits int, c *grocksdb.Cache, maxOpenFiles int) *grocksdb.Options {
 	blockOpts := grocksdb.NewDefaultBlockBasedTableOptions()
 	blockOpts.SetBlockSize(32 << 10) // 32kB
@@ -57,6 +62,11 @@ func createAndSetDBOptions(bloomBits int, c *grocksdb.Cache, maxOpenFiles int) *
 	opts.SetWriteBufferSize(1 << 27)      // 128MB
 	opts.SetMaxBytesForLevelBase(1 << 27) // 128MB
 	opts.SetMaxOpenFiles(maxOpenFiles)
-	opts.SetCompression(grocksdb.LZ4HCCompression)
+        if *noCompression {
+                // resolve error rocksDB: Invalid argument: Compression type LZ4HC is not linked with the binary
+                opts.SetCompression(grocksdb.NoCompression)
+        } else {
+                opts.SetCompression(grocksdb.LZ4HCCompression)
+        }
 	return opts
 }


### PR DESCRIPTION
This occurs for Windows builds when built on dynamic linking