### PR TITLE
fixes #1427 scientific notation parsing error

### DIFF
--- a/bchain/baseparser.go
+++ b/bchain/baseparser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -39,29 +40,121 @@ func (p *BaseParser) GetAddrDescForUnknownInput(tx *Tx, input int) AddressDescri
 	return nil
 }
 
-const zeros = "0000000000000000000000000000000000000000"
+const (
+	zeros                   = "0000000000000000000000000000000000000000"
+	maxAmountExpandedDigits = 1024
+)
 
 // AmountToBigInt converts amount in common.JSONNumber (string) to big.Int
 // it uses string operations to avoid problems with rounding
 func (p *BaseParser) AmountToBigInt(n common.JSONNumber) (big.Int, error) {
 	var r big.Int
-	s := string(n)
-	i := strings.IndexByte(s, '.')
 	d := min(p.AmountDecimalPoint, len(zeros))
-	if i == -1 {
-		s = s + zeros[:d]
+	if d < 0 {
+		d = 0
+	}
+	s := string(n)
+	if strings.IndexAny(s, "eE") == -1 {
+		s = normalizePlainAmountToIntString(s, d)
 	} else {
-		z := d - len(s) + i + 1
-		if z > 0 {
-			s = s[:i] + s[i+1:] + zeros[:z]
-		} else {
-			s = s[:i] + s[i+1:len(s)+z]
+		var err error
+		s, err = normalizeScientificAmountToIntString(s, d)
+		if err != nil {
+			return r, errors.New("AmountToBigInt: failed to convert")
 		}
 	}
 	if _, ok := r.SetString(s, 10); !ok {
 		return r, errors.New("AmountToBigInt: failed to convert")
 	}
 	return r, nil
+}
+
+func normalizePlainAmountToIntString(s string, decimalPoint int) string {
+	i := strings.IndexByte(s, '.')
+	if i == -1 {
+		return s + zeros[:decimalPoint]
+	}
+	z := decimalPoint - len(s) + i + 1
+	if z > 0 {
+		return s[:i] + s[i+1:] + zeros[:z]
+	}
+	return s[:i] + s[i+1:len(s)+z]
+}
+
+func normalizeScientificAmountToIntString(s string, decimalPoint int) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		s = "0"
+	}
+
+	sign := ""
+	if strings.HasPrefix(s, "-") {
+		sign = "-"
+		s = s[1:]
+	} else if strings.HasPrefix(s, "+") {
+		s = s[1:]
+	}
+	if s == "" {
+		return "", errors.New("empty mantissa")
+	}
+
+	exponent := 0
+	if i := strings.IndexAny(s, "eE"); i != -1 {
+		if strings.IndexAny(s[i+1:], "eE") != -1 {
+			return "", errors.New("invalid scientific notation")
+		}
+		var err error
+		exponent, err = strconv.Atoi(s[i+1:])
+		if err != nil {
+			return "", err
+		}
+		s = s[:i]
+		if s == "" {
+			return "", errors.New("empty mantissa")
+		}
+	}
+
+	fractionDigits := 0
+	if i := strings.IndexByte(s, '.'); i != -1 {
+		if strings.IndexByte(s[i+1:], '.') != -1 {
+			return "", errors.New("invalid decimal notation")
+		}
+		fractionDigits = len(s) - i - 1
+		s = s[:i] + s[i+1:]
+	}
+	if s == "" {
+		return "", errors.New("empty value")
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return "", errors.New("invalid value")
+		}
+	}
+
+	s = strings.TrimLeft(s, "0")
+	if s == "" {
+		return "0", nil
+	}
+
+	shift := exponent - fractionDigits + decimalPoint
+	if shift >= 0 {
+		if shift > maxAmountExpandedDigits || len(s) > maxAmountExpandedDigits-shift {
+			return "", errors.New("expanded value too large")
+		}
+		s = s + strings.Repeat("0", shift)
+	} else {
+		keep := len(s) + shift
+		if keep > 0 {
+			s = s[:keep]
+		} else {
+			s = "0"
+		}
+	}
+
+	if sign == "-" && s != "0" {
+		s = sign + s
+	}
+	return s, nil
 }
 
 // AmountToDecimalString converts amount in big.Int to string with decimal point in the place defined by the parameter d

