### PR TITLE
feat(tron): split bandwidth into staked and free fields

### DIFF
--- a/bchain/coins/tron/tronhttp_endpoints.go
+++ b/bchain/coins/tron/tronhttp_endpoints.go
@@ -85,10 +85,12 @@ func (b *TronRPC) GetAddressChainExtraData(addrDesc bchain.AddressDescriptor) (j
 	}
 
 	payload, err := json.Marshal(bchain.TronAccountExtraData{
-		AvailableBandwidth: tronAvailableResource(resp.FreeNetLimit, resp.FreeNetUsed) + tronAvailableResource(resp.NetLimit, resp.NetUsed),
-		TotalBandwidth:     resp.FreeNetLimit + resp.NetLimit,
-		AvailableEnergy:    tronAvailableResource(resp.EnergyLimit, resp.EnergyUsed),
-		TotalEnergy:        resp.EnergyLimit,
+		AvailableStakedBandwidth: tronAvailableResource(resp.NetLimit, resp.NetUsed),
+		TotalStakedBandwidth:     resp.NetLimit,
+		AvailableFreeBandwidth:   tronAvailableResource(resp.FreeNetLimit, resp.FreeNetUsed),
+		TotalFreeBandwidth:       resp.FreeNetLimit,
+		AvailableEnergy:          tronAvailableResource(resp.EnergyLimit, resp.EnergyUsed),
+		TotalEnergy:              resp.EnergyLimit,
 	})
 	if err != nil {
 		return nil, err

--- a/bchain/coins/tron/tronrpc_test.go
+++ b/bchain/coins/tron/tronrpc_test.go
@@ -461,8 +461,10 @@ func TestTronRPC_GetAddressChainExtraData(t *testing.T) {
 	payload, err := tronRPC.GetAddressChainExtraData(addrDesc)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
-		"availableBandwidth":650,
-		"totalBandwidth":1000,
+		"availableStakedBandwidth":150,
+		"totalStakedBandwidth":400,
+		"availableFreeBandwidth":500,
+		"totalFreeBandwidth":600,
 		"availableEnergy":7766,
 		"totalEnergy":9000
 	}`, string(payload))
@@ -501,10 +503,12 @@ func TestTronRPC_GetAddressChainExtraData_MissingFieldsClampToZero(t *testing.T)
 	var extra bchain.TronAccountExtraData
 	require.NoError(t, json.Unmarshal(payload, &extra))
 	require.Equal(t, bchain.TronAccountExtraData{
-		AvailableBandwidth: 40,
-		TotalBandwidth:     150,
-		AvailableEnergy:    0,
-		TotalEnergy:        0,
+		AvailableStakedBandwidth: 40,
+		TotalStakedBandwidth:     50,
+		AvailableFreeBandwidth:   0,
+		TotalFreeBandwidth:       100,
+		AvailableEnergy:          0,
+		TotalEnergy:              0,
 	}, extra)
 }
 

--- a/bchain/types_chainextradata.go
+++ b/bchain/types_chainextradata.go
@@ -37,8 +37,10 @@ type TronChainExtraData struct {
 
 // TronAccountExtraData contains normalized Tron-specific account resource metadata.
 type TronAccountExtraData struct {
-	AvailableBandwidth int64 `json:"availableBandwidth"`
-	TotalBandwidth     int64 `json:"totalBandwidth"`
-	AvailableEnergy    int64 `json:"availableEnergy"`
-	TotalEnergy        int64 `json:"totalEnergy"`
+	AvailableStakedBandwidth int64 `json:"availableStakedBandwidth"`
+	TotalStakedBandwidth     int64 `json:"totalStakedBandwidth"`
+	AvailableFreeBandwidth   int64 `json:"availableFreeBandwidth"`
+	TotalFreeBandwidth       int64 `json:"totalFreeBandwidth"`
+	AvailableEnergy          int64 `json:"availableEnergy"`
+	TotalEnergy              int64 `json:"totalEnergy"`
 }

--- a/blockbook-api.ts
+++ b/blockbook-api.ts
@@ -30,8 +30,10 @@ export interface TronChainExtraData {
     votes?: TronVoteExtra[];
 }
 export interface TronAccountExtraData {
-    availableBandwidth: number;
-    totalBandwidth: number;
+    availableStakedBandwidth: number;
+    totalStakedBandwidth: number;
+    availableFreeBandwidth: number;
+    totalFreeBandwidth: number;
     availableEnergy: number;
     totalEnergy: number;
 }

--- a/server/public_tron_test.go
+++ b/server/public_tron_test.go
@@ -84,7 +84,7 @@ func httpTestsTron(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"page":1,"totalPages":1,"itemsOnPage":1000,"address":"TZEZWXYQS44388xBoMhQdpL1HrBZFLfDpt","balance":"123450255","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":1,"nonTokenTxs":1,"internalTxs":1,"txids":["a431984fef1d014620504d02f821f872221cf44c250a81a31e81fa4855b2b302"],"nonce":"255","tokens":[{"type":"TRC20","standard":"TRC20","name":"TronTestContract236","contract":"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf","transfers":1,"symbol":"TRC236","decimals":6,"balance":"1000255236"}],"chainExtraData":{"payloadType":"tron","payload":{"availableBandwidth":255,"totalBandwidth":1255,"availableEnergy":25500,"totalEnergy":35500}}}`,
+				`{"page":1,"totalPages":1,"itemsOnPage":1000,"address":"TZEZWXYQS44388xBoMhQdpL1HrBZFLfDpt","balance":"123450255","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":1,"nonTokenTxs":1,"internalTxs":1,"txids":["a431984fef1d014620504d02f821f872221cf44c250a81a31e81fa4855b2b302"],"nonce":"255","tokens":[{"type":"TRC20","standard":"TRC20","name":"TronTestContract236","contract":"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf","transfers":1,"symbol":"TRC236","decimals":6,"balance":"1000255236"}],"chainExtraData":{"payloadType":"tron","payload":{"availableStakedBandwidth":255,"totalStakedBandwidth":1255,"availableFreeBandwidth":755,"totalFreeBandwidth":1755,"availableEnergy":25500,"totalEnergy":35500}}}`,
 			},
 		},
 		{
@@ -161,7 +161,7 @@ var websocketTestsTron = []websocketTest{
 				"details":    "txids",
 			},
 		},
