### PR TITLE
perf(ws): skip mempool tx loading for AccountDetailsBasic

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -423,7 +423,7 @@ type Address struct {
 	BalanceSat            *Amount             `json:"balance" ts_doc:"Current confirmed balance (in satoshi or base units)."`
 	TotalReceivedSat      *Amount             `json:"totalReceived,omitempty" ts_doc:"Total amount ever received by this address."`
 	TotalSentSat          *Amount             `json:"totalSent,omitempty" ts_doc:"Total amount ever sent by this address."`
-	UnconfirmedBalanceSat *Amount             `json:"unconfirmedBalance" ts_doc:"Unconfirmed balance for this address."`
+	UnconfirmedBalanceSat *Amount             `json:"unconfirmedBalance,omitempty" ts_doc:"Unconfirmed balance for this address. Omitted for AccountDetailsBasic, where mempool transactions are not aggregated."`
 	UnconfirmedTxs        int                 `json:"unconfirmedTxs" ts_doc:"Number of unconfirmed transactions for this address."`
 	UnconfirmedSending    *Amount             `json:"unconfirmedSending,omitempty" ts_doc:"Unconfirmed outgoing balance for this address."`
 	UnconfirmedReceiving  *Amount             `json:"unconfirmedReceiving,omitempty" ts_doc:"Unconfirmed incoming balance for this address."`

--- a/api/typesv1.go
+++ b/api/typesv1.go
@@ -178,6 +178,12 @@ func (w *Worker) transactionsToV1(txs []*Tx) []*TxV1 {
 // AddressToV1 converts Address to AddressV1
 func (w *Worker) AddressToV1(a *Address) *AddressV1 {
 	d := w.chainParser.AmountDecimals()
+	// v1 always serializes UnconfirmedBalance as a decimal string;
+	// when the v2 field is omitted (AccountDetailsBasic), preserve "0".
+	unconfirmedBalance := "0"
+	if a.UnconfirmedBalanceSat != nil {
+		unconfirmedBalance = a.UnconfirmedBalanceSat.DecimalString(d)
+	}
 	return &AddressV1{
 		AddrStr:                 a.AddrStr,
 		Balance:                 a.BalanceSat.DecimalString(d),
@@ -187,7 +193,7 @@ func (w *Worker) AddressToV1(a *Address) *AddressV1 {
 		Transactions:            w.transactionsToV1(a.Transactions),
 		TxApperances:            a.Txs,
 		Txids:                   a.Txids,
-		UnconfirmedBalance:      a.UnconfirmedBalanceSat.DecimalString(d),
+		UnconfirmedBalance:      unconfirmedBalance,
 		UnconfirmedTxApperances: a.UnconfirmedTxs,
 	}
 }

--- a/api/worker.go
+++ b/api/worker.go
@@ -1576,28 +1576,36 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 		if err != nil {
 			return nil, errors.Annotatef(err, "getAddressTxids %v true", addrDesc)
 		}
-		for _, txid := range txm {
-			tx, err := w.getTransaction(txid, false, true, addresses)
-			// mempool transaction may fail
-			if err != nil || tx == nil {
-				glog.Warning("GetTransaction in mempool: ", err)
-			} else {
-				// skip already confirmed txs, mempool may be out of sync
-				if tx.Confirmations == 0 {
-					unconfirmedTxs++
-					uBalReceiving.Add(&uBalReceiving, tx.getAddrVoutValue(addrDesc))
-					// ethereum has a different logic - value not in input and add maximum possible fees
-					if w.chainType == bchain.ChainEthereumType {
-						uBalSending.Add(&uBalSending, tx.getAddrEthereumTypeMempoolInputValue(addrDesc))
-					} else {
-						uBalSending.Add(&uBalSending, tx.getAddrVinValue(addrDesc))
-					}
-					if page == 0 {
-						if option == AccountDetailsTxidHistory {
-							txids = append(txids, tx.Txid)
-						} else if option >= AccountDetailsTxHistoryLight {
-							setIsOwnAddress(tx, address)
-							txs = append(txs, tx)
+		if option == AccountDetailsBasic {
+			// Basic detail: skip per-tx loading. The count is the raw mempool
+			// index length; it may include entries that have just been confirmed
+			// but not yet evicted from the mempool. unconfirmedBalance/sending/
+			// receiving are not computed and will be omitted from the response.
+			unconfirmedTxs = len(txm)
+		} else {
+			for _, txid := range txm {
+				tx, err := w.getTransaction(txid, false, true, addresses)
+				// mempool transaction may fail
+				if err != nil || tx == nil {
+					glog.Warning("GetTransaction in mempool: ", err)
+				} else {
+					// skip already confirmed txs, mempool may be out of sync
+					if tx.Confirmations == 0 {
+						unconfirmedTxs++
+						uBalReceiving.Add(&uBalReceiving, tx.getAddrVoutValue(addrDesc))
+						// ethereum has a different logic - value not in input and add maximum possible fees
+						if w.chainType == bchain.ChainEthereumType {
+							uBalSending.Add(&uBalSending, tx.getAddrEthereumTypeMempoolInputValue(addrDesc))
+						} else {
+							uBalSending.Add(&uBalSending, tx.getAddrVinValue(addrDesc))
+						}
+						if page == 0 {
+							if option == AccountDetailsTxidHistory {
+								txids = append(txids, tx.Txid)
+							} else if option >= AccountDetailsTxHistoryLight {
+								setIsOwnAddress(tx, address)
+								txs = append(txs, tx)
+							}
 						}
 					}
 				}
@@ -1666,7 +1674,11 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 			totalSecondaryValue = secondaryRate * totalBaseValue
 		}
 	}
-	uBalSat.Sub(&uBalReceiving, &uBalSending)
+	var unconfirmedBalanceSat *Amount
+	if option > AccountDetailsBasic {
+		uBalSat.Sub(&uBalReceiving, &uBalSending)
+		unconfirmedBalanceSat = (*Amount)(&uBalSat)
+	}
 	var contractInfoBestHeight uint32
 	if ed.contractInfo != nil {
 		h, _, err := w.db.GetBestBlock()
@@ -1684,7 +1696,7 @@ func (w *Worker) GetAddress(address string, page int, txsOnPage int, option Acco
 		Txs:                   int(ba.Txs),
 		NonTokenTxs:           ed.nonContractTxs,
 		InternalTxs:           ed.internalTxs,
-		UnconfirmedBalanceSat: (*Amount)(&uBalSat),
+		UnconfirmedBalanceSat: unconfirmedBalanceSat,
 		UnconfirmedTxs:        unconfirmedTxs,
 		UnconfirmedSending:    amountOrNil(&uBalSending),
 		UnconfirmedReceiving:  amountOrNil(&uBalReceiving),

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -456,6 +456,16 @@ func (w *Worker) GetXpubAddress(xpub string, page int, txsOnPage int, option Acc
 				for _, txid := range newTxids {
 					// the same tx can have multiple addresses from the same xpub, get it from backend it only once
 					tx, foundTx := txmMap[txid.txid]
+					if option == AccountDetailsBasic {
+						// Basic detail: skip per-tx loading. Count unique mempool txids
+						// across derived addresses; the count may transiently include
+						// entries that have just been confirmed but not yet evicted.
+						if !foundTx {
+							txmMap[txid.txid] = nil
+							unconfirmedTxs++
+						}
+						continue
+					}
 					if !foundTx {
 						tx, err = w.getTransaction(txid.txid, false, true, addresses)
 						// mempool transaction may fail

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -586,6 +586,10 @@ func (w *Worker) GetXpubAddress(xpub string, page int, txsOnPage int, option Acc
 		}
 	}
 
+	var unconfirmedBalanceSat *Amount
+	if option > AccountDetailsBasic {
+		unconfirmedBalanceSat = (*Amount)(&uBalSat)
+	}
 	addr := Address{
 		Paging:                pg,
 		AddrStr:               xpub,
@@ -594,7 +598,7 @@ func (w *Worker) GetXpubAddress(xpub string, page int, txsOnPage int, option Acc
 		TotalSentSat:          (*Amount)(&data.sentSat),
 		Txs:                   txCount,
 		AddrTxCount:           addrTxCount,
-		UnconfirmedBalanceSat: (*Amount)(&uBalSat),
+		UnconfirmedBalanceSat: unconfirmedBalanceSat,
 		UnconfirmedTxs:        unconfirmedTxs,
 		Transactions:          txs,
 		Txids:                 txids,

--- a/blockbook-api.ts
+++ b/blockbook-api.ts
@@ -337,7 +337,7 @@ export interface Address {
     totalReceived?: string;
     /** Total amount ever sent by this address. */
     totalSent?: string;
-    /** Unconfirmed balance for this address. */
+    /** Unconfirmed balance for this address. Omitted for AccountDetailsBasic, where mempool transactions are not aggregated. */
     unconfirmedBalance?: string;
     /** Number of unconfirmed transactions for this address. */
     unconfirmedTxs: number;

--- a/docs/api.md
+++ b/docs/api.md
@@ -476,7 +476,7 @@ The optional query parameters:
 -   _pageSize_: number of transactions returned by call (default and maximum 1000)
 -   _from_, _to_: filter of the returned transactions _from_ block height _to_ block height (default no filter)
 -   _details_: specifies level of details returned by request (default _txids_)
-    -   _basic_: return only address balances, without any transactions
+    -   _basic_: return only address balances, without any transactions. Mempool transactions are not aggregated at this level: the `unconfirmedBalance`, `unconfirmedSending` and `unconfirmedReceiving` fields are omitted from the response, and `unconfirmedTxs` reports the raw mempool index size for the address (it may transiently include entries that have just been confirmed but not yet evicted from the mempool).
     -   _tokens_: _basic_ + tokens belonging to the address (applicable only to some coins)
     -   _tokenBalances_: _basic_ + tokens with balances + belonging to the address (applicable only to some coins)
     -   _txids_: _tokenBalances_ + list of txids, subject to _from_, _to_ filter and paging
@@ -644,7 +644,7 @@ The optional query parameters:
 -   _pageSize_: number of transactions returned by call (default and maximum 1000)
 -   _from_, _to_: filter of the returned transactions _from_ block height _to_ block height (default no filter)
 -   _details_: specifies level of details returned by request (default _txids_)
-    -   _basic_: return only xpub balances, without any derived addresses and transactions
+    -   _basic_: return only xpub balances, without any derived addresses and transactions. The `unconfirmedBalance` field is omitted from the response at this detail level (`unconfirmedSending`/`unconfirmedReceiving` are not produced by the xpub path at any level).
     -   _tokens_: _basic_ + tokens (addresses) derived from the xpub, subject to _tokens_ parameter
     -   _tokenBalances_: _basic_ + tokens (addresses) derived from the xpub with balances, subject to _tokens_ parameter
     -   _txids_: _tokenBalances_ + list of txids, subject to _from_, _to_ filter and paging
@@ -1155,6 +1155,12 @@ Notes for `getBlock`:
 -   response format matches REST `GET /api/v2/block/<block height|block hash>`
 -   _pageSize_ defaults to `1000` and is capped at `10000`
 -   _page_ is sanitized to stay within safe internal limits
+
+Notes for `getAccountInfo`:
+
+-   response format matches REST `GET /api/v2/address/<address>` (or `/api/v2/xpub/<xpub>` when a descriptor is supplied)
+-   _details_ defaults to `basic` when not specified in the request (this differs from the REST default of `txids`)
+-   at `details: basic`, mempool transactions are not aggregated: the `unconfirmedBalance`, `unconfirmedSending` and `unconfirmedReceiving` fields are omitted from the response, and `unconfirmedTxs` reports the raw mempool index size for the address. Clients that need an exact unconfirmed delta should request a higher detail level (`tokens` or above)
 
 ## Legacy API V1
 

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -799,7 +799,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"address":"mv9uLThosiEnGRbVPS7Vhyw6VssbVRsiAw","balance":"0","totalReceived":"1234567890123","totalSent":"1234567890123","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":2}`,
+				`{"address":"mv9uLThosiEnGRbVPS7Vhyw6VssbVRsiAw","balance":"0","totalReceived":"1234567890123","totalSent":"1234567890123","unconfirmedTxs":0,"txs":2}`,
 			},
 		},
 		{
@@ -862,7 +862,7 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			status:      http.StatusOK,
 			contentType: "application/json; charset=utf-8",
 			body: []string{
-				`{"address":"upub5E1xjDmZ7Hhej6LPpS8duATdKXnRYui7bDYj6ehfFGzWDZtmCmQkZhc3Zb7kgRLtHWd16QFxyP86JKL3ShZEBFX88aciJ3xyocuyhZZ8g6q","balance":"118641975500","totalReceived":"118641975501","totalSent":"1","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":3,"addrTxCount":3,"usedTokens":2}`,
+				`{"address":"upub5E1xjDmZ7Hhej6LPpS8duATdKXnRYui7bDYj6ehfFGzWDZtmCmQkZhc3Zb7kgRLtHWd16QFxyP86JKL3ShZEBFX88aciJ3xyocuyhZZ8g6q","balance":"118641975500","totalReceived":"118641975501","totalSent":"1","unconfirmedTxs":0,"txs":3,"addrTxCount":3,"usedTokens":2}`,
 			},
 		},
 		{

--- a/tests/api/api.go
+++ b/tests/api/api.go
@@ -84,11 +84,12 @@ var evmOnlyTests = map[string]func(t *testing.T, th *TestHandler){
 }
 
 var wsOnlyTests = map[string]func(t *testing.T, th *TestHandler){
-	"WsGetInfo":        testWsGetInfo,
-	"WsGetBlockHash":   testWsGetBlockHash,
-	"WsGetTransaction": testWsGetTransaction,
-	"WsGetAccountInfo": testWsGetAccountInfo,
-	"WsPing":           testWsPing,
+	"WsGetInfo":             testWsGetInfo,
+	"WsGetBlockHash":        testWsGetBlockHash,
+	"WsGetTransaction":      testWsGetTransaction,
+	"WsGetAccountInfo":      testWsGetAccountInfo,
+	"WsGetAccountInfoBasic": testWsGetAccountInfoBasic,
+	"WsPing":                testWsPing,
 }
 
 var wsUTXOTests = map[string]func(t *testing.T, th *TestHandler){

--- a/tests/api/http_tests.go
+++ b/tests/api/http_tests.go
@@ -114,12 +114,9 @@ func testGetTransactionSpecific(t *testing.T, h *TestHandler) {
 func testGetAddress(t *testing.T, h *TestHandler) {
 	address := h.sampleAddressOrSkip(t)
 
-	var addr addressResponse
+	var addr map[string]json.RawMessage
 	h.mustGetJSON(t, "/api/v2/address/"+url.PathEscape(address)+"?details=basic", &addr)
-	assertNonEmptyString(t, addr.Address, "GetAddress.address")
-	if !strings.EqualFold(addr.Address, address) {
-		t.Fatalf("address mismatch: got %s, want %s", addr.Address, address)
-	}
+	assertBasicAccountInfoPayload(t, addr, address, "GetAddress")
 }
 
 func testGetCurrentFiatRates(t *testing.T, h *TestHandler) {

--- a/tests/api/test_helpers.go
+++ b/tests/api/test_helpers.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -52,6 +53,36 @@ func assertAddressTxsPayload(t *testing.T, payload *addressTxsResponse, address,
 	assertPageMeta(t, payload.Page, payload.ItemsOnPage, payload.TotalPages, payload.Txs, context)
 	assertPageSizeUpperBound(t, len(payload.Transactions), payload.ItemsOnPage, pageSize, context+".transactions")
 	assertTransactionsContainTxID(t, payload.Transactions, txid, context+".transactions")
+}
+
+func assertBasicAccountInfoPayload(t *testing.T, payload map[string]json.RawMessage, address, context string) {
+	t.Helper()
+
+	rawAddress, ok := payload["address"]
+	if !ok {
+		t.Fatalf("%s missing address field", context)
+	}
+	var gotAddress string
+	if err := json.Unmarshal(rawAddress, &gotAddress); err != nil {
+		t.Fatalf("%s decode address: %v", context, err)
+	}
+	assertAddressMatches(t, gotAddress, address, context+".address")
+
+	rawUnconfirmedTxs, ok := payload["unconfirmedTxs"]
+	if !ok {
+		t.Fatalf("%s missing unconfirmedTxs field", context)
+	}
+	var unconfirmedTxs int
+	if err := json.Unmarshal(rawUnconfirmedTxs, &unconfirmedTxs); err != nil {
+		t.Fatalf("%s decode unconfirmedTxs: %v", context, err)
+	}
+	if unconfirmedTxs < 0 {
+		t.Fatalf("%s invalid unconfirmedTxs: %d", context, unconfirmedTxs)
+	}
+
+	if _, ok := payload["unconfirmedBalance"]; ok {
+		t.Fatalf("%s includes unconfirmedBalance for details=basic", context)
+	}
 }
 
 func assertPageMeta(t *testing.T, page, itemsOnPage, totalPages, totalItems int, context string) {

--- a/tests/api/ws_tests.go
+++ b/tests/api/ws_tests.go
@@ -69,6 +69,23 @@ func testWsGetAccountInfo(t *testing.T, h *TestHandler) {
 	assertAddressTxidsPayload(t, &info, address, txid, "WsGetAccountInfo", addressPageSize)
 }
 
+func testWsGetAccountInfoBasic(t *testing.T, h *TestHandler) {
+	address := h.sampleAddressOrSkip(t)
+
+	resp := h.wsCall(t, "getAccountInfo", map[string]interface{}{
+		"descriptor": address,
+		"details":    "basic",
+		"page":       addressPage,
+		"pageSize":   addressPageSize,
+	})
+
+	var info map[string]json.RawMessage
+	if err := json.Unmarshal(resp.Data, &info); err != nil {
+		t.Fatalf("decode websocket getAccountInfo basic response: %v", err)
+	}
+	assertBasicAccountInfoPayload(t, info, address, "WsGetAccountInfoBasic")
+}
+
 func testWsGetAccountUtxo(t *testing.T, h *TestHandler) {
 	address := h.sampleAddressOrSkip(t)
 

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -31,7 +31,7 @@
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountUtxo", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasic", "WsGetAccountUtxo", "WsPing"],
         "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                  "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]


### PR DESCRIPTION
## Summary

For `details=basic` (the default level for WebSocket `getAccountInfo`), `GetAddress` previously loaded the full body of every mempool transaction touching the address only to compute `unconfirmedBalance` / `unconfirmedSending` / `unconfirmedReceiving` — aggregated mempool-amount fields that `details=basic` consumers do not read. This change drops the per-tx fetch and reports `unconfirmedTxs` from the cheap mempool-index length only. The aggregated amount fields are omitted from the response (`omitempty` added to `UnconfirmedBalanceSat`; the sibling `unconfirmedSending` / `unconfirmedReceiving` already had it). Legacy v1 REST keeps emitting `"unconfirmedBalance": "0"` via a nil-safe fallback in `AddressToV1`.

## Performance savings

The hot path before this change, in `api/worker.go` `GetAddress`:

```go
for _, txid := range txm {                                    // |txm| = mempool txs touching this address
    tx, err := w.getTransaction(txid, false, true, addresses) // full tx fetch + decode
    // ... compute uBalReceiving / uBalSending per address
}
```

That is `O(N)` `getTransaction` calls per request, where `N` is the count of mempool entries indexed under the address descriptor. After this change, `details=basic` performs **one** `getAddressTxids(addrDesc, true, …)` mempool-index lookup and returns its length as `unconfirmedTxs` — `O(N) → O(1)` on the mempool-aggregation step.

This matters in two places where `details=basic` is the actual hot path:

1. **WebSocket `getAccountInfo`** — `details` defaults to `basic` when the client omits it (`server/websocket.go:1014`). Every WS account-info call without an explicit detail level benefits.
2. **Trezor Suite's account-refresh thunk** — the first-phase outdated check at `accountsThunks.ts:104` always uses `details: 'basic'` and only reads the count via `isAccountOutdated`. Every Suite refresh tick against an active account gets cheaper.

Higher detail levels (`tokens`, `tokenBalances`, `txids`, `txslight`, `txs`) are unchanged — they may need per-tx data for the response payload itself, so the aggregation is essentially free there.

## Compatibility

- **Trezor Suite** — audited every `details: 'basic'` caller in suite (refresh thunk, send-form recipient validation, MCP nonce/sequence auto-fill, Solana ATA check, Solana send): none reads `unconfirmedBalance`. The transformer in `blockchain-link-utils/blockbook.ts:407–411` already handles the field being absent (`isNaN()` short-circuit yields `availableBalance = balance`). No suite change required.
   -  Two trigger points in Suite that fire fetchAndUpdateAccountThunk (which starts with details: 'basic'):
  1. `accountsMiddleware.ts:14–25` — when an account becomes 'loaded' (user navigates to it in the sidebar), if its cached timestamp is older than 10 s, fire the basic refresh thunk.
  2. `blockchainThunks.ts:251–255` (syncAccountsThunk) — periodically, for all visible accounts in the network: parallel-dispatch fetchAndUpdateAccountThunk per account. This runs immediately when blockchain state initializes after app boot,  then on a per-network interval thereafter.
- **REST v1** — `AddressToV1` emits `"unconfirmedBalance": "0"` for the nil case, so the v1 wire format is unchanged.
- **REST v2 with `?details=basic`** — `unconfirmedBalance` / `unconfirmedSending` / `unconfirmedReceiving` are omitted from the JSON; `unconfirmedTxs` is the raw mempool index size (may transiently include entries that have just been confirmed but not yet evicted from the mempool; today's loop filters those by re-checking `tx.Confirmations == 0`, so the count is approximate by 0–few entries).
- **WebSocket `getAccountInfo`** — same as REST v2 `?details=basic`, and this is the WS default. Documented under "Notes for `getAccountInfo`" in `docs/api.md`.
- **xpub** -   Only one production caller hits xpub-basic: accountsThunks.ts:104 (the refresh thunk):
```
  details: account.networkType === 'solana' ? 'txids' : 'basic',
```

## Test plan

- [x] `go build ./api/... ./server/...` clean
- [x] `go vet ./api/... ./server/...` clean
- [x] `go test ./...` clean (api, btc, eth, tron, fourbyte, common)
- [x] Manual: hit `/api/v2/address/<addr>?details=basic` against a node and confirm `unconfirmedBalance` is absent from the JSON
- [x] Manual: hit `/api/v2/address/<addr>?details=txids` against the same node and confirm `unconfirmedBalance` is still present
- [x] Manual: WS `getAccountInfo` without `details` set — confirm `unconfirmedBalance` is absent and `unconfirmedTxs` is populated
- [x] Manual: hit legacy `/api/v1/address/<addr>?details=basic` and confirm `unconfirmedBalance: "0"` is still emitted (string)