### PR TITLE
ws origin allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ Blockbook API is described [here](/docs/api.md).
 ## Environment variables
 
 List of environment variables that affect Blockbook's behavior is [here](/docs/env.md).
+
+## Security Note
+
+WebSocket origin checks are not enforced by default. If you expose Blockbook without a proxy that restricts origins, it is your responsibility to configure the origin allowlist (or equivalent controls). See `docs/env.md` for details.

--- a/docs/env.md
+++ b/docs/env.md
@@ -4,6 +4,8 @@ Some behavior of Blockbook can be modified by environment variables. The variabl
 
 -   `<coin shortcut>_WS_GETACCOUNTINFO_LIMIT` - Limits the number of `getAccountInfo` requests per websocket connection to reduce server abuse. Accepts number as input.
 
+-   `<coin shortcut>_WS_ALLOWED_ORIGINS` - Comma-separated list of allowed WebSocket origins (e.g. `https://example.com`, `http://localhost:3000`). If omitted, all origins are allowed and it is the operator's responsibility to enforce origin access (for example via proxy).
+
 -   `<coin shortcut>_STAKING_POOL_CONTRACT` - The pool name and contract used for Ethereum staking. The format of the variable is `<pool name>/<pool contract>`. If missing, staking support is disabled.
 
 -   `COINGECKO_API_KEY`, `<network>_COINGECKO_API_KEY`, or `<coin shortcut>_COINGECKO_API_KEY` - API key for making requests to CoinGecko in the paid tier.

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"net/http"
+	"net/url"
 	"os"
 	"runtime/debug"
 	"strconv"
@@ -83,6 +84,7 @@ type WebsocketServer struct {
 	fiatRatesSubscriptions       map[string]map[*websocketChannel]string
 	fiatRatesTokenSubscriptions  map[*websocketChannel][]string
 	fiatRatesSubscriptionsLock   sync.Mutex
+	allowedOrigins               map[string]struct{}
 	allowedRpcCallTo             map[string]struct{}
 }
 
