### PR TITLE
Override Message Queue url in config from env vars

### DIFF
--- a/.github/actions/export-env-vars/action.yml
+++ b/.github/actions/export-env-vars/action.yml
@@ -24,8 +24,10 @@ runs:
         alias_prefixes = (
             "BB_DEV_RPC_URL_HTTP_",
             "BB_DEV_RPC_URL_WS_",
+            "BB_DEV_MQ_URL_",
             "BB_PROD_RPC_URL_HTTP_",
             "BB_PROD_RPC_URL_WS_",
+            "BB_PROD_MQ_URL_",
             "BB_RPC_BIND_HOST_",
             "BB_RPC_ALLOW_IP_",
             "BB_DEV_API_URL_HTTP_",

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ TCMALLOC =
 PORTABLE = 0
 ARGS ?=
 GITCOMMIT ?= $(shell git describe --always --dirty 2>/dev/null)
-# Forward BB_BUILD_ENV, BB_*_RPC_URL_*, BB_RPC_*, and BB_DEV_API_* overrides into Docker for build/test tooling.
-BB_RPC_ENV := $(shell env | awk -F= '/^BB_BUILD_ENV$$|^BB_(DEV|PROD)_RPC_URL_(HTTP|WS)_|^BB_RPC_(BIND_HOST|ALLOW_IP)_|^BB_DEV_API_URL_(HTTP|WS)_/ {print "-e " $$1}')
+# Forward BB_BUILD_ENV, BB_*_RPC_URL_*, BB_*_MQ_URL_*, BB_RPC_*, and BB_DEV_API_* overrides into Docker for build/test tooling.
+BB_RPC_ENV := $(shell env | awk -F= '/^BB_BUILD_ENV$$|^BB_(DEV|PROD)_RPC_URL_(HTTP|WS)_|^BB_(DEV|PROD)_MQ_URL_|^BB_RPC_(BIND_HOST|ALLOW_IP)_|^BB_DEV_API_URL_(HTTP|WS)_/ {print "-e " $$1}')
 
 TARGETS=$(subst .json,, $(shell ls configs/coins))
 

--- a/build/tools/templates.go
+++ b/build/tools/templates.go
@@ -119,8 +119,10 @@ const (
 	buildEnvProd         = "prod"
 	devRPCURLHTTPPrefix  = "BB_DEV_RPC_URL_HTTP_"
 	devRPCURLWSPrefix    = "BB_DEV_RPC_URL_WS_"
+	devMQURLPrefix       = "BB_DEV_MQ_URL_"
 	prodRPCURLHTTPPrefix = "BB_PROD_RPC_URL_HTTP_"
 	prodRPCURLWSPrefix   = "BB_PROD_RPC_URL_WS_"
+	prodMQURLPrefix      = "BB_PROD_MQ_URL_"
 )
 
 func jsonToString(msg json.RawMessage) (string, error) {
@@ -214,8 +216,10 @@ func rpcEnvPrefixes() []string {
 	return []string{
 		devRPCURLWSPrefix,
 		devRPCURLHTTPPrefix,
+		devMQURLPrefix,
 		prodRPCURLWSPrefix,
 		prodRPCURLHTTPPrefix,
+		prodMQURLPrefix,
 		"BB_RPC_BIND_HOST_",
 		"BB_RPC_ALLOW_IP_",
 	}
@@ -262,6 +266,15 @@ func rpcURLPrefixesForBuildEnv(buildEnv string) (string, string) {
 		return prodRPCURLHTTPPrefix, prodRPCURLWSPrefix
 	default:
 		return devRPCURLHTTPPrefix, devRPCURLWSPrefix
+	}
+}
+
+func mqURLPrefixForBuildEnv(buildEnv string) string {
+	switch buildEnv {
+	case buildEnvProd:
+		return prodMQURLPrefix
+	default:
+		return devMQURLPrefix
 	}
 }
 
@@ -386,6 +399,7 @@ func LoadConfig(configsDir, coin string) (*Config, error) {
 	}
 
 	rpcURLHTTPPrefix, rpcURLWSPrefix := rpcURLPrefixesForBuildEnv(buildEnv)
+	mqURLPrefix := mqURLPrefixForBuildEnv(buildEnv)
 
 	// Resolve RPC env by exact alias first and fall back to *_archive for shared test/deploy wiring.
 	if rpcURL, ok := lookupEnvWithArchiveFallback(rpcURLHTTPPrefix, config.Coin.Alias); ok {
@@ -394,6 +408,9 @@ func LoadConfig(configsDir, coin string) (*Config, error) {
 	}
 	if rpcURLWS, ok := lookupEnvWithArchiveFallback(rpcURLWSPrefix, config.Coin.Alias); ok {
 		config.IPC.RPCURLWSTemplate = rpcURLWS
+	}
+	if mqURL, ok := lookupEnvWithArchiveFallback(mqURLPrefix, config.Coin.Alias); ok {
+		config.IPC.MessageQueueBindingTemplate = mqURL
 	}
 
 	if !isEmpty(config, "backend") {

--- a/build/tools/templates_test.go
+++ b/build/tools/templates_test.go
@@ -162,6 +162,87 @@ func TestLoadConfigSetsWantsBackendServiceFromEffectiveRPCURL(t *testing.T) {
 	})
 }
 
+func TestLoadConfigOverridesMessageQueueBindingFromEnv(t *testing.T) {
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	withTemporarilyUnsetEnv(t,
+		buildEnvVar,
+		devMQURLPrefix+"bitcoin",
+		devMQURLPrefix+"bitcoin_archive",
+		prodMQURLPrefix+"bitcoin",
+		prodMQURLPrefix+"bitcoin_archive",
+	)
+
+	t.Setenv(buildEnvVar, buildEnvDev)
+	t.Setenv(devMQURLPrefix+"bitcoin", "tcp://mq-dev.example:38330")
+
+	config, err := LoadConfig(configsDir, "bitcoin")
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	renderedMQ, err := renderConfigTemplate(config, "IPC.MessageQueueBindingTemplate")
+	if err != nil {
+		t.Fatalf("renderConfigTemplate(MessageQueueBindingTemplate) error = %v", err)
+	}
+	if renderedMQ != "tcp://mq-dev.example:38330" {
+		t.Fatalf("message_queue_binding = %q, want %q", renderedMQ, "tcp://mq-dev.example:38330")
+	}
+}
+
+func TestLoadConfigUsesProdMQOverrideWhenBuildEnvIsProd(t *testing.T) {
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	withTemporarilyUnsetEnv(t,
+		buildEnvVar,
+		devMQURLPrefix+"bitcoin",
+		prodMQURLPrefix+"bitcoin",
+	)
+
+	t.Setenv(buildEnvVar, buildEnvProd)
+	t.Setenv(devMQURLPrefix+"bitcoin", "tcp://mq-dev.example:38330")
+	t.Setenv(prodMQURLPrefix+"bitcoin", "tcp://mq-prod.example:48330")
+
+	config, err := LoadConfig(configsDir, "bitcoin")
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	renderedMQ, err := renderConfigTemplate(config, "IPC.MessageQueueBindingTemplate")
+	if err != nil {
+		t.Fatalf("renderConfigTemplate(MessageQueueBindingTemplate) error = %v", err)
+	}
+	if renderedMQ != "tcp://mq-prod.example:48330" {
+		t.Fatalf("message_queue_binding = %q, want %q", renderedMQ, "tcp://mq-prod.example:48330")
+	}
+}
+
+func TestLoadConfigUsesUnderscoreMQOverrideForHyphenAlias(t *testing.T) {
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	withTemporarilyUnsetEnv(t,
+		buildEnvVar,
+		devMQURLPrefix+"ethereum_classic",
+		prodMQURLPrefix+"ethereum_classic",
+	)
+
+	t.Setenv(buildEnvVar, buildEnvDev)
+	t.Setenv(devMQURLPrefix+"ethereum_classic", "tcp://mq-classic.example:9037")
+
+	config, err := LoadConfig(configsDir, "ethereum-classic")
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	renderedMQ, err := renderConfigTemplate(config, "IPC.MessageQueueBindingTemplate")
+	if err != nil {
+		t.Fatalf("renderConfigTemplate(MessageQueueBindingTemplate) error = %v", err)
+	}
+	if renderedMQ != "tcp://mq-classic.example:9037" {
+		t.Fatalf("message_queue_binding = %q, want %q", renderedMQ, "tcp://mq-classic.example:9037")
+	}
+}
+
 func TestBlockbookServiceTemplateGatesWantsLine(t *testing.T) {
 	config := &Config{}
 	config.Coin.Name = "Bitcoin"

--- a/docs/build.md
+++ b/docs/build.md
@@ -101,6 +101,11 @@ Resolution prefers the exact alias and also accepts archive variants such as `<a
 subscriptions. The selected value should point to the same host as the selected HTTP RPC override and follows the same
 fallback resolution.
 
+`BB_DEV_MQ_URL_<coin alias>` / `BB_PROD_MQ_URL_<coin alias>`: Override `ipc.message_queue_binding_template` during
+package/config generation. The value is used as-is and should be a full MQ endpoint such as
+`tcp://backend_hostname:28332`. The root `Makefile` forwards these variables into the Docker build/test containers and
+the same alias/archive fallback resolution applies.
+
 Example:
 `BB_BUILD_ENV=prod BB_PROD_RPC_URL_HTTP_ethereum=http://backend_hostname:1234 BB_PROD_RPC_URL_WS_ethereum_archive=ws://backend_hostname:1234 make deb-ethereum_archive`.
 

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -92,6 +92,7 @@ Special cases:
 | Runner mapping                | BB_RUNNER_<coin>                       | BB_RUNNER_POLYGON_ARCHIVE            |
 | Build env selector            | BB_BUILD_ENV                           | dev                                  |
 | Backend RPC env identity      | coin.alias                             | BB_DEV_RPC_URL_HTTP_polygon_archive_bor |
+| Backend MQ env identity       | coin.alias                             | BB_DEV_MQ_URL_polygon_archive_bor    |
 | Blockbook package name        | blockbook.package_name                 | blockbook-polygon                    |
 | Backend package name          | backend.package_name                   | backend-polygon                      |
 | Build target identity         | workflow/config coin name              | deb-blockbook-polygon_archive        |

--- a/docs/config.md
+++ b/docs/config.md
@@ -47,7 +47,10 @@ Good examples of coin configuration are
     * `rpc_pass` – Password of back-end RPC service, used by both Blockbook and back-end configuration templates.
     * `rpc_timeout` – RPC timeout used by Blockbook.
     * `message_queue_binding_template` – Template that defines URL of back-end's message queue (ZMQ), used by both
-       Blockbook and back-end configuration template. See note on templates below.
+       Blockbook and back-end configuration template. You can override it at build time by setting the selected
+       `BB_DEV_MQ_URL_<coin alias>` or `BB_PROD_MQ_URL_<coin alias>` variable (for example,
+       `BB_BUILD_ENV=dev BB_DEV_MQ_URL_bitcoin=tcp://backend_hostname:28332`), which is used as-is during template
+       generation. See note on templates below.
 
 * `backend` – Definition of back-end package, configuration and service.
     * `package_name` – Name of package. See convention note in [build guide](/docs/build.md#on-naming-conventions-and-versioning).

--- a/docs/env.md
+++ b/docs/env.md
@@ -29,6 +29,10 @@ Some behavior of Blockbook can be modified by environment variables. The variabl
 -   `BB_DEV_RPC_URL_WS_<coin alias>` / `BB_PROD_RPC_URL_WS_<coin alias>` - Override `ipc.rpc_url_ws_template` for
     WebSocket subscriptions; should point to the same host as the selected HTTP RPC override and follows the same
     fallback resolution.
+-   `BB_DEV_MQ_URL_<coin alias>` / `BB_PROD_MQ_URL_<coin alias>` - Override `ipc.message_queue_binding_template`
+    during package/config generation. The value is used as-is, so it should include the full MQ transport URL
+    (for example `tcp://backend_hostname:28332`). This follows the same alias/archive fallback resolution as the
+    RPC URL overrides.
 -   `BB_RPC_BIND_HOST_<coin alias>` - Overrides backend RPC bind host during package/config generation; when set to
     `0.0.0.0`, RPC stays restricted unless `BB_RPC_ALLOW_IP_<coin alias>` is set.
 -   `BB_RPC_ALLOW_IP_<coin alias>` - Overrides backend RPC allow list for UTXO configs (e.g. `rpcallowip`), defaulting

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,7 @@ URLs that link to *localhost*. If you need run tests against remote servers, the
 * tests use `BB_BUILD_ENV=dev`
 * set `BB_DEV_RPC_URL_HTTP_<coin alias>` to override `rpc_url_template` during template generation (forwarded into Docker by the root `Makefile`)
 * set `BB_DEV_RPC_URL_WS_<coin alias>` to override `rpc_url_ws_template` for WebSocket subscriptions when needed
+* set `BB_DEV_MQ_URL_<coin alias>` to override `message_queue_binding_template` when tests need a non-local MQ binding
 * temporarily change config
 * SSH tunneling – `ssh -nNT -L 8030:localhost:8030 remote-server`
 * HTTP proxy


### PR DESCRIPTION
If Tron or BTC blockbooks do not have backend/node running on the same host, their MQ would not connect to it since it always points to `localhost` from configuration. 

Introducing the same mechanism as we have for RPC : 
```
BB_*_RPC_URL_HTTP
BB_*_RPC_URL_WS
```
- `*` = DEV/PROD

Now we would have also :
```
BB_*_MQ_URL
```