### PR TITLE
docs: rocksdb v7.5.3 -> rocksdb v9.10.0

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -209,7 +209,7 @@ sudo apt-get update && sudo apt-get install -y \
     build-essential git wget pkg-config libzmq3-dev libgflags-dev libsnappy-dev zlib1g-dev libzstd-dev  libbz2-dev liblz4-dev
 git clone https://github.com/facebook/rocksdb.git
 cd rocksdb
-git checkout v7.5.3
+git checkout v9.10.0
 CFLAGS=-fPIC CXXFLAGS=-fPIC make release
 ```
 


### PR DESCRIPTION
# Summary

This MR updates the RocksDB version described in Blockbook's documentation (for manual build) from v7.5.3 to v9.10.0. The older version triggered errors such as:
```
could not determine kind of name for C.rocksdb_cache_create_hyper_clock
could not determine kind of name for C.rocksdb_hyper_clock_cache_options_create
...
could not determine kind of name for C.rocksdb_get_default_column_family_handle
```

This discrepancy in the documentation could cost the developer up to several hours.