### PR TITLE
Add ENS resolver #1108

### DIFF
--- a/static/test-websocket.html
+++ b/static/test-websocket.html
@@ -191,10 +191,12 @@
                     secondaryCurrency,
                     // default gap=20
                 };
+
                 send(method, params, function (result) {
-                    document.getElementById('getAccountInfoResult').innerText = JSON.stringify(
-                        result,
-                    ).replace(/,/g, ', ');
+                    const isENS = descriptor.endsWith('.eth');
+                    const prefix = isENS ? `ENS: ${descriptor} → ${result.address || 'failed'}\n` : '';
+                    document.getElementById('getAccountInfoResult').innerText =
+                        prefix + JSON.stringify(result).replace(/,/g, ', ');
                 });
             }
 
@@ -671,7 +673,7 @@
                     <div class="row" style="margin: 0">
                         <input
                             type="text"
-                            placeholder="descriptor"
+                            placeholder="descriptor (address or ENS name)"
                             style="width: 79%"
                             class="form-control"
                             id="getAccountInfoDescriptor"


### PR DESCRIPTION
Solves #1108 

I've added ENS resolver function and helper functions to `getAccountInfo `, and I've updated getAccountInfo section in test-websocket.html to take either address or ENS in the` descriptor`.

**Test data:**

Tested for sepolia.eth:

```

I0602 05:18:29.593823    2640 websocket.go:271] Client connected 2, 172.17.0.1:35274
I0602 05:18:36.963859    2640 websocket.go:606] ENS Debug: data='0x0178b8bf1d689859765781bcbe48fe0c5f2c67bd63fc1ba4d35982090d7ad37ed7662081', to='0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e', from='0x0000000000000000000000000000000000000000'
I0602 05:18:37.017323    2640 websocket.go:614] ENS Debug: RPC result: 0x0000000000000000000000008fade66b79cc9f707ab26799354482eb93a5b7dd
I0602 05:18:37.017473    2640 websocket.go:625] ENS Debug: resolver address: 0x8fade66b79cc9f707ab26799354482eb93a5b7dd
I0602 05:18:37.017484    2640 websocket.go:628] ENS Debug: Second call - data='0x3b3b57de1d689859765781bcbe48fe0c5f2c67bd63fc1ba4d35982090d7ad37ed7662081', to='0x8fade66b79cc9f707ab26799354482eb93a5b7dd'
I0602 05:18:37.062836    2640 websocket.go:636] ENS Debug: Second RPC result: 0x0000000000000000000000009703d9cf2f834e71d9b70675e746f7b634c9d1e9
I0602 05:18:37.062981    2640 websocket.go:647] ENS Debug: Final resolved address: 0x9703d9cf2f834e71d9b70675e746f7b634c9d1e9
```

