### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/bchain/baseparser.go
+++ b/bchain/baseparser.go
@@ -47,10 +47,7 @@ func (p *BaseParser) AmountToBigInt(n common.JSONNumber) (big.Int, error) {
 	var r big.Int
 	s := string(n)
 	i := strings.IndexByte(s, '.')
-	d := p.AmountDecimalPoint
-	if d > len(zeros) {
-		d = len(zeros)
-	}
+	d := min(p.AmountDecimalPoint, len(zeros))
 	if i == -1 {
 		s = s + zeros[:d]
 	} else {

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -51,10 +51,7 @@ func parseSimpleStringProperty(data string) string {
 	// allow string properties as UTF-8 data
 	b, err := hex.DecodeString(data)
 	if err == nil {
-		i := bytes.Index(b, []byte{0})
-		if i > 32 {
-			i = 32
-		}
+		i := min(bytes.Index(b, []byte{0}), 32)
 		if i > 0 {
 			b = b[:i]
 		}


### PR DESCRIPTION
Inspired by https://github.com/trezor/blockbook/pull/1222 and replace all.

Use the built-in max/min from the standard library in Go 1.21 to simplify the code. https://pkg.go.dev/builtin@go1.21.0#max