@@ -97,12 +99,6 @@ func NewWebsocketServer(db *db.RocksDB, chain bchain.BlockChain, mempool bchain.
 		return nil, err
 	}
 	s := &WebsocketServer{
-		upgrader: &websocket.Upgrader{
-			ReadBufferSize:    1024 * 32,
-			WriteBufferSize:   1024 * 32,
-			CheckOrigin:       checkOrigin,
-			EnableCompression: true,
-		},
 		db:                          db,
 		txCache:                     txCache,
 		chain:                       chain,
@@ -119,6 +115,14 @@ func NewWebsocketServer(db *db.RocksDB, chain bchain.BlockChain, mempool bchain.
 		fiatRatesSubscriptions:      make(map[string]map[*websocketChannel]string),
 		fiatRatesTokenSubscriptions: make(map[*websocketChannel][]string),
 	}
+	s.upgrader = &websocket.Upgrader{
+		ReadBufferSize:    1024 * 32,
+		WriteBufferSize:   1024 * 32,
+		CheckOrigin:       s.checkOrigin,
+		EnableCompression: true,
+	}
+	originEnvName := strings.ToUpper(is.GetNetwork()) + "_WS_ALLOWED_ORIGINS"
+	s.allowedOrigins = parseAllowedOrigins(originEnvName, os.Getenv(originEnvName))
 	envRpcCall := os.Getenv(strings.ToUpper(is.GetNetwork()) + "_ALLOWED_RPC_CALL_TO")
 	if envRpcCall != "" {
 		s.allowedRpcCallTo = make(map[string]struct{})
@@ -133,9 +137,54 @@ func NewWebsocketServer(db *db.RocksDB, chain bchain.BlockChain, mempool bchain.
 	return s, nil
 }
 
-// allow all origins
-func checkOrigin(r *http.Request) bool {
-	return true
+func parseAllowedOrigins(originEnvName, envAllowedOrigins string) map[string]struct{} {
+	if envAllowedOrigins == "" {
+		glog.Warning("Websocket origin allowlist not configured (", originEnvName, "); all origins allowed")
+		return nil
+	}
+	allowedOrigins := make(map[string]struct{})
+	for _, origin := range strings.Split(envAllowedOrigins, ",") {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		normalizedOrigin, ok := normalizeOrigin(origin)
+		if !ok {
+			glog.Warning("Ignoring invalid websocket origin in ", originEnvName, ": ", origin)
+			continue
+		}
+		allowedOrigins[normalizedOrigin] = struct{}{}
+	}
+	if len(allowedOrigins) == 0 {
+		glog.Warning("Websocket origin allowlist is empty after parsing ", originEnvName, "; all origins allowed")
+		return nil
+	}
+	glog.Info("Websocket origin allowlist enabled: ", envAllowedOrigins)
+	return allowedOrigins
+}
+
+func (s *WebsocketServer) checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if len(s.allowedOrigins) == 0 {
+		return true
+	}
+	normalizedOrigin, ok := normalizeOrigin(origin)
+	if !ok {
+		return false
+	}
+	_, ok = s.allowedOrigins[normalizedOrigin]
+	return ok
+}
+
+func normalizeOrigin(origin string) (string, bool) {
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", false
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host), true
 }
 
 func getIP(r *http.Request) string {

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1,9 +1,11 @@
 //go:build unittest
+// +build unittest
 
 package server
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -12,6 +14,152 @@ import (
 	"github.com/trezor/blockbook/bchain/coins/eth"
 	"github.com/trezor/blockbook/tests/dbtestdata"
 )
+
+func TestCheckOriginAllowAll(t *testing.T) {
+	s := &WebsocketServer{}
+	tests := []struct {
+		name   string
+		origin string
+		want   bool
+	}{
+		{
+			name: "no origin",
+			want: true,
+		},
+		{
+			name:   "valid origin",
+			origin: "https://example.com",
+			want:   true,
+		},
+		{
+			name:   "invalid origin",
+			origin: "://bad",
+			want:   true,
+		},
+		{
+			name:   "null origin",
+			origin: "null",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{Header: make(http.Header)}
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			got := s.checkOrigin(r)
+			if got != tt.want {
+				t.Fatalf("checkOrigin() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckOriginAllowlist(t *testing.T) {
+	allowedOrigins := make(map[string]struct{})
+	for _, origin := range []string{"https://example.com", "http://localhost:3000"} {
+		normalizedOrigin, ok := normalizeOrigin(origin)
+		if !ok {
+			t.Fatalf("normalizeOrigin(%q) failed", origin)
+		}
+		allowedOrigins[normalizedOrigin] = struct{}{}
+	}
+	s := &WebsocketServer{allowedOrigins: allowedOrigins}
+
+	tests := []struct {
+		name   string
+		origin string
+		want   bool
+	}{
+		{
+			name: "no origin",
+			want: true,
+		},
+		{
+			name:   "allowed origin",
+			origin: "https://example.com",
+			want:   true,
+		},
+		{
+			name:   "allowed origin different case",
+			origin: "HTTP://LOCALHOST:3000",
+			want:   true,
+		},
+		{
+			name:   "disallowed origin",
+			origin: "https://evil.com",
+			want:   false,
+		},
+		{
+			name:   "invalid origin",
+			origin: "://bad",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{Header: make(http.Header)}
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			got := s.checkOrigin(r)
+			if got != tt.want {
+				t.Fatalf("checkOrigin() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAllowedOrigins(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{
+			name: "empty",
+			env:  "",
+			want: nil,
+		},
+		{
+			name: "valid entries",
+			env:  "https://example.com,http://localhost:3000",
+			want: []string{"https://example.com", "http://localhost:3000"},
+		},
+		{
+			name: "trims and normalizes",
+			env:  " HTTPS://Example.com:9130 , http://LOCALHOST:3000 ",
+			want: []string{"https://example.com:9130", "http://localhost:3000"},
+		},
+		{
+			name: "invalid filtered",
+			env:  "https://example.com,://bad,",
+			want: []string{"https://example.com"},
+		},
+		{
+			name: "all invalid",
+			env:  "://bad,not-a-url",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAllowedOrigins("FAKE_WS_ALLOWED_ORIGINS", tt.env)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseAllowedOrigins() len = %d, want %d", len(got), len(tt.want))
+			}
+			for _, origin := range tt.want {
+				if _, ok := got[origin]; !ok {
+					t.Fatalf("parseAllowedOrigins() missing %q", origin)
+				}
+			}
+		})
+	}
+}
 
 func TestSetConfirmedBlockTxMetadataSetsConfirmedFields(t *testing.T) {
 	tx := bchain.Tx{


### PR DESCRIPTION
- Added optional WebSocket origin allowlist support with explicit logging, and documented the operator responsibility for securing origins when not using the proxy.

# Testing
- `go test ./server -tags unittest -run 'TestCheckOrigin|TestParseAllowedOrigins|Test_PublicServer_EthereumType'`