-		want: `{"id":"2","data":{"page":1,"totalPages":1,"itemsOnPage":25,"address":"TZEZWXYQS44388xBoMhQdpL1HrBZFLfDpt","balance":"123450255","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":1,"nonTokenTxs":1,"internalTxs":1,"txids":["a431984fef1d014620504d02f821f872221cf44c250a81a31e81fa4855b2b302"],"nonce":"255","tokens":[{"type":"TRC20","standard":"TRC20","name":"TronTestContract236","contract":"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf","transfers":1,"symbol":"TRC236","decimals":6,"balance":"1000255236"}],"chainExtraData":{"payloadType":"tron","payload":{"availableBandwidth":255,"totalBandwidth":1255,"availableEnergy":25500,"totalEnergy":35500}}}}`,
+		want: `{"id":"2","data":{"page":1,"totalPages":1,"itemsOnPage":25,"address":"TZEZWXYQS44388xBoMhQdpL1HrBZFLfDpt","balance":"123450255","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":1,"nonTokenTxs":1,"internalTxs":1,"txids":["a431984fef1d014620504d02f821f872221cf44c250a81a31e81fa4855b2b302"],"nonce":"255","tokens":[{"type":"TRC20","standard":"TRC20","name":"TronTestContract236","contract":"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf","transfers":1,"symbol":"TRC236","decimals":6,"balance":"1000255236"}],"chainExtraData":{"payloadType":"tron","payload":{"availableStakedBandwidth":255,"totalStakedBandwidth":1255,"availableFreeBandwidth":755,"totalFreeBandwidth":1755,"availableEnergy":25500,"totalEnergy":35500}}}}`,
 	},
 }
 

