### PR TITLE
fix(stuck-syncing): bound retry loops that could stall chain-tip resync

### DIFF
--- a/bchain/coins/eth/ethrpc_blockhash_test.go
+++ b/bchain/coins/eth/ethrpc_blockhash_test.go
@@ -1,0 +1,92 @@
+package eth
+
+import (
+	"context"
+	stdErrors "errors"
+	"math/big"
+	"testing"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/trezor/blockbook/bchain"
+)
+
+type stubEVMHeader struct {
+	hash string
+	num  *big.Int
+}
+
+func (h *stubEVMHeader) Hash() string         { return h.hash }
+func (h *stubEVMHeader) Number() *big.Int     { return h.num }
+func (h *stubEVMHeader) Difficulty() *big.Int { return big.NewInt(0) }
+
+type stubEVMClient struct {
+	header bchain.EVMHeader
+	err    error
+}
+
+func (s *stubEVMClient) NetworkID(ctx context.Context) (*big.Int, error) { return nil, nil }
+func (s *stubEVMClient) HeaderByNumber(ctx context.Context, number *big.Int) (bchain.EVMHeader, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.header, nil
+}
+func (s *stubEVMClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) { return nil, nil }
+func (s *stubEVMClient) EstimateGas(ctx context.Context, msg interface{}) (uint64, error) {
+	return 0, nil
+}
+func (s *stubEVMClient) BalanceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (*big.Int, error) {
+	return nil, nil
+}
+func (s *stubEVMClient) NonceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
+
+func newTestEthereumRPC(client bchain.EVMClient) *EthereumRPC {
+	return &EthereumRPC{Client: client, Timeout: time.Second}
+}
+
+func TestGetBlockHashMapsErrBlockNotFound(t *testing.T) {
+	// AvalancheClient.HeaderByNumber returns bchain.ErrBlockNotFound directly
+	// after the unfinalized-data fix. GetBlockHash must recognize that and
+	// surface ErrBlockNotFound to sync.go's stdErrors.Is check; otherwise
+	// fork detection breaks because juju/errors v0.0.0-2017 has no Unwrap.
+	b := newTestEthereumRPC(&stubEVMClient{err: bchain.ErrBlockNotFound})
+	_, err := b.GetBlockHash(123)
+	if !stdErrors.Is(err, bchain.ErrBlockNotFound) {
+		t.Fatalf("GetBlockHash() error = %v, want ErrBlockNotFound", err)
+	}
+}
+
+func TestGetBlockHashMapsEthereumNotFound(t *testing.T) {
+	b := newTestEthereumRPC(&stubEVMClient{err: ethereum.NotFound})
+	_, err := b.GetBlockHash(123)
+	if !stdErrors.Is(err, bchain.ErrBlockNotFound) {
+		t.Fatalf("GetBlockHash() error = %v, want ErrBlockNotFound", err)
+	}
+}
+
+func TestGetBlockHashPropagatesOtherErrors(t *testing.T) {
+	other := stdErrors.New("rpc connection refused")
+	b := newTestEthereumRPC(&stubEVMClient{err: other})
+	_, err := b.GetBlockHash(123)
+	if err == nil {
+		t.Fatal("GetBlockHash() error = nil, want propagated error")
+	}
+	if stdErrors.Is(err, bchain.ErrBlockNotFound) {
+		t.Fatalf("GetBlockHash() error = %v, must not match ErrBlockNotFound", err)
+	}
+}
+
+func TestGetBlockHashReturnsHash(t *testing.T) {
+	header := &stubEVMHeader{hash: "0xdeadbeef", num: big.NewInt(123)}
+	b := newTestEthereumRPC(&stubEVMClient{header: header})
+	got, err := b.GetBlockHash(123)
+	if err != nil {
+		t.Fatalf("GetBlockHash() error = %v", err)
+	}
+	if got != "0xdeadbeef" {
+		t.Fatalf("GetBlockHash() = %q, want %q", got, "0xdeadbeef")
+	}
+}

