### PR TITLE
Accept non-standard tx versions outside int32 range

### DIFF
--- a/bchain/coins/btc/bitcoinparser.go
+++ b/bchain/coins/btc/bitcoinparser.go
@@ -80,9 +80,14 @@ type Vout struct {
 // Tx is blockchain transaction
 // unnecessary fields are commented out to avoid overhead
 type Tx struct {
-	Hex         string       `json:"hex"`
-	Txid        string       `json:"txid"`
-	Version     int32        `json:"version"`
+	Hex  string `json:"hex"`
+	Txid string `json:"txid"`
+	// Version is decoded as uint32 to tolerate non-standard/invalid tx
+	// versions present on Bitcoin mainnet (e.g. tx 637dd1a3...fef7413f in
+	// block 256818 has version 2187681472, which overflows int32). It is
+	// bit-cast to int32 in ParseTxFromJson to match the value the binary
+	// block parser produces via wire.MsgTx.Deserialize.
+	Version     uint32       `json:"version"`
 	LockTime    uint32       `json:"locktime"`
 	VSize       int64        `json:"vsize,omitempty"`
 	Vin         []bchain.Vin `json:"vin"`
@@ -108,7 +113,7 @@ func (p *BitcoinParser) ParseTxFromJson(msg json.RawMessage) (*bchain.Tx, error)
 	// it is necessary to copy bitcoinTx to Tx to make it compatible
 	tx.Hex = bitcoinTx.Hex
 	tx.Txid = bitcoinTx.Txid
-	tx.Version = bitcoinTx.Version
+	tx.Version = int32(bitcoinTx.Version)
 	tx.LockTime = bitcoinTx.LockTime
 	tx.VSize = bitcoinTx.VSize
 	tx.Vin = bitcoinTx.Vin

--- a/bchain/coins/btc/bitcoinparser_test.go
+++ b/bchain/coins/btc/bitcoinparser_test.go
@@ -1312,3 +1312,49 @@ func TestBitcoinParser_DerivationBasePath(t *testing.T) {
 		})
 	}
 }
+
+// TestParseTxFromJson_VersionOverflow exercises ParseTxFromJson with
+// non-standard/invalid tx-version values that don't fit in int32.
+// Bitcoin Core serializes the transaction's version field as an unsigned
+// 32-bit integer in JSON, so values above math.MaxInt32 (e.g. the historical
+// mainnet tx 637dd1a3418386a418ceeac7bb58633a904dbf127fa47bbea9cc8f86fef7413f
+// in block 256818, whose version is 2187681472) must be accepted and
+// bit-cast to int32 to match the value produced by the binary block parser.
+func TestParseTxFromJson_VersionOverflow(t *testing.T) {
+	p := NewBitcoinParser(GetChainParams("main"), &Configuration{})
+	tests := []struct {
+		name        string
+		jsonVersion string
+		wantVersion int32
+	}{
+		{
+			name:        "standard version 2",
+			jsonVersion: "2",
+			wantVersion: 2,
+		},
+		{
+			// uint32 0x826C6B40 == 2187681472, bit-cast to int32 == -2107285824
+			name:        "real-world overflow tx 637dd1a3...",
+			jsonVersion: "2187681472",
+			wantVersion: -2107285824,
+		},
+		{
+			// uint32 0xFFFFFFFF, bit-cast to int32 == -1
+			name:        "uint32 max",
+			jsonVersion: "4294967295",
+			wantVersion: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := `{"hex":"00","txid":"637dd1a3418386a418ceeac7bb58633a904dbf127fa47bbea9cc8f86fef7413f","version":` + tt.jsonVersion + `,"locktime":0,"vin":[],"vout":[]}`
+			got, err := p.ParseTxFromJson([]byte(msg))
+			if err != nil {
+				t.Fatalf("ParseTxFromJson() unexpected error: %v", err)
+			}
+			if got.Version != tt.wantVersion {
+				t.Errorf("ParseTxFromJson() Version = %d, want %d", got.Version, tt.wantVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1111 

Bitcoin mainnet contains a handful of historical transactions whose  4-byte version field, interpreted as unsigned, exceeds int32 max  (e.g. 637dd1a3...fef7413f in block 256818, version 2187681472).  The binary block parser already tolerates this via wire.MsgTx's  int32 bit-cast, so these txs are correctly indexed during sync.  The /api/v2/tx/<txid> endpoint, however, refetches the tx body on  cache miss via getrawtransaction (JSON), and json.Unmarshal into  int32 rejected the value, surfacing as "Transaction not found  (json: cannot unmarshal number 2187681472 ...)".  

Decode btc.Tx.Version as uint32 in the JSON staging struct and  bit-cast to int32 when copying to bchain.Tx, mirroring the binary  path and the existing fallback pattern in litecoinparser.go. The  on-disk bchain.Tx.Version int32 type is unchanged, so no DB  migration is required.