### PR TITLE
closing Rocksdb on shutdown signal

### DIFF
--- a/blockbook.go
+++ b/blockbook.go
@@ -12,6 +12,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -134,7 +135,24 @@ func mainWithExitCode() int {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	chanOsSignal = make(chan os.Signal, 1)
-	signal.Notify(chanOsSignal, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+	shutdownSigCh := make(chan os.Signal, 1)
+	signalCh := make(chan os.Signal, 1)
+	// Use a single signal listener and fan out shutdown signals to avoid races
+	// where long-running workers consume the OS signal before main shutdown runs.
+	signal.Notify(signalCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+	var shutdownOnce sync.Once
+	go func() {
+		sig := <-signalCh
+		shutdownOnce.Do(func() {
+			// Flip global shutdown state and close chanOsSignal to broadcast shutdown.
+			// Closing the channel unblocks select loops that only receive from it.
+			common.SetInShutdown()
+			close(chanOsSignal)
+			// Ensure waitForSignalAndShutdown can proceed even if the OS signal
+			// was already consumed by another goroutine in previous versions.
+			shutdownSigCh <- sig
+		})
+	}()
 
 	glog.Infof("Blockbook: %+v, debug mode %v", common.GetVersionInfo(), *debugMode)
 
@@ -174,7 +192,13 @@ func mainWithExitCode() int {
 		glog.Error("rocksDB: ", err)
 		return exitCodeFatal
 	}
-	defer index.Close()
+	defer func() {
+		glog.Info("shutdown: rocksdb close start")
+		if err := index.Close(); err != nil {
+			glog.Error("shutdown: rocksdb close error: ", err)
+		}
+		glog.Info("shutdown: rocksdb close finished")
+	}()
 
 	internalState, err = newInternalState(config, index, *enableSubNewTx)
 	if err != nil {
@@ -358,17 +382,18 @@ func mainWithExitCode() int {
 	if internalServer != nil || publicServer != nil || chain != nil {
 		// start fiat rates downloader only if not shutting down immediately
 		initDownloaders(index, chain, config)
-		waitForSignalAndShutdown(internalServer, publicServer, chain, 10*time.Second)
+		waitForSignalAndShutdown(internalServer, publicServer, chain, shutdownSigCh, 10*time.Second)
 	}
 
+	// Always stop periodic state storage to prevent writes during shutdown.
+	close(chanStoreInternalState)
 	if *synchronize {
 		close(chanSyncIndex)
 		close(chanSyncMempool)
-		close(chanStoreInternalState)
 		<-chanSyncIndexDone
 		<-chanSyncMempoolDone
-		<-chanStoreInternalStateDone
 	}
+	<-chanStoreInternalStateDone
 	return exitCodeOK
 }
 
@@ -521,10 +546,16 @@ func syncIndexLoop() {
 	// resync index about every 15 minutes if there are no chanSyncIndex requests, with debounce 1 second
 	common.TickAndDebounce(time.Duration(*resyncIndexPeriodMs)*time.Millisecond, debounceResyncIndexMs*time.Millisecond, chanSyncIndex, func() {
 		if err := syncWorker.ResyncIndex(onNewBlockHash, false); err != nil {
+			if err == db.ErrOperationInterrupted || common.IsInShutdown() {
+				return
+			}
 			glog.Error("syncIndexLoop ", errors.ErrorStack(err), ", will retry...")
 			// retry once in case of random network error, after a slight delay
 			time.Sleep(time.Millisecond * 2500)
 			if err := syncWorker.ResyncIndex(onNewBlockHash, false); err != nil {
+				if err == db.ErrOperationInterrupted || common.IsInShutdown() {
+					return
+				}
 				glog.Error("syncIndexLoop ", errors.ErrorStack(err))
 			}
 		}
@@ -572,12 +603,11 @@ func syncMempoolLoop() {
 }
 
 func storeInternalStateLoop() {
-	stopCompute := make(chan os.Signal)
 	defer func() {
-		close(stopCompute)
 		close(chanStoreInternalStateDone)
 	}()
-	signal.Notify(stopCompute, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+	// Reuse the global shutdown channel so compute work stops when shutdown begins.
+	stopCompute := chanOsSignal
 	var computeRunning bool
 	lastCompute := time.Now()
 	lastAppInfo := time.Now()
@@ -653,11 +683,17 @@ func pushSynchronizationHandler(nt bchain.NotificationType) {
 	}
 }
 
-func waitForSignalAndShutdown(internal *server.InternalServer, public *server.PublicServer, chain bchain.BlockChain, timeout time.Duration) {
-	sig := <-chanOsSignal
+func waitForSignalAndShutdown(internal *server.InternalServer, public *server.PublicServer, chain bchain.BlockChain, shutdownSig <-chan os.Signal, timeout time.Duration) {
+	// Read the first OS signal from the dedicated channel to avoid races with worker shutdown paths.
+	sig := <-shutdownSig
 	common.SetInShutdown()
-	glog.Infof("shutdown: %v", sig)
+	if sig != nil {
+		glog.Infof("shutdown: %v", sig)
+	} else {
+		glog.Info("shutdown: signal received")
+	}
 
+	// Bound server/RPC shutdown; RocksDB close happens after main returns via defer.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/build/templates/backend/debian/service
+++ b/build/templates/backend/debian/service
@@ -7,7 +7,10 @@ After=network.target
 ExecStart={{template "Backend.ExecCommandTemplate" .}}
 User={{.Backend.SystemUser}}
 Restart=on-failure
+# Allow enough time for graceful shutdown/flush work before SIGKILL.
 TimeoutStopSec=300
+# Be explicit about the signal used for graceful shutdown.
+KillSignal=SIGTERM
 WorkingDirectory={{.Env.BackendInstallPath}}/{{.Coin.Alias}}
 {{if eq .Backend.ServiceType "forking" -}}
 Type=forking


### PR DESCRIPTION
### Summary
Ensure SIGTERM reliably triggers the main shutdown path so RocksDB is closed cleanly and internal state is stored, even when worker goroutines are active. Make the systemd unit explicit about graceful termination and add inline docs for the shutdown fan-out.

### Problem
Blockbook uses a shared signal channel for both long-running worker loops and the main shutdown handler. In practice, a worker could consume SIGTERM first, leaving `waitForSignalAndShutdown` blocked. That prevents the normal shutdown sequence and the deferred `index.Close()` from running, which leaves `internalState.DbState` set to open and may cause a "database was left in open state" warning on restart.

### Approach
- Use a single OS signal listener and fan out shutdown to two channels:
  - a closed channel that wakes any worker `select` loops
  - a dedicated channel for `waitForSignalAndShutdown`
- Treat shutdown as a first-class interruption in both initial and regular sync.
- Stop periodic internal state storage on shutdown to avoid writing during close.
- Make the systemd unit explicit about SIGTERM and its timeout.

### Key changes
- `blockbook.go`: deterministic signal fan-out, shutdown sequencing, and comments.
- `db/sync.go`: regular sync now honors shutdown and exits quickly.
- `build/templates/backend/debian/service`: explicit `KillSignal=SIGTERM` with comment.

### Behavior after change
- SIGTERM always reaches the main shutdown handler.
- Worker loops unblock immediately when shutdown begins.
- RocksDB closes via deferred `index.Close()` and stores `DbStateClosed`.

### Verification
- `systemctl stop` and confirm logs show `shutdown: SIGTERM` followed by `rocksdb: close`.
- Restart and verify no "database was left in open state" warning.

### Risks / follow-ups
- Mempool resync does not yet accept a stop context; if it is in flight, shutdown waits for it to finish. This is unchanged but now fully bounded by `TimeoutStopSec` and `waitForSignalAndShutdown`.
