### PR TITLE
Retry unfinalized RPC responses

### DIFF
--- a/bchain/coins/avalanche/evm.go
+++ b/bchain/coins/avalanche/evm.go
@@ -93,9 +93,12 @@ func (c *AvalancheRPCClient) EthSubscribe(ctx context.Context, channel interface
 func (c *AvalancheRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	err := c.Client.CallContext(ctx, result, method, args...)
 	// unfinalized data cannot be queried error returned when trying to query a block height greater than last finalized block
-	// do not throw rpc error and instead treat as ErrBlockNotFound
+	// treat as ErrBlockNotFound so sync retries instead of processing an empty result
 	// https://docs.avax.network/quickstart/exchanges/integrate-exchange-with-avalanche#determining-finality
-	if err != nil && !strings.Contains(err.Error(), "cannot query unfinalized data") {
+	if err != nil {
+		if strings.Contains(err.Error(), "cannot query unfinalized data") {
+			return bchain.ErrBlockNotFound
+		}
 		return err
 	}
 	return nil

--- a/bchain/coins/avalanche/evm_test.go
+++ b/bchain/coins/avalanche/evm_test.go
@@ -1,0 +1,73 @@
+package avalanche
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/trezor/blockbook/bchain"
+)
+
+type testAvalancheRPCService struct{}
+
+func (s *testAvalancheRPCService) Unfinalized() (string, error) {
+	return "", errors.New("cannot query unfinalized data")
+}
+
+func (s *testAvalancheRPCService) OtherError() (string, error) {
+	return "", errors.New("other failure")
+}
+
+func (s *testAvalancheRPCService) Success() (string, error) {
+	return "ok", nil
+}
+
+func newTestAvalancheRPCClient(t *testing.T) *AvalancheRPCClient {
+	t.Helper()
+
+	server := rpc.NewServer()
+	if err := server.RegisterName("test", &testAvalancheRPCService{}); err != nil {
+		t.Fatalf("RegisterName() error = %v", err)
+	}
+	client := rpc.DialInProc(server)
+	t.Cleanup(func() {
+		client.Close()
+		server.Stop()
+	})
+
+	return &AvalancheRPCClient{Client: client}
+}
+
+func TestAvalancheRPCClientCallContextMapsUnfinalizedDataToBlockNotFound(t *testing.T) {
+	client := newTestAvalancheRPCClient(t)
+
+	var result string
+	err := client.CallContext(context.Background(), &result, "test_unfinalized")
+	if !errors.Is(err, bchain.ErrBlockNotFound) {
+		t.Fatalf("CallContext() error = %v, want ErrBlockNotFound", err)
+	}
+}
+
+func TestAvalancheRPCClientCallContextReturnsOtherErrors(t *testing.T) {
+	client := newTestAvalancheRPCClient(t)
+
+	var result string
+	err := client.CallContext(context.Background(), &result, "test_otherError")
+	if err == nil || !strings.Contains(err.Error(), "other failure") {
+		t.Fatalf("CallContext() error = %v, want other failure", err)
+	}
+}
+
+func TestAvalancheRPCClientCallContextReturnsResult(t *testing.T) {
+	client := newTestAvalancheRPCClient(t)
+
+	var result string
+	if err := client.CallContext(context.Background(), &result, "test_success"); err != nil {
+		t.Fatalf("CallContext() error = %v", err)
+	}
+	if result != "ok" {
+		t.Fatalf("result = %q, want %q", result, "ok")
+	}
+}

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	stdErrors "errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -901,7 +902,7 @@ func (b *EthereumRPC) GetBlockHash(height uint32) (string, error) {
 	defer cancel()
 	h, err := b.Client.HeaderByNumber(ctx, &n)
 	if err != nil {
-		if err == ethereum.NotFound {
+		if err == ethereum.NotFound || stdErrors.Is(err, bchain.ErrBlockNotFound) {
 			return "", bchain.ErrBlockNotFound
 		}
 		return "", errors.Annotatef(err, "height %v", height)


### PR DESCRIPTION
Map Avalanche "cannot query unfinalized data" RPC errors to ErrBlockNotFound instead of swallowing them. This prevents failed trace calls from being treated as successful empty results, which caused trace length mismatches during sync.