--- a/db/sync.go
+++ b/db/sync.go
@@ -373,6 +373,66 @@ func (w *SyncWorker) shouldRestartSyncOnMissingBlock(height uint32, expectedHash
 	return currentHash != expectedHash, nil
 }
 
+// coordinatorPastTip reports whether the chain tip has fallen below h. The
+// parallel/bulk coordinators call this after repeated GetBlockHash failures
+// at height h to decide between retrying (transient backend issue) and
+// aborting with errResync (chain rolled back below the requested range).
+func (w *SyncWorker) coordinatorPastTip(h uint32) (bool, error) {
+	bestHeight, err := w.chain.GetBestBlockHeight()
+	if err != nil {
+		return false, err
+	}
+	return bestHeight < h, nil
+}
+
+// closeTerminating closes the channel idempotently. Coordinators may decide
+// to terminate from multiple paths (hch send abort, wait-loop abort), so the
+// close must tolerate a prior close.
+func closeTerminating(terminating chan struct{}) {
+	select {
+	case <-terminating:
+	default:
+		close(terminating)
+	}
+}
+
+// waitForWorkers blocks until wg has finished. If a worker reports an abort
+// while we wait, terminating is closed so other workers blocked on bch sends
+// can break out and reach wg.Done(). Returns the first abort error seen, or
+// nil if workers exited cleanly.
+//
+// Without this, a worker reporting an error after the connect loop has ended
+// could leave the rest of the workers stuck on bch sends (writer is misaligned
+// because the failing worker abandoned its slot), and wg.Wait() would block
+// forever.
+func waitForWorkers(wg *sync.WaitGroup, terminating chan struct{}, abortCh chan error) error {
+	wgDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+	var abortErr error
+	for {
+		select {
+		case <-wgDone:
+			// Workers exited; an abort may have landed at the same instant.
+			select {
+			case e := <-abortCh:
+				if abortErr == nil {
+					abortErr = e
+				}
+			default:
+			}
+			return abortErr
+		case e := <-abortCh:
+			if abortErr == nil {
+				abortErr = e
+			}
+			closeTerminating(terminating)
+		}
+	}
+}
+
 func isRetryableGetBlockError(err error) bool {
 	if err == nil {
 		return false
@@ -484,6 +544,7 @@ func (w *SyncWorker) ParallelConnectBlocks(onNewBlock bchain.OnNewBlockFunc, low
 	}
 	go writeBlockWorker()
 	var hash string
+	hashErrors := 0
 ConnectLoop:
 	for h := lower; h <= higher; {
 		select {
@@ -507,27 +568,54 @@ ConnectLoop:
 			if err != nil {
 				glog.Error("GetBlockHash error ", err)
 				w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
+				hashErrors++
+				if hashErrors >= w.missingBlockRetry.RecheckThreshold {
+					pastTip, checkErr := w.coordinatorPastTip(h)
+					if checkErr != nil {
+						glog.Error("sync: coordinator past-tip check error ", checkErr)
+					} else if pastTip {
+						glog.Warningf("sync: chain tip below height %d, restarting sync", h)
+						err = errResync
+						close(terminating)
+						break ConnectLoop
+					}
+					hashErrors = 0
+				}
 				time.Sleep(time.Millisecond * 500)
 				continue
 			}
-			hch <- hashHeight{hash, h}
-			h++
+			hashErrors = 0
+			// hch may be at capacity if workers have aborted and stopped draining
+			// it. Selecting here ensures we see abortCh / chanOsSignal instead of
+			// blocking forever on the send.
+			select {
+			case hch <- hashHeight{hash, h}:
+				h++
+			case abortErr := <-abortCh:
+				if stdErrors.Is(abortErr, errResync) {
+					glog.Warning("sync: parallel connect aborted, restarting sync")
+				} else {
+					glog.Error("sync: parallel connect aborted, worker error ", abortErr)
+				}
+				err = abortErr
+				close(terminating)
+				break ConnectLoop
+			case <-w.chanOsSignal:
+				glog.Info("connectBlocksParallel interrupted at height ", h)
+				err = ErrOperationInterrupted
+				close(terminating)
+				break ConnectLoop
+			}
 		}
 	}
 	close(hch)
 	// signal stop to workers that are in a error loop
 	hchClosed.Store(true)
-	// wait for workers and close bch that will stop writer loop
-	wg.Wait()
-	// Hardening: a worker can report a terminal tail error after ConnectLoop has
-	// already ended (for example once hchClosed=true). Drain once so we return
-	// that error instead of silently succeeding.
-	select {
-	case abortErr := <-abortCh:
-		if err == nil {
-			err = abortErr
-		}
-	default:
+	// Wait for workers with abort awareness. A late tail-abort would otherwise
+	// leave other workers blocked on bch sends (writer is round-robin and the
+	// aborting worker abandoned its slot), preventing wg.Wait() from returning.
+	if abortErr := waitForWorkers(&wg, terminating, abortCh); abortErr != nil && err == nil {
+		err = abortErr
 	}
 	for i := 0; i < int(syncWorkers); i++ {
 		close(bch[i])
@@ -543,9 +631,11 @@ func (w *SyncWorker) getBlockWorker(i int, syncWorkers uint32, wg *sync.WaitGrou
 	cfg := w.missingBlockRetry
 GetBlockLoop:
 	for hh := range hch {
-		// Track consecutive not-found errors per block so we only re-check the
-		// chain once the backend has had a chance to catch up.
+		// Track consecutive errors per block: notFoundRetries counts retryable
+		// failures (backend catching up); nonRetriableErrors counts persistent
+		// failures (deserialization, malformed responses) that won't self-heal.
 		notFoundRetries := 0
+		nonRetriableErrors := 0
 		for {
 			// Allow global shutdown or an abort to stop the retry loop promptly.
 			select {
@@ -558,6 +648,7 @@ GetBlockLoop:
 			block, err = w.chain.GetBlock(hh.hash, hh.height)
 			if err != nil {
 				if isRetryableGetBlockError(err) {
+					nonRetriableErrors = 0
 					notFoundRetries++
 					glog.Error("getBlockWorker ", i, " connect block ", hh.height, " ", hh.hash, " error ", err, ". Retrying...")
 					threshold := cfg.RecheckThreshold
@@ -593,6 +684,30 @@ GetBlockLoop:
 						return
 					}
 					notFoundRetries = 0
+					nonRetriableErrors++
+					// Mid-range non-retryable errors used to loop forever, blocking the
+					// pipeline behind a single broken block. Bound the retries: after
+					// RecheckThreshold attempts, distinguish a stale hash (reorg →
+					// restart) from a genuine fetch failure (surface the error).
+					if nonRetriableErrors >= cfg.RecheckThreshold {
+						restart, checkErr := w.shouldRestartSyncOnMissingBlock(hh.height, hh.hash)
+						if checkErr != nil {
+							glog.Error("getBlockWorker ", i, " missing block check error ", checkErr)
+						} else if restart {
+							glog.Warning("sync: block ", hh.height, " ", hh.hash, " no longer on chain, restarting sync")
+							select {
+							case abortCh <- errResync:
+							default:
+							}
+							return
+						}
+						glog.Error("getBlockWorker ", i, " persistent non-retryable error at ", hh.height, " ", hh.hash, ": ", err, ". Aborting.")
+						select {
+						case abortCh <- err:
+						default:
+						}
+						return
+					}
 					glog.Error("getBlockWorker ", i, " connect block error ", err, ". Retrying...")
 				}
 				w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
@@ -678,6 +793,7 @@ func (w *SyncWorker) BulkConnectBlocks(lower, higher uint32) error {
 	var hash string
 	start := time.Now()
 	msTime := time.Now().Add(1 * time.Minute)
+	hashErrors := 0
 ConnectLoop:
 	for h := lower; h <= higher; {
 		select {
@@ -702,38 +818,66 @@ ConnectLoop:
 			if err != nil {
 				glog.Error("GetBlockHash error ", err)
 				w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
+				hashErrors++
+				if hashErrors >= w.missingBlockRetry.RecheckThreshold {
+					pastTip, checkErr := w.coordinatorPastTip(h)
+					if checkErr != nil {
+						glog.Error("sync: coordinator past-tip check error ", checkErr)
+					} else if pastTip {
+						glog.Warningf("sync: chain tip below height %d, restarting sync", h)
+						err = errResync
+						close(terminating)
+						break ConnectLoop
+					}
+					hashErrors = 0
+				}
 				time.Sleep(time.Millisecond * 500)
 				continue
 			}
-			hch <- hashHeight{hash, h}
-			if h > 0 && h%1000 == 0 {
-				w.metrics.BlockbookBestHeight.Set(float64(h))
-				glog.Info("connecting block ", h, " ", hash, ", elapsed ", time.Since(start), " ", w.db.GetAndResetConnectBlockStats())
-				start = time.Now()
-			}
-			if msTime.Before(time.Now()) {
-				if glog.V(1) {
-					glog.Info(w.db.GetMemoryStats())
+			hashErrors = 0
+			// hch may be at capacity if workers have aborted and stopped draining
+			// it. Selecting here ensures we see abortCh / chanOsSignal instead of
+			// blocking forever on the send.
+			select {
+			case hch <- hashHeight{hash, h}:
+				if h > 0 && h%1000 == 0 {
+					w.metrics.BlockbookBestHeight.Set(float64(h))
+					glog.Info("connecting block ", h, " ", hash, ", elapsed ", time.Since(start), " ", w.db.GetAndResetConnectBlockStats())
+					start = time.Now()
 				}
-				w.metrics.IndexDBSize.Set(float64(w.db.DatabaseSizeOnDisk()))
-				msTime = time.Now().Add(10 * time.Minute)
+				if msTime.Before(time.Now()) {
+					if glog.V(1) {
+						glog.Info(w.db.GetMemoryStats())
+					}
+					w.metrics.IndexDBSize.Set(float64(w.db.DatabaseSizeOnDisk()))
+					msTime = time.Now().Add(10 * time.Minute)
+				}
+				h++
+			case abortErr := <-abortCh:
+				if stdErrors.Is(abortErr, errResync) {
+					glog.Warning("sync: bulk connect aborted, restarting sync")
+				} else {
+					glog.Error("sync: bulk connect aborted, worker error ", abortErr)
+				}
+				err = abortErr
+				close(terminating)
+				break ConnectLoop
+			case <-w.chanOsSignal:
+				glog.Info("connectBlocksParallel interrupted at height ", h)
+				err = ErrOperationInterrupted
+				close(terminating)
+				break ConnectLoop
 			}
-			h++
 		}
 	}
 	close(hch)
 	// signal stop to workers that are in a error loop
 	hchClosed.Store(true)
-	// wait for workers and close bch that will stop writer loop
-	wg.Wait()
-	// Hardening: capture a late worker error reported after the connect loop
-	// exits so the caller can retry instead of treating sync as successful.
-	select {
-	case abortErr := <-abortCh:
-		if err == nil {
-			err = abortErr
-		}
-	default:
+	// Wait for workers with abort awareness. A late tail-abort would otherwise
+	// leave other workers blocked on bch sends (writer is round-robin and the
+	// aborting worker abandoned its slot), preventing wg.Wait() from returning.
+	if abortErr := waitForWorkers(&wg, terminating, abortCh); abortErr != nil && err == nil {
+		err = abortErr
 	}
 	for i := 0; i < w.syncWorkers; i++ {
 		close(bch[i])

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -8,11 +8,16 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	jujuErrors "github.com/juju/errors"
 	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/common"
 )
 
 func TestIsRetryableGetBlockError(t *testing.T) {
@@ -117,5 +122,256 @@ func TestIsRetryableGetBlockError(t *testing.T) {
 				t.Fatalf("isRetryableGetBlockError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// stubChain satisfies bchain.BlockChain by embedding the interface (nil) and
+// overriding only the methods we need. Calling any non-overridden method
+// panics — tests must exercise only the configured methods.
+type stubChain struct {
+	bchain.BlockChain
+	bestHeightFn func() (uint32, error)
+	blockHashFn  func(uint32) (string, error)
+	getBlockFn   func(string, uint32) (*bchain.Block, error)
+}
+
+func (s *stubChain) GetBestBlockHeight() (uint32, error) { return s.bestHeightFn() }
+func (s *stubChain) GetBlockHash(h uint32) (string, error) {
+	return s.blockHashFn(h)
+}
+func (s *stubChain) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	return s.getBlockFn(hash, height)
+}
+
+func newTestSyncWorker(t *testing.T, chain bchain.BlockChain) *SyncWorker {
+	t.Helper()
+	metrics, err := common.GetMetrics("test_" + t.Name())
+	if err != nil {
+		t.Fatalf("GetMetrics() error = %v", err)
+	}
+	return &SyncWorker{
+		chain:        chain,
+		chanOsSignal: make(chan os.Signal, 1),
+		metrics:      metrics,
+		missingBlockRetry: MissingBlockRetryConfig{
+			RecheckThreshold:    3,
+			TipRecheckThreshold: 1,
+			RetryDelay:          time.Millisecond,
+		},
+	}
+}
+
+func TestCoordinatorPastTip(t *testing.T) {
+	tests := []struct {
+		name       string
+		bestHeight uint32
+		bestErr    error
+		h          uint32
+		want       bool
+		wantErr    bool
+	}{
+		{name: "tip above h", bestHeight: 100, h: 50, want: false},
+		{name: "tip equals h", bestHeight: 100, h: 100, want: false},
+		{name: "tip below h", bestHeight: 100, h: 200, want: true},
+		{name: "best height error", bestErr: stdErrors.New("rpc gone"), h: 50, want: false, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := &stubChain{
+				bestHeightFn: func() (uint32, error) { return tt.bestHeight, tt.bestErr },
+			}
+			w := newTestSyncWorker(t, chain)
+			got, err := w.coordinatorPastTip(tt.h)
+			if tt.wantErr && err == nil {
+				t.Fatalf("coordinatorPastTip() error = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("coordinatorPastTip() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("coordinatorPastTip() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// runWorkerForOneBlock spins up a single getBlockWorker on a one-element hch
+// (closed immediately so the worker iterates exactly once over the supplied
+// hashHeight) and waits until it terminates or the test deadline expires.
+// Returns whatever appeared on abortCh, or nil if the worker exited cleanly.
+func runWorkerForOneBlock(t *testing.T, w *SyncWorker, hh hashHeight) error {
+	t.Helper()
+	hch := make(chan hashHeight, 1)
+	hch <- hh
+	close(hch)
+	bch := []chan *bchain.Block{make(chan *bchain.Block, 1)}
+	hchClosed := atomic.Value{}
+	// Force the worker into the mid-range branch — the new bounded path —
+	// even though hch itself is closed. Without this, a non-retryable error
+	// would take the existing tail-of-range escape and not exercise the fix.
+	hchClosed.Store(false)
+	terminating := make(chan struct{})
+	abortCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go w.getBlockWorker(0, 1, &wg, hch, bch, &hchClosed, terminating, abortCh)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case err := <-abortCh:
+		<-done
+		return err
+	case <-done:
+		return nil
+	case <-time.After(2 * time.Second):
+		close(terminating)
+		<-done
+		t.Fatal("getBlockWorker did not terminate within deadline")
+		return nil
+	}
+}
+
+func TestGetBlockWorkerEscalatesNonRetryableErrorsToAbort(t *testing.T) {
+	// Non-retryable error mid-range used to loop forever. After the fix,
+	// the worker should give up after RecheckThreshold attempts and surface
+	// the original error to abortCh, since the chain confirms the hash is
+	// still expected at the same height.
+	boom := stdErrors.New("malformed block payload")
+	chain := &stubChain{
+		bestHeightFn: func() (uint32, error) { return 100, nil },
+		blockHashFn:  func(uint32) (string, error) { return "expected-hash", nil },
+		getBlockFn:   func(string, uint32) (*bchain.Block, error) { return nil, boom },
+	}
+	w := newTestSyncWorker(t, chain)
+
+	err := runWorkerForOneBlock(t, w, hashHeight{hash: "expected-hash", height: 50})
+	if err == nil {
+		t.Fatal("expected abortCh error, got nil")
+	}
+	if stdErrors.Is(err, errResync) {
+		t.Fatalf("got errResync, want original error %v", boom)
+	}
+	if err.Error() != boom.Error() {
+		t.Fatalf("abortCh error = %v, want %v", err, boom)
+	}
+}
+
+func TestGetBlockWorkerRestartsOnReorgForNonRetryable(t *testing.T) {
+	// Non-retryable error mid-range, but the chain reports a different hash
+	// at the same height — that's a reorg. The worker should bail out with
+	// errResync rather than the original error.
+	boom := stdErrors.New("malformed block payload")
+	chain := &stubChain{
+		bestHeightFn: func() (uint32, error) { return 100, nil },
+		blockHashFn:  func(uint32) (string, error) { return "different-hash", nil },
+		getBlockFn:   func(string, uint32) (*bchain.Block, error) { return nil, boom },
+	}
+	w := newTestSyncWorker(t, chain)
+
+	err := runWorkerForOneBlock(t, w, hashHeight{hash: "expected-hash", height: 50})
+	if !stdErrors.Is(err, errResync) {
+		t.Fatalf("abortCh error = %v, want errResync", err)
+	}
+}
+
+func TestWaitForWorkersReturnsCleanly(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	terminating := make(chan struct{})
+	abortCh := make(chan error, 1)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		wg.Done()
+	}()
+
+	done := make(chan struct{})
+	var got error
+	go func() {
+		got = waitForWorkers(&wg, terminating, abortCh)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForWorkers did not return")
+	}
+	if got != nil {
+		t.Fatalf("waitForWorkers() = %v, want nil", got)
+	}
+	select {
+	case <-terminating:
+		t.Fatal("terminating should not be closed when no abort occurred")
+	default:
+	}
+}
+
+func TestWaitForWorkersUnsticksBlockedWorkers(t *testing.T) {
+	// Reproduces the deadlock the reviewer flagged: one worker sends an abort
+	// and exits, another worker is stuck on a bch-send-equivalent (here,
+	// blocked on terminating). Without abort-aware wait, wg.Wait() never
+	// returns. waitForWorkers must close terminating to release the stuck
+	// worker so the wait can complete.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	terminating := make(chan struct{})
+	abortCh := make(chan error, 1)
+	boom := stdErrors.New("worker fatal")
+
+	// Worker A: aborts and exits.
+	go func() {
+		abortCh <- boom
+		wg.Done()
+	}()
+	// Worker B: blocked until terminating is closed (simulating bch-send wedge).
+	go func() {
+		<-terminating
+		wg.Done()
+	}()
+
+	done := make(chan struct{})
+	var got error
+	go func() {
+		got = waitForWorkers(&wg, terminating, abortCh)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForWorkers did not return — deadlock not resolved")
+	}
+	if !stdErrors.Is(got, boom) {
+		t.Fatalf("waitForWorkers() = %v, want %v", got, boom)
+	}
+	select {
+	case <-terminating:
+	default:
+		t.Fatal("terminating should be closed after abort")
+	}
+}
+
+func TestWaitForWorkersCapturesLateAbort(t *testing.T) {
+	// Workers may push to abortCh and then call wg.Done() in quick succession.
+	// If wg completes before the wait loop reads abortCh, the abort must still
+	// be drained — otherwise the caller treats a failed sync as successful.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	terminating := make(chan struct{})
+	abortCh := make(chan error, 1)
+	boom := stdErrors.New("late abort")
+
+	abortCh <- boom // already buffered before the wait starts
+	wg.Done()
+
+	got := waitForWorkers(&wg, terminating, abortCh)
+	if !stdErrors.Is(got, boom) {
+		t.Fatalf("waitForWorkers() = %v, want %v", got, boom)
 	}
 }


### PR DESCRIPTION
- Parallel/bulk coordinators: persistent GetBlockHash failures spun forever; now escalate to errResync once the tip has fallen below the height.
- getBlockWorker: mid-range non-retryable errors looped until the hash queue closed; now bounded at RecheckThreshold, then restart on reorg or surface the error to the coordinator.