### PR TITLE
Remove ContractInfo duplication from api types

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -64,6 +64,26 @@ func (w *Worker) enrichTokenProtocols(tokens Tokens, protocols []string) {
 	w.enrichErc4626Tokens(tokens)
 }
 
+// contractInfoResultFromBchain wraps bchain.ContractInfo into the API-level
+// ContractInfoResult. Rates and Protocols stay nil; callers that want
+// enrichment use GetContractInfoData directly.
+func contractInfoResultFromBchain(ci *bchain.ContractInfo, bestHeight uint32) *ContractInfoResult {
+	if ci == nil {
+		return nil
+	}
+	return &ContractInfoResult{
+		Type:              ci.Type,
+		Standard:          ci.Standard,
+		Contract:          ci.Contract,
+		Name:              ci.Name,
+		Symbol:            ci.Symbol,
+		Decimals:          ci.Decimals,
+		CreatedInBlock:    ci.CreatedInBlock,
+		DestructedInBlock: ci.DestructedInBlock,
+		BlockHeight:       bestHeight,
+	}
+}
+
 func (w *Worker) buildContractInfoRates(contract string, standard bchain.TokenStandardName, currency string) *ContractInfoRates {
 	if !contractInfoSupportsRates(standard) || w.fiatRates == nil {
 		return nil

--- a/api/types.go
+++ b/api/types.go
@@ -414,31 +414,31 @@ type StakingPool struct {
 // Address holds information about an address and its transactions
 type Address struct {
 	Paging
-	AddrStr               string               `json:"address" ts_doc:"The address string in standard format."`
-	BalanceSat            *Amount              `json:"balance" ts_doc:"Current confirmed balance (in satoshi or base units)."`
-	TotalReceivedSat      *Amount              `json:"totalReceived,omitempty" ts_doc:"Total amount ever received by this address."`
-	TotalSentSat          *Amount              `json:"totalSent,omitempty" ts_doc:"Total amount ever sent by this address."`
-	UnconfirmedBalanceSat *Amount              `json:"unconfirmedBalance" ts_doc:"Unconfirmed balance for this address."`
-	UnconfirmedTxs        int                  `json:"unconfirmedTxs" ts_doc:"Number of unconfirmed transactions for this address."`
-	UnconfirmedSending    *Amount              `json:"unconfirmedSending,omitempty" ts_doc:"Unconfirmed outgoing balance for this address."`
-	UnconfirmedReceiving  *Amount              `json:"unconfirmedReceiving,omitempty" ts_doc:"Unconfirmed incoming balance for this address."`
-	Txs                   int                  `json:"txs" ts_doc:"Number of transactions for this address (including confirmed)."`
-	AddrTxCount           int                  `json:"addrTxCount,omitempty" ts_doc:"Historical total count of transactions, if known."`
-	NonTokenTxs           int                  `json:"nonTokenTxs,omitempty" ts_doc:"Number of transactions not involving tokens (pure coin transfers)."`
-	InternalTxs           int                  `json:"internalTxs,omitempty" ts_doc:"Number of internal transactions (e.g., Ethereum calls)."`
-	Transactions          []*Tx                `json:"transactions,omitempty" ts_doc:"List of transaction details (if requested)."`
-	Txids                 []string             `json:"txids,omitempty" ts_doc:"List of transaction IDs (if detailed data is not requested)."`
-	Nonce                 string               `json:"nonce,omitempty" ts_doc:"Current transaction nonce for Ethereum-like addresses."`
-	UsedTokens            int                  `json:"usedTokens,omitempty" ts_doc:"Number of tokens with any historical usage at this address."`
-	Tokens                Tokens               `json:"tokens,omitempty" ts_doc:"List of tokens associated with this address."`
-	SecondaryValue        float64              `json:"secondaryValue,omitempty" ts_doc:"Total value of the address in secondary currency (e.g. fiat)."`
-	TokensBaseValue       float64              `json:"tokensBaseValue,omitempty" ts_doc:"Sum of token values in base currency."`
-	TokensSecondaryValue  float64              `json:"tokensSecondaryValue,omitempty" ts_doc:"Sum of token values in secondary currency (fiat)."`
-	TotalBaseValue        float64              `json:"totalBaseValue,omitempty" ts_doc:"Address's entire value in base currency, including tokens."`
-	TotalSecondaryValue   float64              `json:"totalSecondaryValue,omitempty" ts_doc:"Address's entire value in secondary currency, including tokens."`
-	ContractInfo          *bchain.ContractInfo `json:"contractInfo,omitempty" ts_doc:"Extra info if the address is a contract (ABI, type)."`
+	AddrStr               string              `json:"address" ts_doc:"The address string in standard format."`
+	BalanceSat            *Amount             `json:"balance" ts_doc:"Current confirmed balance (in satoshi or base units)."`
+	TotalReceivedSat      *Amount             `json:"totalReceived,omitempty" ts_doc:"Total amount ever received by this address."`
+	TotalSentSat          *Amount             `json:"totalSent,omitempty" ts_doc:"Total amount ever sent by this address."`
+	UnconfirmedBalanceSat *Amount             `json:"unconfirmedBalance" ts_doc:"Unconfirmed balance for this address."`
+	UnconfirmedTxs        int                 `json:"unconfirmedTxs" ts_doc:"Number of unconfirmed transactions for this address."`
+	UnconfirmedSending    *Amount             `json:"unconfirmedSending,omitempty" ts_doc:"Unconfirmed outgoing balance for this address."`
+	UnconfirmedReceiving  *Amount             `json:"unconfirmedReceiving,omitempty" ts_doc:"Unconfirmed incoming balance for this address."`
+	Txs                   int                 `json:"txs" ts_doc:"Number of transactions for this address (including confirmed)."`
+	AddrTxCount           int                 `json:"addrTxCount,omitempty" ts_doc:"Historical total count of transactions, if known."`
+	NonTokenTxs           int                 `json:"nonTokenTxs,omitempty" ts_doc:"Number of transactions not involving tokens (pure coin transfers)."`
+	InternalTxs           int                 `json:"internalTxs,omitempty" ts_doc:"Number of internal transactions (e.g., Ethereum calls)."`
+	Transactions          []*Tx               `json:"transactions,omitempty" ts_doc:"List of transaction details (if requested)."`
+	Txids                 []string            `json:"txids,omitempty" ts_doc:"List of transaction IDs (if detailed data is not requested)."`
+	Nonce                 string              `json:"nonce,omitempty" ts_doc:"Current transaction nonce for Ethereum-like addresses."`
+	UsedTokens            int                 `json:"usedTokens,omitempty" ts_doc:"Number of tokens with any historical usage at this address."`
+	Tokens                Tokens              `json:"tokens,omitempty" ts_doc:"List of tokens associated with this address."`
+	SecondaryValue        float64             `json:"secondaryValue,omitempty" ts_doc:"Total value of the address in secondary currency (e.g. fiat)."`
+	TokensBaseValue       float64             `json:"tokensBaseValue,omitempty" ts_doc:"Sum of token values in base currency."`
+	TokensSecondaryValue  float64             `json:"tokensSecondaryValue,omitempty" ts_doc:"Sum of token values in secondary currency (fiat)."`
+	TotalBaseValue        float64             `json:"totalBaseValue,omitempty" ts_doc:"Address's entire value in base currency, including tokens."`
+	TotalSecondaryValue   float64             `json:"totalSecondaryValue,omitempty" ts_doc:"Address's entire value in secondary currency, including tokens."`
+	ContractInfo          *ContractInfoResult `json:"contractInfo,omitempty" ts_doc:"Extra info if the address is a contract. Shape matches getContractInfo; rates and protocols are populated only when explicitly requested via getContractInfo."`
 	// Deprecated: replaced by ContractInfo
-	Erc20Contract  *bchain.ContractInfo   `json:"erc20Contract,omitempty" ts_doc:"@deprecated: replaced by contractInfo"`
+	Erc20Contract  *ContractInfoResult    `json:"erc20Contract,omitempty" ts_doc:"@deprecated: replaced by contractInfo"`
 	AddressAliases AddressAliasesMap      `json:"addressAliases,omitempty" ts_doc:"Aliases assigned to this address."`
 	StakingPools   []StakingPool          `json:"stakingPools,omitempty" ts_doc:"List of staking pool data if address interacts with staking."`
 	ChainExtraData *AccountChainExtraData `json:"chainExtraData,omitempty" ts_type:"{ payloadType: 'tron'; payload?: TronAccountExtraData } | { payloadType: string; payload?: any }" ts_doc:"Additional normalized chain-specific account/address data. Use payloadType as discriminator for payload."`

--- a/api/worker.go
+++ b/api/worker.go
@@ -1661,6 +1661,14 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 		}
 	}
 	uBalSat.Sub(&uBalReceiving, &uBalSending)
+	var contractInfoBestHeight uint32
+	if ed.contractInfo != nil {
+		h, _, err := w.db.GetBestBlock()
+		if err != nil {
+			return nil, errors.Annotatef(err, "GetBestBlock")
+		}
+		contractInfoBestHeight = h
+	}
 	r := &Address{
 		Paging:                pg,
 		AddrStr:               address,
@@ -1682,7 +1690,7 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 		TokensSecondaryValue:  ed.tokensSecondaryValue,
 		TotalBaseValue:        totalBaseValue,
 		TotalSecondaryValue:   totalSecondaryValue,
-		ContractInfo:          ed.contractInfo,
+		ContractInfo:          contractInfoResultFromBchain(ed.contractInfo, contractInfoBestHeight),
 		Nonce:                 ed.nonce,
 		AddressAliases:        w.getAddressAliases(addresses),
 		StakingPools:          ed.stakingPools,
@@ -1690,7 +1698,7 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 	}
 	// keep address backward compatible, set deprecated Erc20Contract value if ERC20 token
 	if ed.contractInfo != nil && ed.contractInfo.Standard == bchain.ERC20TokenStandard {
-		r.Erc20Contract = ed.contractInfo
+		r.Erc20Contract = r.ContractInfo
 	}
 	glog.Info("GetAddress-", option, " ", address, ", ", time.Since(start))
 	return r, nil

--- a/blockbook-api.ts
+++ b/blockbook-api.ts
@@ -261,23 +261,6 @@ export interface StakingPool {
     /** Any balance automatically reinvested into the pool. */
     autocompoundBalance?: string;
 }
-export interface ContractInfo {
-    /** @deprecated: Use standard instead. */
-    type: '' | 'XPUBAddress' | 'ERC20' | 'ERC721' | 'ERC1155' | 'BEP20' | 'BEP721' | 'BEP1155' | 'TRC20' | 'TRC721' | 'TRC1155';
-    standard: '' | 'XPUBAddress' | 'ERC20' | 'ERC721' | 'ERC1155' | 'BEP20' | 'BEP721' | 'BEP1155' | 'TRC20' | 'TRC721' | 'TRC1155';
-    /** Smart contract address. */
-    contract: string;
-    /** Readable name of the contract. */
-    name: string;
-    /** Symbol for tokens under this contract, if applicable. */
-    symbol: string;
-    /** Number of decimal places, if applicable. */
-    decimals: number;
-    /** Block height where contract was first created. */
-    createdInBlock?: number;
-    /** Block height where contract was destroyed (if any). */
-    destructedInBlock?: number;
-}
 export interface Erc4626TokenMetadata {
     /** Token contract address. */
     contract: string;
@@ -390,10 +373,10 @@ export interface Address {
     totalBaseValue?: number;
     /** Address's entire value in secondary currency, including tokens. */
     totalSecondaryValue?: number;
-    /** Extra info if the address is a contract (ABI, type). */
-    contractInfo?: ContractInfo;
+    /** Extra info if the address is a contract. Shape matches getContractInfo; rates and protocols are populated only when explicitly requested via getContractInfo. */
+    contractInfo?: ContractInfoResult;
     /** @deprecated: replaced by contractInfo */
-    erc20Contract?: ContractInfo;
+    erc20Contract?: ContractInfoResult;
     /** Aliases assigned to this address. */
     addressAliases?: {[key: string]: AddressAlias};
     /** List of staking pool data if address interacts with staking. */

--- a/server/public_tron_test.go
+++ b/server/public_tron_test.go
@@ -111,7 +111,7 @@ func httpTestsTron(t *testing.T, ts *httptest.Server) {
 				`"transactions":[{"txid":"a431984fef1d014620504d02f821f872221cf44c250a81a31e81fa4855b2b302"`,
 				`"chainExtraData":{"contractType":"TriggerSmartContract","operation":"contractCall","assetIssueID":"1002001","totalFee":"3076500","energyUsage":"14650","energyUsageTotal":"14650","bandwidthUsage":"345","bandwidthFee":"0","result":"SUCCESS"}`,
 				`"nonce":"236"`,
-				`"contractInfo":{"type":"TRC20","standard":"TRC20","contract":"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf","name":"TronTestContract236","symbol":"TRC236","decimals":6,"createdInBlock":1000}`,
+				`"contractInfo":{"type":"TRC20","standard":"TRC20","contract":"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf","name":"TronTestContract236","symbol":"TRC236","decimals":6,"createdInBlock":1000,"blockHeight":100000}`,
 				`"addressAliases":{"TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf":{"Type":"Contract","Alias":"TronTestContract236"}}`,
 			},
 		},


### PR DESCRIPTION
We discovered a duplication in `blockbook-api.ts` that could be easily fixed.