--- a/bchain/baseparser_test.go
+++ b/bchain/baseparser_test.go
@@ -34,6 +34,19 @@ var amounts = []struct {
 	{big.NewInt(12345678), "0.0000000000000000000000000000000012345678", 1234, "!"}, // test of too big number decimal places
 }
 
+var scientificNotationAmounts = []struct {
+	a   *big.Int
+	s   string
+	adp int
+}{
+	{big.NewInt(97), "9.7e-7", 8},
+	{big.NewInt(97), "9.7E-7", 8},
+	{big.NewInt(970000000), "9.7e+0", 8},
+	{big.NewInt(-8), "-8e-8", 8},
+	{big.NewInt(12345678), "1.23456789e-1", 8},
+	{big.NewInt(0), "9.7e-20", 8},
+}
+
 func TestBaseParser_AmountToDecimalString(t *testing.T) {
 	for _, tt := range amounts {
 		t.Run(tt.s, func(t *testing.T) {
@@ -41,6 +54,51 @@ func TestBaseParser_AmountToDecimalString(t *testing.T) {
 				t.Errorf("BaseParser.AmountToDecimalString() = %v, want %v", got, tt.s)
 			}
 		})
+	}
+}
+
+func TestBaseParser_AmountToBigIntScientificNotation(t *testing.T) {
+	for _, tt := range scientificNotationAmounts {
+		t.Run(tt.s, func(t *testing.T) {
+			got, err := NewBaseParser(tt.adp).AmountToBigInt(common.JSONNumber(tt.s))
+			if err != nil {
+				t.Errorf("BaseParser.AmountToBigInt() error = %v", err)
+				return
+			}
+			if got.Cmp(tt.a) != 0 {
+				t.Errorf("BaseParser.AmountToBigInt() = %v, want %v", got, tt.a)
+			}
+		})
+	}
+}
+
+func TestBaseParser_AmountToBigIntScientificNotationInvalid(t *testing.T) {
+	cases := []string{
+		"9.7e",
+		"9.7ee-7",
+		"e-7",
+		"--1",
+		"1.2.3e1",
+		"1e2000",
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			_, err := NewBaseParser(8).AmountToBigInt(common.JSONNumber(tc))
+			if err == nil {
+				t.Errorf("BaseParser.AmountToBigInt() expected error for %q", tc)
+			}
+		})
+	}
+}
+
+func TestBaseParser_AmountToBigIntScientificNotationExpansionLimit(t *testing.T) {
+	p := NewBaseParser(0)
+
+	if _, err := p.AmountToBigInt(common.JSONNumber("1e1023")); err != nil {
+		t.Fatalf("BaseParser.AmountToBigInt() unexpected error at limit: %v", err)
+	}
+	if _, err := p.AmountToBigInt(common.JSONNumber("1e1024")); err == nil {
+		t.Fatalf("BaseParser.AmountToBigInt() expected error above limit")
 	}
 }
 

--- a/tests/api/api.go
+++ b/tests/api/api.go
@@ -21,6 +21,8 @@ const (
 	blockPageSize       = 1
 	sampleBlockPageSize = 3
 	sampleBlockProbeMax = 3
+	sciNotationWindow   = 40
+	sciNotationTxLimit  = 8
 )
 
 type testCapability uint8