--- a/server/tron_template_test.go
+++ b/server/tron_template_test.go
@@ -83,14 +83,14 @@ func TestAccountChainExtra(t *testing.T) {
 		addr := &api.Address{
 			ChainExtraData: &api.AccountChainExtraData{
 				PayloadType: "tron",
-				Payload:     json.RawMessage(`{"availableBandwidth":600,"totalBandwidth":1000,"availableEnergy":1234,"totalEnergy":9000}`),
+				Payload:     json.RawMessage(`{"availableStakedBandwidth":400,"totalStakedBandwidth":700,"availableFreeBandwidth":200,"totalFreeBandwidth":300,"availableEnergy":1234,"totalEnergy":9000}`),
 			},
 		}
 		got := accountChainExtra(addr)
 		if got == nil {
 			t.Fatal("expected extra data")
 		}
-		if got.AvailableBandwidth != 600 || got.TotalBandwidth != 1000 {
+		if got.AvailableStakedBandwidth != 400 || got.TotalStakedBandwidth != 700 || got.AvailableFreeBandwidth != 200 || got.TotalFreeBandwidth != 300 {
 			t.Fatalf("unexpected bandwidth values %+v", got)
 		}
 		if got.AvailableEnergy != 1234 || got.TotalEnergy != 9000 {

--- a/static/templates/address_chainextra_tron.html
+++ b/static/templates/address_chainextra_tron.html
@@ -5,8 +5,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>Bandwidth</td>
-    <td>{{formatInt64 $chainExtra.AvailableBandwidth}} / {{formatInt64 $chainExtra.TotalBandwidth}}</td>
+    <td>Staked Bandwidth</td>
+    <td>{{formatInt64 $chainExtra.AvailableStakedBandwidth}} / {{formatInt64 $chainExtra.TotalStakedBandwidth}}</td>
+</tr>
+<tr>
+    <td>Free Bandwidth</td>
+    <td>{{formatInt64 $chainExtra.AvailableFreeBandwidth}} / {{formatInt64 $chainExtra.TotalFreeBandwidth}}</td>
 </tr>
 <tr>
     <td>Energy</td>

--- a/tests/dbtestdata/fakechain_tron.go
+++ b/tests/dbtestdata/fakechain_tron.go
@@ -156,10 +156,12 @@ func (c *fakeBlockChainTronType) GetAddressChainExtraData(addrDesc bchain.Addres
 	}
 
 	payload, err := json.Marshal(&bchain.TronAccountExtraData{
-		AvailableBandwidth: seed,
-		TotalBandwidth:     seed + 1000,
-		AvailableEnergy:    seed * 100,
-		TotalEnergy:        seed*100 + 10000,
+		AvailableStakedBandwidth: seed,
+		TotalStakedBandwidth:     seed + 1000,
+		AvailableFreeBandwidth:   seed + 500,
+		TotalFreeBandwidth:       seed + 1500,
+		AvailableEnergy:          seed * 100,
+		TotalEnergy:              seed*100 + 10000,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Previously `availableBandwidth` and `totalBandwidth` summed staked NET and free NET together. This PR splits them into separate fields so consumers can distinguish the two sources:

  - `availableStakedBandwidth` / `totalStakedBandwidth` — from `NetLimit` / `NetUsed`
  - `availableFreeBandwidth` / `totalFreeBandwidth` — from `FreeNetLimit` / `FreeNetUsed`



## Screenshots

*Resources section showing staked and free bandwidth as separate rows*
<img width="1311" height="822" alt="image" src="https://github.com/user-attachments/assets/92fe1e63-85d2-4c97-bfca-c0e0ae1e25dc" />
