### PR TITLE
Enhance CoinGecko Integration with Plan-Aware API Handling

### DIFF
--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -80,7 +80,9 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, url string, coin str
 			freeURL = "https://api.coingecko.com/api/v3"
 		)
 
-		if apiKey != "" && (plan == "pro" || plan == "") {
+		plan = strings.ToLower(strings.TrimSpace(plan))
+
+		if apiKey != "" && plan != "free" {
 			url = proURL
 		} else {
 			url = freeURL
@@ -103,6 +105,7 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, url string, coin str
 		db:              db,
 		throttlingDelay: time.Duration(throttlingDelayMs) * time.Millisecond,
 		metrics:         metrics,
+		plan:            plan,
 	}
 }
 

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -80,6 +80,7 @@ func NewFiatRates(db *db.RocksDB, config *common.Config, metrics *common.Metrics
 		PlatformIdentifier string `json:"platformIdentifier"`
 		PlatformVsCurrency string `json:"platformVsCurrency"`
 		PeriodSeconds      int64  `json:"periodSeconds"`
+		Plan               string `json:"plan"`
 	}
 	rdParams := &fiatRatesParams{}
 	err := json.Unmarshal([]byte(config.FiatRatesParams), &rdParams)
@@ -108,7 +109,7 @@ func NewFiatRates(db *db.RocksDB, config *common.Config, metrics *common.Metrics
 			// a small hack - in tests the callback is not used, therefore there is no delay slowing down the test
 			throttle = false
 		}
-		fr.downloader = NewCoinGeckoDownloader(db, db.GetInternalState().GetNetwork(), rdParams.URL, rdParams.Coin, rdParams.PlatformIdentifier, rdParams.PlatformVsCurrency, fr.allowedVsCurrencies, fr.timeFormat, metrics, throttle)
+		fr.downloader = NewCoinGeckoDownloader(db, db.GetInternalState().GetNetwork(), rdParams.URL, rdParams.Coin, rdParams.PlatformIdentifier, rdParams.PlatformVsCurrency, fr.allowedVsCurrencies, fr.timeFormat, rdParams.Plan, metrics, throttle)
 		if is != nil {
 			is.HasFiatRates = true
 			is.HasTokenFiatRates = fr.downloadTokens


### PR DESCRIPTION
This PR adds support for a **`plan`** parameter to the CoinGecko downloader, enabling correct API endpoint selection and header usage for **free**, **demo**, and **pro** plans.

### Key Changes

* Added `plan` field to the `Coingecko` struct.
* Updated `NewCoinGeckoDownloader` to accept a `plan` argument.
* Added plan-aware logic for:

  * Selecting the correct API base URL (`pro` vs. `free`).
  * Setting the appropriate API key header (`x-cg-pro-api-key` vs. `x-cg-demo-api-key`).
* Extended `fiat_rates.go` config params to accept and forward `plan`.
* Updated all internal request calls to pass `cg.plan`.

### Reference

CoinGecko API header requirements depend on plan type:
[https://docs.coingecko.com/docs/setting-up-your-api-key#2-making-api-request](https://docs.coingecko.com/docs/setting-up-your-api-key#2-making-api-request)

### Summary

This update ensures that the downloader behaves correctly depending on whether a Pro or Demo/Free API key is used, aligning with CoinGecko’s documented API requirements.