@@ -38,18 +40,19 @@ type testDefinition struct {
 }
 
 var commonTests = map[string]func(t *testing.T, th *TestHandler){
-	"Status":                 testStatus,
-	"GetBlockIndex":          testGetBlockIndex,
-	"GetBlockByHeight":       testGetBlockByHeight,
-	"GetBlock":               testGetBlock,
-	"GetTransaction":         testGetTransaction,
-	"GetTransactionSpecific": testGetTransactionSpecific,
-	"GetAddress":             testGetAddress,
-	"GetAddressTxids":        testGetAddressTxids,
-	"GetAddressTxs":          testGetAddressTxs,
-	"GetCurrentFiatRates":    testGetCurrentFiatRates,
-	"GetTickersList":         testGetTickersList,
-	"GetMultiTickers":        testGetMultiTickers,
+	"Status":                          testStatus,
+	"GetBlockIndex":                   testGetBlockIndex,
+	"GetBlockByHeight":                testGetBlockByHeight,
+	"GetBlock":                        testGetBlock,
+	"GetTransaction":                  testGetTransaction,
+	"GetTransactionSpecific":          testGetTransactionSpecific,
+	"GetAddress":                      testGetAddress,
+	"GetAddressTxids":                 testGetAddressTxids,
+	"GetAddressTxs":                   testGetAddressTxs,
+	"GetAddressTxsScientificNotation": testGetAddressTxsScientificNotation,
+	"GetCurrentFiatRates":             testGetCurrentFiatRates,
+	"GetTickersList":                  testGetTickersList,
+	"GetMultiTickers":                 testGetMultiTickers,
 }
 
 var utxoOnlyTests = map[string]func(t *testing.T, th *TestHandler){
@@ -113,6 +116,10 @@ type TestHandler struct {
 	sampleFiatResolved     bool
 	sampleFiatAvailable    bool
 	sampleFiatTicker       fiatTickerResponse
+	sampleSciAddrResolved  bool
+	sampleSciAddress       string
+	sampleSciTxID          string
+	sampleSciHeight        int
 
 	capabilitiesResolved bool
 	supportsUTXO         bool

--- a/tests/api/http_tests.go
+++ b/tests/api/http_tests.go
@@ -219,6 +219,21 @@ func testGetAddressTxs(t *testing.T, h *TestHandler) {
 	assertAddressTxsPayload(t, &addr, address, txid, "GetAddressTxs", addressPageSize)
 }
 
+func testGetAddressTxsScientificNotation(t *testing.T, h *TestHandler) {
+	const maxPageSize = 1000
+
+	address, txid, height, found := h.getSampleAddressWithScientificNotationTx(t)
+	if !found {
+		t.Skipf("Skipping test, no tx-specific scientific-notation amounts found in last %d blocks", sciNotationWindow)
+	}
+
+	path := buildAddressDetailsPathWithRange(address, "txs", addressPage, maxPageSize, height, height)
+	var addr addressTxsResponse
+	h.mustGetJSON(t, path, &addr)
+
+	assertAddressTxsPayload(t, &addr, address, txid, "GetAddressTxsScientificNotation", maxPageSize)
+}
+
 func testGetUtxo(t *testing.T, h *TestHandler) {
 	address := h.sampleAddressOrSkip(t)
 

--- a/tests/api/sample_data.go
+++ b/tests/api/sample_data.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
 )
+
+var scientificNotationPattern = regexp.MustCompile(`"value(?:Zat|Sat)?"\s*:\s*-?\d+\.\d+[eE][+-]?\d+`)
 
 func (h *TestHandler) getStatus(t *testing.T) *statusBlockbook {
 	if h.status != nil {
@@ -116,6 +119,85 @@ func (h *TestHandler) getSampleAddress(t *testing.T) (string, bool) {
 		h.sampleAddress = firstAddressFromTx(tx)
 	}
 	return h.sampleAddress, h.sampleAddress != ""
+}
+
+func (h *TestHandler) getSampleAddressWithScientificNotationTx(t *testing.T) (address, txid string, height int, found bool) {
+	if h.sampleSciAddrResolved {
+		return h.sampleSciAddress, h.sampleSciTxID, h.sampleSciHeight, h.sampleSciAddress != "" && h.sampleSciTxID != ""
+	}
+	h.sampleSciAddrResolved = true
+
+	status := h.getStatus(t)
+	lower := status.BestHeight - sciNotationWindow + 1
+	if lower < 1 {
+		lower = 1
+	}
+
+	for height = status.BestHeight; height >= lower; height-- {
+		hash, ok := h.getBlockHashForHeight(t, height, false)
+		if !ok || strings.TrimSpace(hash) == "" {
+			continue
+		}
+
+		txids, ok := h.getBlockTxIDsForProbe(t, hash, sciNotationTxLimit)
+		if !ok {
+			continue
+		}
+
+		for _, txid = range txids {
+			txid = strings.TrimSpace(txid)
+			if txid == "" || !h.txSpecificHasScientificNotationAmount(t, txid) {
+				continue
+			}
+
+			tx, ok := h.getTransactionByID(t, txid, false)
+			if !ok {
+				continue
+			}
+			if isEVMTxID(txid) {
+				address = firstAddressFromTxPreferVin(tx)
+			} else {
+				address = firstAddressFromTx(tx)
+			}
+			if !isAddressCandidate(address) {
+				continue
+			}
+
+			h.sampleSciAddress = address
+			h.sampleSciTxID = txid
+			h.sampleSciHeight = height
+			return address, txid, height, true
+		}
+	}
+
+	return "", "", 0, false
+}
+
+func (h *TestHandler) getBlockTxIDsForProbe(t *testing.T, hash string, pageSize int) ([]string, bool) {
+	t.Helper()
+
+	path := fmt.Sprintf("/api/v2/block/%s?page=1&pageSize=%d", url.PathEscape(hash), pageSize)
+	status, body := h.getHTTP(t, path)
+	if status != http.StatusOK {
+		return nil, false
+	}
+
+	var res blockResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		t.Fatalf("decode block response for scientific-notation probe %s: %v", hash, err)
+	}
+	return extractTxIDs(t, res.Txs), true
+}
+
+func (h *TestHandler) txSpecificHasScientificNotationAmount(t *testing.T, txid string) bool {
+	t.Helper()
+
+	path := "/api/v2/tx-specific/" + url.PathEscape(txid)
+	status, body := h.getHTTP(t, path)
+	if status != http.StatusOK {
+		return false
+	}
+	return scientificNotationPattern.Match(body)
 }
 
 func (h *TestHandler) getSampleIndexedBlock(t *testing.T) (height int, hash string, found bool) {

--- a/tests/api/test_helpers.go
+++ b/tests/api/test_helpers.go
@@ -27,6 +27,17 @@ func buildAddressDetailsPathWithTo(address, details string, page, pageSize, toHe
 	return path
 }
 
+func buildAddressDetailsPathWithRange(address, details string, page, pageSize, fromHeight, toHeight int) string {
+	path := buildAddressDetailsPath(address, details, page, pageSize)
+	if fromHeight > 0 {
+		path += "&from=" + strconv.Itoa(fromHeight)
+	}
+	if toHeight > 0 {
+		path += "&to=" + strconv.Itoa(toHeight)
+	}
+	return path
+}
+
 func assertAddressTxidsPayload(t *testing.T, payload *addressTxidsResponse, address, txid, context string, pageSize int) {
 	t.Helper()
 	assertAddressMatches(t, payload.Address, address, context+".address")

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -191,7 +191,7 @@
     "zcash": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetAddressTxsScientificNotation", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]


### PR DESCRIPTION
Fixes #1427 

### Summary
- `AmountToBigInt` now handles scientific notation (`e`/`E`) safely.
- Non-scientific values use a fast path based on legacy plain-decimal logic.
- Scientific expansion is bounded to prevent pathological CPU/memory usage.
- Zcash API integration test matrix includes the new scientific-notation address-`details=txs` check.

### Likely affected:

- /api/v2/tx/<txid> (and WS getTransaction) on tx-cache miss.
- /api/v2/address with other details too (txids, sometimes even basic) when mempool txs are fetched and parsed.
- Sync/indexing paths that fetch full tx JSON from backend (GetBlockFull, Zcash fallback per-tx fetch), so it can break syncing, not only API.
- Fee parsing calls (estimatefee, estimatesmartfee, getmempoolentry) if backend returns scientific notation there.

### Findings
- Safety improved: very large scientific exponents are rejected instead of expanding into huge strings.
- Performance is the same as the old implementation

### Tests
- `go test -tags unittest ./bchain`
- `go test -v -tags integration ./tests -run 'TestIntegration/zcash/api/GetAddressTxsScientificNotation' -count=1`
