### PR TITLE
Resolve Arbitrum, Base, and Zcash build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ deb-blockbook-%: .deb-image
 	docker run -t --rm -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/src" -v "$(CURDIR)/build:/out" $(DEB_IMAGE) /build/build-deb.sh blockbook $* $(ARGS)
 
 deb-%: .deb-image
-	docker run -t --rm -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/src" -v "$(CURDIR)/build:/out" $(DEB_IMAGE) /build/build-deb.sh all $* $(ARGS)
+	docker run -t --rm -e PACKAGER=$(PACKAGER) -v /var/run/docker.sock:/var/run/docker.sock -v "$(CURDIR):/src" -v "$(CURDIR)/build:/out" $(DEB_IMAGE) /build/build-deb.sh all $* $(ARGS)
 
 deb-blockbook-all: clean-deb $(addprefix deb-blockbook-, $(TARGETS))
 

--- a/build/templates/backend/Makefile
+++ b/build/templates/backend/Makefile
@@ -1,5 +1,9 @@
 {{define "main" -}}
+{{- if ne .Backend.BinaryURL "" }}
 ARCHIVE := $(shell basename {{.Backend.BinaryURL}})
+{{- else }}
+ARCHIVE :=
+{{- end }}
 
 all:
 	mkdir backend
@@ -34,6 +38,8 @@ all:
 
 clean:
 	rm -rf backend
+{{- if ne .Backend.BinaryURL "" }}
 	rm -f ${ARCHIVE}
+{{- end }}
 	rm -f checksum
 {{end}}


### PR DESCRIPTION
Builds for the following coins are failing for me on Debian 13 running Docker 28.4.0: (built using "make all-(coin)")

- Arbitrum (+ archive)
- Arbitrum Nova (+ archive)
- Base (+ archive)
- Base Op-Node (+ archive)
- Zcash

Two errors are showing upon build attempt: inability to connect to the Docker socket, and an error "basename: missing operand".

Upon inspection of the coin configs, I noticed that the common denominator between these coins is that they use "docker cp" within their extract_command.

This patch fixes their builds by mounting the Docker socket within builds that use the deb-% target, enabling docker-in-docker. It also resolves the basename error, caused by BinaryURL being empty in some cases.