### PR TITLE
1465 tron recognize account activation

### DIFF
--- a/bchain/coins/tron/tronrpc.go
+++ b/bchain/coins/tron/tronrpc.go
@@ -48,6 +48,7 @@ type tronResourceCode int64
 type tronTxContractValue struct {
 	OwnerAddress    string            `json:"owner_address,omitempty"`
 	ToAddress       string            `json:"to_address,omitempty"`
+	AccountAddress  string            `json:"account_address,omitempty"`
 	ContractAddress string            `json:"contract_address,omitempty"`
 	ReceiverAddress string            `json:"receiver_address,omitempty"`
 	Resource        *tronResourceCode `json:"resource,omitempty"`

--- a/bchain/coins/tron/txextra.go
+++ b/bchain/coins/tron/txextra.go
@@ -36,6 +36,8 @@ type tronGetTransactionInfoByIDResponse struct {
 
 func tronOperationFromContractType(contractType string) string {
 	switch contractType {
+	case "AccountCreateContract":
+		return "activateAccount"
 	case "VoteWitnessContract":
 		return "vote"
 	case "FreezeBalanceContract", "FreezeBalanceV2Contract":
@@ -159,6 +161,8 @@ func tronBuildRpcTransaction(txByID *tronGetTransactionByIDResponse, txInfo *tro
 		v := c.Parameter.Value
 		tx.From = ToTronAddressFromAddress(v.OwnerAddress)
 		switch c.Type {
+		case "AccountCreateContract":
+			tx.To = strings.TrimSpace(v.AccountAddress)
 		case "TransferContract", "TransferAssetContract":
 			tx.To = strings.TrimSpace(v.ToAddress)
 			tx.Value = tronInt64PtrToHexQuantity(v.Amount)

--- a/bchain/coins/tron/txextra_test.go
+++ b/bchain/coins/tron/txextra_test.go
@@ -46,6 +46,17 @@ func TestTronBuildExtraData_VoteWitness(t *testing.T) {
 	require.Equal(t, "3", extra.Votes[1].Count)
 }
 
+func TestTronBuildExtraData_AccountCreateOperation(t *testing.T) {
+	contract := tronTxContract{Type: "AccountCreateContract"}
+	txByID := &tronGetTransactionByIDResponse{}
+	txByID.RawData.Contract = []tronTxContract{contract}
+	txInfo := &tronGetTransactionInfoByIDResponse{}
+
+	extra := tronBuildExtraData(txByID, txInfo)
+	require.Equal(t, "AccountCreateContract", extra.ContractType)
+	require.Equal(t, "activateAccount", extra.Operation)
+}
+
 func TestTronBuildExtraData_StakeAndDelegateDetails(t *testing.T) {
 	t.Run("stake amount", func(t *testing.T) {
 		contract := tronTxContract{Type: "FreezeBalanceV2Contract"}
@@ -182,6 +193,27 @@ func TestTronBuildRpcTransaction_ValueIsEthereumHexQuantity(t *testing.T) {
 			require.Equal(t, tt.want, value.Int64())
 		})
 	}
+}
+
+func TestTronBuildRpcTransaction_AccountCreateContractSetsToAddress(t *testing.T) {
+	contract := tronTxContract{Type: "AccountCreateContract"}
+	contract.Parameter.Value.OwnerAddress = "41508b7b8057fc9170398a65bbc89ff3ccfcc0f4a5"
+	contract.Parameter.Value.AccountAddress = "41da79e32a568680fccedadcab18a6e1bc231c0476"
+
+	txByID := &tronGetTransactionByIDResponse{
+		TxID: "e5babca390bfb5ba2e26151f031893f5b01237536fbd700f5f563423a1dc1b7d",
+	}
+	txByID.RawData.Contract = []tronTxContract{contract}
+
+	txInfo := &tronGetTransactionInfoByIDResponse{
+		BlockNumber: int64Ptr(1),
+	}
+
+	tx := tronBuildRpcTransaction(txByID, txInfo)
+
+	require.Equal(t, ToTronAddressFromAddress(contract.Parameter.Value.OwnerAddress), tx.From)
+	require.Equal(t, contract.Parameter.Value.AccountAddress, tx.To)
+	require.Equal(t, "0x0", tx.Value)
 }
 
 func TestTronGetTransactionInfoByIDResponse_IgnoresCancelUnfreezeV2AmountShape(t *testing.T) {

--- a/tests/rpc/testdata/tron.json
+++ b/tests/rpc/testdata/tron.json
@@ -280,6 +280,35 @@
           "bandwidthUsage": "273"
         }
       }
+    },
+    "e5babca390bfb5ba2e26151f031893f5b01237536fbd700f5f563423a1dc1b7d": {
+      "txid": "e5babca390bfb5ba2e26151f031893f5b01237536fbd700f5f563423a1dc1b7d",
+      "blockTime": 1775651697,
+      "time": 1775651697,
+      "vin": [
+        {
+          "addresses": [
+            "THK69pBoDrnkjoTg11PUmAkQHQd4nWqdev"
+          ]
+        }
+      ],
+      "vout": [
+        {
+          "value": 0,
+          "scriptPubKey": {
+            "addresses": [
+              "TVtQKm4vq5CCmLZEifozM11gyTYiYRajsL"
+            ]
+          }
+        }
+      ],
+      "coinSpecificData": {
+        "chainExtraData": {
+          "contractType": "AccountCreateContract",
+          "operation": "activateAccount",
+          "totalFee": "1100000"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Added support for TRON AccountCreateContract parsing so account-activation txs are no longer shown as unparsed.
- Mapped AccountCreateContract to set tx.To = account_address
- Added acccount activation tx to Tron RPC tests (`tests/rpc/testdata/tron.json`)
