### PR TITLE
fix: fix NIL token decimals to 6 from 18

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -64,7 +64,47 @@ func NewWorker(db *db.RocksDB, chain bchain.BlockChain, mempool bchain.Mempool, 
 	if w.chainType == bchain.ChainBitcoinType {
 		w.initXpubCache()
 	}
+
+	// Seed ERC-20 contract fixes into DB once at startup so API reads remain fast.
+	// We intentionally scope this to the Ethereum (ETH) instances to avoid cross-chain
+	// address collisions.
+	if !w.chain.IsTestnet() && (w.chain.GetCoinName() == "Ethereum" || w.chain.GetCoinName() == "Ethereum Archive") {
+		w.seedERC20ContractFixesToDB()
+	}
 	return w, nil
+}
+
+func (w *Worker) seedERC20ContractFixesToDB() {
+	contractFixes := eth.ContractFixes()
+	for i := range contractFixes {
+		fix := contractFixes[i]
+		addrDesc, err := w.chainParser.GetAddrDescFromAddress(fix.Contract)
+		if err != nil {
+			glog.Warningf("seedERC20ContractFixesToDB: invalid contract address %q: %v", fix.Contract, err)
+			continue
+		}
+
+		ci, err := w.db.GetContractInfo(addrDesc, bchain.UnknownTokenStandard)
+		if err != nil {
+			glog.Warningf("seedERC20ContractFixesToDB: GetContractInfo error for %q: %v", fix.Contract, err)
+			continue
+		}
+		if ci == nil {
+			// Contract not present yet in DB (common for tokens the instance hasn't indexed).
+			// Future lookups will use the fetch fast-path.
+			continue
+		}
+
+		if eth.ApplyContractFixToContractInfo(ci, fix.Contract) {
+			// Ensure StoreContractInfo can persist it.
+			if ci.Contract == "" {
+				ci.Contract = fix.Contract
+			}
+			if err := w.db.StoreContractInfo(ci); err != nil {
+				glog.Errorf("seedERC20ContractFixesToDB: StoreContractInfo error for %q: %v", fix.Contract, err)
+			}
+		}
+	}
 }
 
 func (w *Worker) getAddressesFromVout(vout *bchain.Vout) (bchain.AddressDescriptor, []string, bool, error) {

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -316,6 +316,23 @@ func erc20BalanceOfCallData(addrDesc bchain.AddressDescriptor) string {
 
 func (b *EthereumRPC) fetchContractInfo(address string) (*bchain.ContractInfo, error) {
 	var contract bchain.ContractInfo
+
+	// Fast path for known ERC-20 contracts with fixed metadata.
+	// This avoids relying on on-chain `decimals()` in cases where it may fail or be non-standard.
+	// Scope overrides to the Ethereum instance (`ETH`) to avoid cross-chain
+	// address collisions (same contract address on different EVM chains).
+	if !b.Testnet && b.ChainConfig != nil && b.ChainConfig.CoinShortcut == "ETH" {
+		if fix := getContractFix(address); fix != nil {
+			contract = bchain.ContractInfo{
+				Contract: address,
+				Name:     fix.Name,
+				Symbol:   fix.Symbol,
+				Decimals: fix.Decimals,
+			}
+			return &contract, nil
+		}
+	}
+
 	b.observeEthCallContractInfo("name")
 	data, err := b.EthereumTypeRpcCall(contractNameSignature, address, "")
 	if err != nil {

--- a/bchain/coins/eth/contract_fixes.go
+++ b/bchain/coins/eth/contract_fixes.go
@@ -1,0 +1,167 @@
+package eth
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/trezor/blockbook/bchain"
+)
+
+// Contract Fixes:
+// We maintain a small allowlist of ERC-20 contracts with known correct token metadata
+// (currently mainly `decimals`). This prevents users from seeing incorrect scaling
+// when a contract's ABI calls fail or return unexpected results.
+
+// Contract fixes JSON is kept as an in-code string to avoid build/tooling issues
+// around embedding files from nested/non-package paths.
+var contractFixesJSON = []byte(`[
+  {
+    "standard": "ERC20",
+    "contract": "0xC19B6A4Ac7C7Cc24459F08984Bbd09664af17bD1",
+    "name": "Sensorium",
+    "symbol": "SENSO",
+    "decimals": 0,
+    "createdInBlock": 11098997
+  },
+  {
+    "standard": "ERC20",
+    "contract": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa",
+    "name": "mETH",
+    "symbol": "mETH",
+    "decimals": 18,
+    "createdInBlock": 18290587
+  },
+  {
+    "standard": "ERC20",
+    "contract": "0xE6829d9a7eE3040e1276Fa75293Bde931859e8fA",
+    "name": "cmETH",
+    "symbol": "cmETH",
+    "decimals": 18,
+    "createdInBlock": 20439180
+  },
+  {
+    "type": "ERC20",
+    "standard": "ERC20",
+    "contract": "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb",
+    "name": "Fluid",
+    "symbol": "FLUID",
+    "decimals": 18,
+    "createdInBlock": 12183236
+  },
+  {
+    "standard": "ERC20",
+    "contract": "0x7cf9a80db3b29ee8efe3710aadb7b95270572d47",
+    "name": "Nillion",
+    "symbol": "NIL",
+    "decimals": 6
+  }
+]`)
+
+type contractFix struct {
+	Standard string `json:"standard"`
+	Contract string `json:"contract"`
+	Name     string `json:"name"`
+	Symbol   string `json:"symbol"`
+	Decimals int    `json:"decimals"`
+}
+
+var (
+	contractFixesOnce       sync.Once
+	contractFixesByAddress  map[string]*contractFix
+	contractFixesList       []contractFix
+	contractFixesLoadErrLog sync.Once
+)
+
+func normalizeContractAddress(addr string) string {
+	addr = strings.TrimSpace(addr)
+	addr = strings.ToLower(addr)
+	return strings.TrimPrefix(addr, "0x")
+}
+
+func loadContractFixes() {
+	var fixes []contractFix
+	if err := json.Unmarshal(contractFixesJSON, &fixes); err != nil {
+		contractFixesByAddress = nil
+		// Ensure we don't spam logs if this function is called repeatedly.
+		contractFixesLoadErrLog.Do(func() {
+			glog.Errorf("eth: cannot unmarshal embedded contract fixes: %v", err)
+		})
+		return
+	}
+
+	contractFixesByAddress = make(map[string]*contractFix, len(fixes))
+	contractFixesList = fixes
+	for i := range fixes {
+		key := normalizeContractAddress(fixes[i].Contract)
+		if key == "" {
+			continue
+		}
+		contractFixesByAddress[key] = &fixes[i]
+	}
+}
+
+func getContractFix(contractAddress string) *contractFix {
+	contractFixesOnce.Do(loadContractFixes)
+	if contractFixesByAddress == nil {
+		return nil
+	}
+	return contractFixesByAddress[normalizeContractAddress(contractAddress)]
+}
+
+type ContractFixInfo struct {
+	Contract string
+	Name     string
+	Symbol   string
+	Decimals int
+}
+
+// ContractFixes returns the full override list.
+// The slice is safe to read after initialization; callers should treat it as read-only.
+func ContractFixes() []ContractFixInfo {
+	contractFixesOnce.Do(loadContractFixes)
+	if contractFixesByAddress == nil {
+		return nil
+	}
+	out := make([]ContractFixInfo, 0, len(contractFixesList))
+	for i := range contractFixesList {
+		out = append(out, ContractFixInfo{
+			Contract: contractFixesList[i].Contract,
+			Name:     contractFixesList[i].Name,
+			Symbol:   contractFixesList[i].Symbol,
+			Decimals: contractFixesList[i].Decimals,
+		})
+	}
+	return out
+}
+
+// ApplyContractFixToContractInfo updates contract metadata in-place if we have an override.
+// It is intentionally conservative to stay backwards compatible:
+// - decimals are overwritten only when they differ
+// - name/symbol are overwritten only when the existing values are empty
+func ApplyContractFixToContractInfo(contractInfo *bchain.ContractInfo, contractAddress string) bool {
+	if contractInfo == nil {
+		return false
+	}
+	fix := getContractFix(contractAddress)
+	if fix == nil {
+		return false
+	}
+	changed := false
+
+	if contractInfo.Decimals != fix.Decimals {
+		contractInfo.Decimals = fix.Decimals
+		changed = true
+	}
+	if fix.Name != "" && contractInfo.Name == "" {
+		contractInfo.Name = fix.Name
+		changed = true
+	}
+	if fix.Symbol != "" && contractInfo.Symbol == "" {
+		contractInfo.Symbol = fix.Symbol
+		changed = true
+	}
+	return changed
+}
+

--- a/bchain/coins/eth/contract_fixes_ethereum.json
+++ b/bchain/coins/eth/contract_fixes_ethereum.json
@@ -1,0 +1,43 @@
+[
+  {
+    "standard": "ERC20",
+    "contract": "0xC19B6A4Ac7C7Cc24459F08984Bbd09664af17bD1",
+    "name": "Sensorium",
+    "symbol": "SENSO",
+    "decimals": 0,
+    "createdInBlock": 11098997
+  },
+  {
+    "standard": "ERC20",
+    "contract": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa",
+    "name": "mETH",
+    "symbol": "mETH",
+    "decimals": 18,
+    "createdInBlock": 18290587
+  },
+  {
+    "standard": "ERC20",
+    "contract": "0xE6829d9a7eE3040e1276Fa75293Bde931859e8fA",
+    "name": "cmETH",
+    "symbol": "cmETH",
+    "decimals": 18,
+    "createdInBlock": 20439180
+  },
+  {
+    "type": "ERC20",
+    "standard": "ERC20",
+    "contract": "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb",
+    "name": "Fluid",
+    "symbol": "FLUID",
+    "decimals": 18,
+    "createdInBlock": 12183236
+  },
+  {
+    "standard": "ERC20",
+    "contract": "0x7cf9a80db3b29ee8efe3710aadb7b95270572d47",
+    "name": "Nillion",
+    "symbol": "NIL",
+    "decimals": 6
+  }
+]
+

--- a/bchain/coins/eth/contract_fixes_test.go
+++ b/bchain/coins/eth/contract_fixes_test.go
@@ -1,0 +1,54 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+func TestContractFixes_LookupNILDecimalsCaseInsensitive(t *testing.T) {
+	contractLower := "0x7cf9a80db3b29ee8efe3710aadb7b95270572d47"
+	contractMixed := "0x7Cf9A80DB3b29Ee8eFe3710aAdB7B95270572d47"
+
+	f1 := getContractFix(contractLower)
+	if f1 == nil {
+		t.Fatalf("expected NIL contract fix to be found for %s", contractLower)
+	}
+	if f1.Decimals != 6 {
+		t.Fatalf("unexpected NIL decimals: got %d, want %d", f1.Decimals, 6)
+	}
+
+	f2 := getContractFix(contractMixed)
+	if f2 == nil {
+		t.Fatalf("expected NIL contract fix to be found for %s", contractMixed)
+	}
+	if f2.Decimals != 6 {
+		t.Fatalf("unexpected NIL decimals for mixed-case contract: got %d, want %d", f2.Decimals, 6)
+	}
+}
+
+func TestApplyContractFixToContractInfo_UpdatesDecimalsAndMetadata(t *testing.T) {
+	contract := "0x7cf9a80db3b29ee8efe3710aadb7b95270572d47"
+	ci := &bchain.ContractInfo{
+		Contract: contract,
+		Decimals: 18, // wrong; should be overridden
+		// Name/Symbol are intentionally empty to ensure they get filled when the DB value is incomplete.
+		Name:   "",
+		Symbol: "",
+	}
+
+	changed := ApplyContractFixToContractInfo(ci, contract)
+	if !changed {
+		t.Fatalf("expected ApplyContractFixToContractInfo to report a change")
+	}
+	if ci.Decimals != 6 {
+		t.Fatalf("unexpected decimals after apply: got %d, want %d", ci.Decimals, 6)
+	}
+	if ci.Name != "Nillion" {
+		t.Fatalf("unexpected name after apply: got %q, want %q", ci.Name, "Nillion")
+	}
+	if ci.Symbol != "NIL" {
+		t.Fatalf("unexpected symbol after apply: got %q, want %q", ci.Symbol, "NIL")
+	}
+}
+

--- a/configs/contract-fix/ethereum.json
+++ b/configs/contract-fix/ethereum.json
@@ -31,5 +31,12 @@
         "symbol": "FLUID",
         "decimals": 18,
         "createdInBlock": 12183236
+    },
+    {
+        "standard": "ERC20",
+        "contract": "0x7cf9a80db3b29ee8efe3710aadb7b95270572d47",
+        "name": "Nillion",
+        "symbol": "NIL",
+        "decimals": 6
     }
 ]


### PR DESCRIPTION
Fixes incorrect NIL (Nillion) token balance display. On-chain decimals is 6 but Blockbook had 18 stored causing balances to appear 10^12 times smaller than actual. Adds contract fix override to correct this.