### PR TITLE
Short-circuit address parsing on hot path during block processing 

### DIFF
--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"context"
+	"encoding/hex"
 	"math/big"
 	"strings"
 
@@ -32,14 +33,20 @@ const contractDecimalsSignature = "0x313ce567"
 const contractBalanceOfSignature = "0x70a08231"
 
 func addressFromPaddedHex(s string) (string, error) {
-	var t big.Int
-	var ok bool
+	// Logs/topics and calldata often include a 0x prefix; strip it so length math and decoding are consistent.
 	if has0xPrefix(s) {
-		_, ok = t.SetString(s[2:], 16)
-	} else {
-		_, ok = t.SetString(s, 16)
+		s = s[2:]
 	}
-	if !ok {
+	if len(s) >= EthereumTypeAddressDescriptorLen*2 {
+		// Fast path: padded topics/data store the address in the last 20 bytes.
+		s = s[len(s)-EthereumTypeAddressDescriptorLen*2:]
+		if b, err := hex.DecodeString(s); err == nil && len(b) == EthereumTypeAddressDescriptorLen {
+			return ethcommon.BytesToAddress(b).String(), nil
+		}
+	}
+	// Fallback: handle odd formats by parsing the full value as a number.
+	var t big.Int
+	if _, ok := t.SetString(s, 16); !ok {
 		return "", errors.New("Data is not a number")
 	}
 	a := ethcommon.BigToAddress(&t)

--- a/bchain/coins/eth/contract_test.go
+++ b/bchain/coins/eth/contract_test.go
@@ -27,14 +27,29 @@ func Test_addressFromPaddedHex(t *testing.T) {
 			wantHex: "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
 		},
 		{
+			name:    "address_no_padding_no_prefix",
+			input:   "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+			wantHex: "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+		},
+		{
 			name:    "uppercase_prefix",
-			input:   "0X0000000000000000000000005dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+			input:   "0X0000000000000000000000005DC6288B35E0807A3D6FEB89B3A2FF4AB773168E",
 			wantHex: "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
 		},
 		{
 			name:    "padded",
 			input:   "0x0000000000000000000000002aacf811ac1a60081ea39f7783c0d26c500871a8",
 			wantHex: "2aacf811ac1a60081ea39f7783c0d26c500871a8",
+		},
+		{
+			name:    "padded_no_prefix",
+			input:   "0000000000000000000000002aacf811ac1a60081ea39f7783c0d26c500871a8",
+			wantHex: "2aacf811ac1a60081ea39f7783c0d26c500871a8",
+		},
+		{
+			name:    "odd_length_over_40",
+			input:   "f5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+			wantHex: "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
 		},
 		{
 			name:    "all_zero",
@@ -47,6 +62,11 @@ func Test_addressFromPaddedHex(t *testing.T) {
 			wantHex: "00000000000000000000000000000000001a2b3c",
 		},
 		{
+			name:    "unpadded_with_prefix",
+			input:   "0x1a2b3c",
+			wantHex: "00000000000000000000000000000000001a2b3c",
+		},
+		{
 			name:    "invalid_fast_path",
 			input:   "0x0000000000000000000000002aacf811ac1a60081ea39f7783c0d26c500871zz",
 			wantErr: true,
@@ -54,6 +74,11 @@ func Test_addressFromPaddedHex(t *testing.T) {
 		{
 			name:    "invalid",
 			input:   "0xzz",
+			wantErr: true,
+		},
+		{
+			name:    "invalid_prefix_only",
+			input:   "0x",
 			wantErr: true,
 		},
 	}

--- a/bchain/coins/eth/contract_test.go
+++ b/bchain/coins/eth/contract_test.go
@@ -3,6 +3,8 @@
 package eth
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strings"
@@ -11,6 +13,80 @@ import (
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/tests/dbtestdata"
 )
+
+func Test_addressFromPaddedHex(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantHex string
+		wantErr bool
+	}{
+		{
+			name:    "address_no_padding_with_prefix",
+			input:   "0x5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+			wantHex: "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+		},
+		{
+			name:    "uppercase_prefix",
+			input:   "0X0000000000000000000000005dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+			wantHex: "5dc6288b35e0807a3d6feb89b3a2ff4ab773168e",
+		},
+		{
+			name:    "padded",
+			input:   "0x0000000000000000000000002aacf811ac1a60081ea39f7783c0d26c500871a8",
+			wantHex: "2aacf811ac1a60081ea39f7783c0d26c500871a8",
+		},
+		{
+			name:    "all_zero",
+			input:   "0x0000000000000000000000000000000000000000000000000000000000000000",
+			wantHex: "0000000000000000000000000000000000000000",
+		},
+		{
+			name:    "unpadded",
+			input:   "1a2b3c",
+			wantHex: "00000000000000000000000000000000001a2b3c",
+		},
+		{
+			name:    "invalid_fast_path",
+			input:   "0x0000000000000000000000002aacf811ac1a60081ea39f7783c0d26c500871zz",
+			wantErr: true,
+		},
+		{
+			name:    "invalid",
+			input:   "0xzz",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addressFromPaddedHex(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("addressFromPaddedHex(%q) error %v", tt.input, err)
+			}
+			if len(got) < 2 || !strings.HasPrefix(got, "0x") {
+				t.Fatalf("addressFromPaddedHex(%q) returned %q", tt.input, got)
+			}
+			gotBytes, err := hex.DecodeString(got[2:])
+			if err != nil {
+				t.Fatalf("decode got %q error %v", got, err)
+			}
+			wantBytes, err := hex.DecodeString(tt.wantHex)
+			if err != nil {
+				t.Fatalf("decode want %q error %v", tt.wantHex, err)
+			}
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Fatalf("addressFromPaddedHex(%q) bytes %x want %x", tt.input, gotBytes, wantBytes)
+			}
+		})
+	}
+}
 
 func Test_contractGetTransfersFromLog(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Summary Of Changes
- Speed up padded address parsing in `addressFromPaddedHex` by decoding the last 20 bytes directly when the input is a 32-byte padded topic or calldata slot, and fall back to big.Int only for odd formats.
- Add unit tests that cover padded, unpadded, and invalid inputs for `addressFromPaddedHex`.

### addressFromPaddedHex: What Was Wrong And How It Was Fixed
- Problem: The original implementation always parsed the full hex string into a big.Int. For topics and calldata, addresses are 32-byte padded, so most of that work was wasted and done on every transfer/log.
- Fix: Strip optional `0x`, fast-path decode the last 40 hex characters (20 bytes) via `hex.DecodeString` and `BytesToAddress`, and fall back to the original big.Int parse only when the fast path does not apply or fails.
