### PR TITLE
Decrease mempool timeout for MEV-protected coins

### DIFF
--- a/bchain/coins/arbitrum/arbitrumrpc.go
+++ b/bchain/coins/arbitrum/arbitrumrpc.go
@@ -71,7 +71,9 @@ func (b *ArbitrumRPC) Initialize() error {
 		return errors.Errorf("Unknown network id %v", id)
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	glog.Info("rpc: block chain ", b.Network)
 

--- a/bchain/coins/avalanche/avalancherpc.go
+++ b/bchain/coins/avalanche/avalancherpc.go
@@ -128,7 +128,9 @@ func (b *AvalancheRPC) Initialize() error {
 		return errors.Errorf("Unknown network id %v", id)
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	glog.Info("rpc: block chain ", b.Network)
 

--- a/bchain/coins/base/baserpc.go
+++ b/bchain/coins/base/baserpc.go
@@ -67,7 +67,9 @@ func (b *BaseRPC) Initialize() error {
 		return errors.Errorf("Unknown network id %v", id)
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	glog.Info("rpc: block chain ", b.Network)
 

--- a/bchain/coins/bsc/bscrpc.go
+++ b/bchain/coins/bsc/bscrpc.go
@@ -76,7 +76,9 @@ func (b *BNBSmartChainRPC) Initialize() error {
 		return errors.Errorf("Unknown network id %v", id)
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	glog.Info("rpc: block chain ", b.Network)
 

--- a/bchain/coins/eth/alternativesendtx.go
+++ b/bchain/coins/eth/alternativesendtx.go
@@ -34,10 +34,11 @@ type AlternativeSendTxProvider struct {
 }
 
 // NewAlternativeSendTxProvider creates a new alternative send tx provider if enabled
-func NewAlternativeSendTxProvider(network string, rpcTimeout int, mempoolTxsTimeout int) *AlternativeSendTxProvider {
+func NewAlternativeSendTxProvider(network string, rpcTimeout int, mempoolTxsTimeout time.Duration) *AlternativeSendTxProvider {
 	urls := strings.Split(os.Getenv(strings.ToUpper(network)+"_ALTERNATIVE_SENDTX_URLS"), ",")
 	onlyAlternative := strings.ToUpper(os.Getenv(strings.ToUpper(network)+"_ALTERNATIVE_SENDTX_ONLY")) == "TRUE"
 	fetchMempoolTx := strings.ToUpper(os.Getenv(strings.ToUpper(network)+"_ALTERNATIVE_FETCH_MEMPOOL_TX")) == "TRUE"
+	// Empty URL keeps the normal public RPC send path.
 	if len(urls) == 0 || urls[0] == "" {
 		return nil
 	}
@@ -47,7 +48,7 @@ func NewAlternativeSendTxProvider(network string, rpcTimeout int, mempoolTxsTime
 		onlyAlternative:   onlyAlternative,
 		fetchMempoolTx:    fetchMempoolTx,
 		rpcTimeout:        time.Duration(rpcTimeout) * time.Second,
-		mempoolTxsTimeout: time.Duration(mempoolTxsTimeout) * time.Hour,
+		mempoolTxsTimeout: mempoolTxsTimeout,
 		mempoolTxs:        make(map[string]storedTx),
 	}
 

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -42,7 +42,14 @@ const (
 	TestNetHoodi Network = 560048
 )
 
-const defaultErc20BatchSize = 100
+const (
+	defaultErc20BatchSize = 100
+
+	// Alternative/private relays expire pending txs quickly, so local pending state
+	// must not inherit the legacy hour-scale public mempool timeout.
+	defaultMempoolTxTimeoutWithAlternativeProvider = 10 * time.Minute
+	defaultAlternativeMempoolTxTimeout             = 5 * time.Minute
+)
 
 // Ethereum address constants
 const (
@@ -79,6 +86,8 @@ type Configuration struct {
 	AddressContractsCacheBulkMaxBytes int64  `json:"address_contracts_cache_bulk_max_bytes,omitempty"`
 	AddressAliases                    bool   `json:"address_aliases,omitempty"`
 	MempoolTxTimeoutHours             int    `json:"mempoolTxTimeoutHours"`
+	MempoolTxTimeout                  string `json:"mempoolTxTimeout,omitempty"`
+	AlternativeMempoolTxTimeout       string `json:"alternativeMempoolTxTimeout,omitempty"`
 	QueryBackendOnMempoolResync       bool   `json:"queryBackendOnMempoolResync"`
 	ProcessInternalTransactions       bool   `json:"processInternalTransactions"`
 	ProcessZeroInternalTransactions   bool   `json:"processZeroInternalTransactions"`
@@ -87,6 +96,37 @@ type Configuration struct {
 	Eip1559Fees                       bool   `json:"eip1559Fees,omitempty"`
 	AlternativeEstimateFee            string `json:"alternative_estimate_fee,omitempty"`
 	AlternativeEstimateFeeParams      string `json:"alternative_estimate_fee_params,omitempty"`
+}
+
+func parsePositiveDuration(name string, value string) (time.Duration, error) {
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, errors.Annotatef(err, "invalid %s", name)
+	}
+	if d <= 0 {
+		return 0, errors.Errorf("%s must be positive", name)
+	}
+	return d, nil
+}
+
+// MempoolTxTimeoutDuration returns the Blockbook-side EVM mempool retention.
+func (c *Configuration) MempoolTxTimeoutDuration(alternativeSendTxProviderEnabled bool) (time.Duration, error) {
+	if c.MempoolTxTimeout != "" {
+		return parsePositiveDuration("mempoolTxTimeout", c.MempoolTxTimeout)
+	}
+	// Keep the shorter timeout scoped to alternative/private submission only.
+	if alternativeSendTxProviderEnabled {
+		return defaultMempoolTxTimeoutWithAlternativeProvider, nil
+	}
+	return time.Duration(c.MempoolTxTimeoutHours) * time.Hour, nil
+}
+
+// AlternativeMempoolTxTimeoutDuration returns the alternative-provider cache retention.
+func (c *Configuration) AlternativeMempoolTxTimeoutDuration() (time.Duration, error) {
+	if c.AlternativeMempoolTxTimeout != "" {
+		return parsePositiveDuration("alternativeMempoolTxTimeout", c.AlternativeMempoolTxTimeout)
+	}
+	return defaultAlternativeMempoolTxTimeout, nil
 }
 
 // EthereumRPC is an interface to JSON-RPC eth service.
@@ -169,6 +209,12 @@ func NewEthereumRPC(config json.RawMessage, pushHandler func(bchain.Notification
 		if _, err := time.ParseDuration(c.TraceTimeout); err != nil {
 			return nil, errors.Annotatef(err, "invalid trace_timeout")
 		}
+	}
+	if _, err := c.MempoolTxTimeoutDuration(false); err != nil {
+		return nil, err
+	}
+	if _, err := c.AlternativeMempoolTxTimeoutDuration(); err != nil {
+		return nil, err
 	}
 
 	s := &EthereumRPC{
@@ -400,7 +446,9 @@ func (b *EthereumRPC) Initialize() error {
 		return err
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	b.consensusMonitor = newConsensusVersionMonitor(b.ChainConfig.ConsensusNodeVersionURL)
 	b.consensusMonitor.start()
@@ -516,21 +564,31 @@ func (m *consensusVersionMonitor) shutdown() {
 }
 
 // InitAlternativeProviders initializes alternative providers
-func (b *EthereumRPC) InitAlternativeProviders() {
+func (b *EthereumRPC) InitAlternativeProviders() error {
 	b.initAlternativeFeeProvider()
 
+	// Env prefix follows explicit network aliases such as OP/BASE, otherwise ETH.
 	network := b.ChainConfig.Network
 	if network == "" {
 		network = b.ChainConfig.CoinShortcut
 	}
-	b.alternativeSendTxProvider = NewAlternativeSendTxProvider(network, b.ChainConfig.RPCTimeout, b.ChainConfig.MempoolTxTimeoutHours)
+	alternativeMempoolTxTimeout, err := b.ChainConfig.AlternativeMempoolTxTimeoutDuration()
+	if err != nil {
+		return err
+	}
+	b.alternativeSendTxProvider = NewAlternativeSendTxProvider(network, b.ChainConfig.RPCTimeout, alternativeMempoolTxTimeout)
+	return nil
 }
 
 // CreateMempool creates mempool if not already created, however does not initialize it
 func (b *EthereumRPC) CreateMempool(chain bchain.BlockChain) (bchain.Mempool, error) {
 	if b.Mempool == nil {
-		b.Mempool = bchain.NewMempoolEthereumType(chain, b.ChainConfig.MempoolTxTimeoutHours, b.ChainConfig.QueryBackendOnMempoolResync)
-		glog.Info("mempool created, MempoolTxTimeoutHours=", b.ChainConfig.MempoolTxTimeoutHours, ", QueryBackendOnMempoolResync=", b.ChainConfig.QueryBackendOnMempoolResync, ", DisableMempoolSync=", b.ChainConfig.DisableMempoolSync)
+		mempoolTxTimeout, err := b.ChainConfig.MempoolTxTimeoutDuration(b.alternativeSendTxProvider != nil)
+		if err != nil {
+			return nil, err
+		}
+		b.Mempool = bchain.NewMempoolEthereumType(chain, mempoolTxTimeout, b.ChainConfig.QueryBackendOnMempoolResync)
+		glog.Info("mempool created, MempoolTxTimeout=", mempoolTxTimeout, ", QueryBackendOnMempoolResync=", b.ChainConfig.QueryBackendOnMempoolResync, ", DisableMempoolSync=", b.ChainConfig.DisableMempoolSync)
 		if b.alternativeSendTxProvider != nil {
 			b.alternativeSendTxProvider.SetupMempool(b.Mempool, b.removeTransactionFromMempool)
 		}

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -98,12 +98,23 @@ type Configuration struct {
 	AlternativeEstimateFeeParams      string `json:"alternative_estimate_fee_params,omitempty"`
 }
 
-func parsePositiveDuration(name string, value string) (time.Duration, error) {
+func parseNonNegativeDuration(name string, value string) (time.Duration, error) {
 	d, err := time.ParseDuration(value)
 	if err != nil {
 		return 0, errors.Annotatef(err, "invalid %s", name)
 	}
-	if d <= 0 {
+	if d < 0 {
+		return 0, errors.Errorf("%s must not be negative", name)
+	}
+	return d, nil
+}
+
+func parsePositiveDuration(name string, value string) (time.Duration, error) {
+	d, err := parseNonNegativeDuration(name, value)
+	if err != nil {
+		return 0, err
+	}
+	if d == 0 {
 		return 0, errors.Errorf("%s must be positive", name)
 	}
 	return d, nil
@@ -112,7 +123,7 @@ func parsePositiveDuration(name string, value string) (time.Duration, error) {
 // MempoolTxTimeoutDuration returns the Blockbook-side EVM mempool retention.
 func (c *Configuration) MempoolTxTimeoutDuration(alternativeSendTxProviderEnabled bool) (time.Duration, error) {
 	if c.MempoolTxTimeout != "" {
-		return parsePositiveDuration("mempoolTxTimeout", c.MempoolTxTimeout)
+		return parseNonNegativeDuration("mempoolTxTimeout", c.MempoolTxTimeout)
 	}
 	// Keep the shorter timeout scoped to alternative/private submission only.
 	if alternativeSendTxProviderEnabled {

--- a/bchain/coins/eth/ethrpc_mempool_timeout_test.go
+++ b/bchain/coins/eth/ethrpc_mempool_timeout_test.go
@@ -1,0 +1,175 @@
+package eth
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestConfigurationMempoolTxTimeoutDuration(t *testing.T) {
+	tests := []struct {
+		name                       string
+		config                     Configuration
+		alternativeProviderEnabled bool
+		want                       time.Duration
+	}{
+		{
+			name: "legacy hours without alternative provider",
+			config: Configuration{
+				MempoolTxTimeoutHours: 12,
+			},
+			want: 12 * time.Hour,
+		},
+		{
+			name: "alternative provider default",
+			config: Configuration{
+				MempoolTxTimeoutHours: 12,
+			},
+			alternativeProviderEnabled: true,
+			want:                       10 * time.Minute,
+		},
+		{
+			name: "explicit duration overrides alternative provider default",
+			config: Configuration{
+				MempoolTxTimeoutHours: 12,
+				MempoolTxTimeout:      "15m",
+			},
+			alternativeProviderEnabled: true,
+			want:                       15 * time.Minute,
+		},
+		{
+			name: "legacy zero is preserved",
+			config: Configuration{
+				MempoolTxTimeoutHours: 0,
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.config.MempoolTxTimeoutDuration(tt.alternativeProviderEnabled)
+			if err != nil {
+				t.Fatalf("MempoolTxTimeoutDuration() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("MempoolTxTimeoutDuration() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigurationAlternativeMempoolTxTimeoutDuration(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Configuration
+		want   time.Duration
+	}{
+		{
+			name: "default",
+			want: 5 * time.Minute,
+		},
+		{
+			name: "explicit duration",
+			config: Configuration{
+				AlternativeMempoolTxTimeout: "7m",
+			},
+			want: 7 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.config.AlternativeMempoolTxTimeoutDuration()
+			if err != nil {
+				t.Fatalf("AlternativeMempoolTxTimeoutDuration() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("AlternativeMempoolTxTimeoutDuration() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewEthereumRPCRejectsInvalidMempoolTimeouts(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "invalid blockbook mempool timeout",
+			config: `{
+				"coin_name":"Ethereum",
+				"coin_shortcut":"ETH",
+				"rpc_timeout":25,
+				"mempoolTxTimeout":"not-a-duration",
+				"block_addresses_to_keep":600
+			}`,
+		},
+		{
+			name: "zero alternative mempool timeout",
+			config: `{
+				"coin_name":"Ethereum",
+				"coin_shortcut":"ETH",
+				"rpc_timeout":25,
+				"alternativeMempoolTxTimeout":"0s",
+				"block_addresses_to_keep":600
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewEthereumRPC(json.RawMessage(tt.config), nil)
+			if err == nil {
+				t.Fatal("expected timeout configuration error")
+			}
+		})
+	}
+}
+
+func TestInitAlternativeProvidersUsesAlternativeMempoolTxTimeout(t *testing.T) {
+	t.Setenv("ETH_ALTERNATIVE_SENDTX_URLS", "http://localhost:8545")
+
+	tests := []struct {
+		name   string
+		config Configuration
+		want   time.Duration
+	}{
+		{
+			name: "default",
+			config: Configuration{
+				CoinShortcut: "eth",
+				RPCTimeout:   1,
+			},
+			want: 5 * time.Minute,
+		},
+		{
+			name: "explicit duration",
+			config: Configuration{
+				CoinShortcut:                "eth",
+				RPCTimeout:                  1,
+				AlternativeMempoolTxTimeout: "7m",
+			},
+			want: 7 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &EthereumRPC{
+				ChainConfig: &tt.config,
+			}
+			if err := b.InitAlternativeProviders(); err != nil {
+				t.Fatalf("InitAlternativeProviders() error = %v", err)
+			}
+
+			if b.alternativeSendTxProvider == nil {
+				t.Fatal("alternativeSendTxProvider is nil")
+			}
+			if got := b.alternativeSendTxProvider.mempoolTxsTimeout; got != tt.want {
+				t.Fatalf("mempoolTxsTimeout = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/bchain/coins/eth/ethrpc_mempool_timeout_test.go
+++ b/bchain/coins/eth/ethrpc_mempool_timeout_test.go
@@ -44,6 +44,14 @@ func TestConfigurationMempoolTxTimeoutDuration(t *testing.T) {
 			},
 			want: 0,
 		},
+		{
+			name: "explicit zero duration is preserved",
+			config: Configuration{
+				MempoolTxTimeoutHours: 12,
+				MempoolTxTimeout:      "0s",
+			},
+			want: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +121,16 @@ func TestNewEthereumRPCRejectsInvalidMempoolTimeouts(t *testing.T) {
 				"coin_shortcut":"ETH",
 				"rpc_timeout":25,
 				"alternativeMempoolTxTimeout":"0s",
+				"block_addresses_to_keep":600
+			}`,
+		},
+		{
+			name: "negative blockbook mempool timeout",
+			config: `{
+				"coin_name":"Ethereum",
+				"coin_shortcut":"ETH",
+				"rpc_timeout":25,
+				"mempoolTxTimeout":"-1s",
 				"block_addresses_to_keep":600
 			}`,
 		},

--- a/bchain/coins/eth/infurafees.go
+++ b/bchain/coins/eth/infurafees.go
@@ -86,6 +86,8 @@ type infuraFeeProvider struct {
 	apiKey string
 }
 
+const infuraFeeStalePeriods = 30
+
 // NewInfuraFeesProvider initializes https://gas.api.infura.io provider
 func NewInfuraFeesProvider(chain bchain.BlockChain, params string, metrics *common.Metrics) (alternativeFeeProviderInterface, error) {
 	p := &infuraFeeProvider{alternativeFeeProvider: &alternativeFeeProvider{metrics: metrics, name: "infura"}}
@@ -93,7 +95,7 @@ func NewInfuraFeesProvider(chain bchain.BlockChain, params string, metrics *comm
 	if err != nil {
 		return nil, err
 	}
-	if p.params.URL == "" || p.params.PeriodSeconds == 0 {
+	if p.params.URL == "" || p.params.PeriodSeconds <= 0 {
 		return nil, errors.New("NewInfuraFeesProvider: missing config parameters 'url' or 'periodSeconds'.")
 	}
 	p.apiKey = os.Getenv("INFURA_API_KEY")
@@ -102,10 +104,15 @@ func NewInfuraFeesProvider(chain bchain.BlockChain, params string, metrics *comm
 	}
 	p.params.URL = strings.Replace(p.params.URL, "${api_key}", p.apiKey, -1)
 	p.chain = chain
-	// if the data are not successfully downloaded 10 times, stop providing data
-	p.staleSyncDuration = time.Duration(p.params.PeriodSeconds*10) * time.Second
+	// Keep cached Infura fees through throttling bursts.
+	// Current archive configs poll every 60s, which gives a 30-minute window.
+	p.staleSyncDuration = infuraFeeStaleDuration(p.params.PeriodSeconds)
 	go p.FeeDownloader()
 	return p, nil
+}
+
+func infuraFeeStaleDuration(periodSeconds int) time.Duration {
+	return time.Duration(periodSeconds*infuraFeeStalePeriods) * time.Second
 }
 
 func (p *infuraFeeProvider) FeeDownloader() {

--- a/bchain/coins/eth/infurafees_test.go
+++ b/bchain/coins/eth/infurafees_test.go
@@ -1,0 +1,62 @@
+package eth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInfuraFeeStaleDuration(t *testing.T) {
+	got := infuraFeeStaleDuration(60)
+	want := 30 * time.Minute
+	if got != want {
+		t.Fatalf("infuraFeeStaleDuration(60) = %s, want %s", got, want)
+	}
+}
+
+func TestInfuraFeeProviderUsesCachedFeesDuringStaleWindow(t *testing.T) {
+	provider := &infuraFeeProvider{
+		alternativeFeeProvider: &alternativeFeeProvider{
+			staleSyncDuration: infuraFeeStaleDuration(60),
+		},
+	}
+
+	provider.processData(&infuraFeesResult{
+		BaseFee: "10",
+		Low: infuraFeeResult{
+			MaxPriorityFeePerGas: "1",
+			MaxFeePerGas:         "11",
+		},
+		Medium: infuraFeeResult{
+			MaxPriorityFeePerGas: "2",
+			MaxFeePerGas:         "12",
+		},
+		High: infuraFeeResult{
+			MaxPriorityFeePerGas: "3",
+			MaxFeePerGas:         "13",
+		},
+	})
+
+	provider.mux.Lock()
+	provider.lastSync = time.Now().Add(-29 * time.Minute)
+	provider.mux.Unlock()
+
+	fees, err := provider.GetEip1559Fees()
+	if err != nil {
+		t.Fatalf("GetEip1559Fees() error = %v", err)
+	}
+	if fees == nil {
+		t.Fatal("GetEip1559Fees() returned nil fees inside stale window")
+	}
+
+	provider.mux.Lock()
+	provider.lastSync = time.Now().Add(-31 * time.Minute)
+	provider.mux.Unlock()
+
+	fees, err = provider.GetEip1559Fees()
+	if err != nil {
+		t.Fatalf("GetEip1559Fees() error = %v", err)
+	}
+	if fees != nil {
+		t.Fatal("GetEip1559Fees() returned fees after stale window")
+	}
+}

--- a/bchain/coins/optimism/optimismrpc.go
+++ b/bchain/coins/optimism/optimismrpc.go
@@ -67,7 +67,9 @@ func (b *OptimismRPC) Initialize() error {
 		return errors.Errorf("Unknown network id %v", id)
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	glog.Info("rpc: block chain ", b.Network)
 

--- a/bchain/coins/polygon/polygonrpc.go
+++ b/bchain/coins/polygon/polygonrpc.go
@@ -67,7 +67,9 @@ func (b *PolygonRPC) Initialize() error {
 		return errors.Errorf("Unknown network id %v", id)
 	}
 
-	b.InitAlternativeProviders()
+	if err = b.InitAlternativeProviders(); err != nil {
+		return err
+	}
 
 	glog.Info("rpc: block chain ", b.Network)
 

--- a/bchain/coins/tron/tronrpc.go
+++ b/bchain/coins/tron/tronrpc.go
@@ -464,7 +464,11 @@ func (b *TronRPC) GetChainParser() bchain.BlockChainParser {
 
 func (b *TronRPC) CreateMempool(chain bchain.BlockChain) (bchain.Mempool, error) {
 	if b.Mempool == nil {
-		b.Mempool = bchain.NewMempoolEthereumType(chain, b.ChainConfig.MempoolTxTimeoutHours, b.ChainConfig.QueryBackendOnMempoolResync)
+		mempoolTxTimeout, err := b.ChainConfig.MempoolTxTimeoutDuration(false)
+		if err != nil {
+			return nil, err
+		}
+		b.Mempool = bchain.NewMempoolEthereumType(chain, mempoolTxTimeout, b.ChainConfig.QueryBackendOnMempoolResync)
 	}
 	return b.Mempool, nil
 }

--- a/bchain/mempool_ethereum_type.go
+++ b/bchain/mempool_ethereum_type.go
@@ -18,8 +18,7 @@ type MempoolEthereumType struct {
 }
 
 // NewMempoolEthereumType creates new mempool handler.
-func NewMempoolEthereumType(chain BlockChain, mempoolTxTimeoutHours int, queryBackendOnResync bool) *MempoolEthereumType {
-	mempoolTimeoutTime := time.Duration(mempoolTxTimeoutHours) * time.Hour
+func NewMempoolEthereumType(chain BlockChain, mempoolTimeoutTime time.Duration, queryBackendOnResync bool) *MempoolEthereumType {
 	return &MempoolEthereumType{
 		BaseMempool: BaseMempool{
 			chain:        chain,

--- a/bchain/mempool_ethereum_type_test.go
+++ b/bchain/mempool_ethereum_type_test.go
@@ -53,3 +53,10 @@ func TestMempoolEthereumType_removeTransactionsMissingFromBackend(t *testing.T) 
 		t.Fatalf("addrDescToTx = %+v, want %+v", m.addrDescToTx, wantAddrDescToTx)
 	}
 }
+
+func TestNewMempoolEthereumTypeUsesDuration(t *testing.T) {
+	m := NewMempoolEthereumType(nil, 10*time.Minute, false)
+	if m.mempoolTimeoutTime != 10*time.Minute {
+		t.Fatalf("mempoolTimeoutTime = %s, want %s", m.mempoolTimeoutTime, 10*time.Minute)
+	}
+}

--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -55,7 +55,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 16}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "20s",

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -57,7 +57,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 8}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "20s",

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -63,7 +63,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees\", \"periodSeconds\": 8}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 48,
                 "processInternalTransactions": true,
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -57,7 +57,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 20}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "20s",

--- a/configs/coins/polygon_archive.json
+++ b/configs/coins/polygon_archive.json
@@ -62,7 +62,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/137/suggestedGasFees\", \"periodSeconds\": 8}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/137/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "20s",

--- a/docs/config.md
+++ b/docs/config.md
@@ -101,6 +101,10 @@ Good examples of coin configuration are
         * `block_addresses_to_keep` – Number of blocks that are to be kept in blockaddresses column.
         * `additional_params` – Object of coin-specific params.
           * Tron-specific endpoint configuration is documented in [Tron Config](/docs/tron-config.md).
+          * Infura alternative EIP-1559 fee provider configuration:
+            * `alternative_estimate_fee` – Set to `infura` to use Infura Gas API fee suggestions instead of native node fee estimation.
+            * `alternative_estimate_fee_params` – JSON string with `url` and `periodSeconds`. `periodSeconds` controls how often Blockbook polls Infura.
+              Cached Infura fees remain usable for 30 failed polling periods, so `periodSeconds: 60` keeps the last successful fees for up to 30 minutes before native fallback.
           * Ethereum mempool timeout configuration:
             * `mempoolTxTimeoutHours` – Legacy Blockbook-side EVM mempool retention in whole hours. It is used when `mempoolTxTimeout` is not set and no alternative send transaction provider is enabled.
             * `mempoolTxTimeout` – Optional Blockbook-side EVM mempool retention as a Go duration string such as `"10m"`. If omitted and an alternative send transaction provider is enabled, Blockbook uses **10 minutes** instead of the legacy hour-based value.

--- a/docs/config.md
+++ b/docs/config.md
@@ -107,8 +107,8 @@ Good examples of coin configuration are
               Cached Infura fees remain usable for 30 failed polling periods, so `periodSeconds: 60` keeps the last successful fees for up to 30 minutes before native fallback.
           * Ethereum mempool timeout configuration:
             * `mempoolTxTimeoutHours` – Legacy Blockbook-side EVM mempool retention in whole hours. It is used when `mempoolTxTimeout` is not set and no alternative send transaction provider is enabled.
-            * `mempoolTxTimeout` – Optional Blockbook-side EVM mempool retention as a Go duration string such as `"10m"`. If omitted and an alternative send transaction provider is enabled, Blockbook uses **10 minutes** instead of the legacy hour-based value.
-            * `alternativeMempoolTxTimeout` – Optional alternative-provider transaction cache retention as a Go duration string such as `"5m"`. Defaults to **5 minutes** when the alternative send transaction provider is enabled.
+            * `mempoolTxTimeout` – Optional Blockbook-side EVM mempool retention as a Go duration string such as `"10m"`; `"0s"` preserves the legacy zero-retention setting. If omitted and an alternative send transaction provider is enabled, Blockbook uses **10 minutes** instead of the legacy hour-based value.
+            * `alternativeMempoolTxTimeout` – Optional alternative-provider transaction cache retention as a positive Go duration string such as `"5m"`. Defaults to **5 minutes** when the alternative send transaction provider is enabled.
           * Hot-address configuration (Blockbook, Ethereum-type indexing):
             * `hot_address_min_contracts` – Minimum number of contracts before hotness tracking applies (default **192**).
             * `hot_address_min_hits` – Lookups within the current block required to mark an address hot (default **3**, clamped to **10**).

--- a/docs/config.md
+++ b/docs/config.md
@@ -101,6 +101,10 @@ Good examples of coin configuration are
         * `block_addresses_to_keep` – Number of blocks that are to be kept in blockaddresses column.
         * `additional_params` – Object of coin-specific params.
           * Tron-specific endpoint configuration is documented in [Tron Config](/docs/tron-config.md).
+          * Ethereum mempool timeout configuration:
+            * `mempoolTxTimeoutHours` – Legacy Blockbook-side EVM mempool retention in whole hours. It is used when `mempoolTxTimeout` is not set and no alternative send transaction provider is enabled.
+            * `mempoolTxTimeout` – Optional Blockbook-side EVM mempool retention as a Go duration string such as `"10m"`. If omitted and an alternative send transaction provider is enabled, Blockbook uses **10 minutes** instead of the legacy hour-based value.
+            * `alternativeMempoolTxTimeout` – Optional alternative-provider transaction cache retention as a Go duration string such as `"5m"`. Defaults to **5 minutes** when the alternative send transaction provider is enabled.
           * Hot-address configuration (Blockbook, Ethereum-type indexing):
             * `hot_address_min_contracts` – Minimum number of contracts before hotness tracking applies (default **192**).
             * `hot_address_min_hits` – Lookups within the current block required to mark an address hot (default **3**, clamped to **10**).

--- a/docs/env.md
+++ b/docs/env.md
@@ -19,6 +19,8 @@ Some behavior of Blockbook can be modified by environment variables. The variabl
 
 -   `<coin shortcut>_STAKING_POOL_CONTRACT` - The pool name and contract used for Ethereum staking. The format of the variable is `<pool name>/<pool contract>`. If missing, staking support is disabled.
 
+-   `INFURA_API_KEY` - API key for the Infura alternative EIP-1559 fee provider. Archive EVM configs using Infura poll once per minute and keep serving the last successful fee data for up to 30 failed polls before falling back to native fee estimation.
+
 -   `COINGECKO_API_KEY`, `<network>_COINGECKO_API_KEY`, or `<coin shortcut>_COINGECKO_API_KEY` - API key for making requests to CoinGecko in the paid tier.
     If any of these variables is set, it must be non-empty (empty value is treated as a configuration error and Blockbook fails on startup).
     Lookup priority is:

--- a/docs/env.md
+++ b/docs/env.md
@@ -29,6 +29,14 @@ Some behavior of Blockbook can be modified by environment variables. The variabl
 
 -   `<coin shortcut>_ALLOWED_RPC_CALL_TO` - Addresses to which `rpcCall` websocket requests can be made, as a comma-separated list. If omitted, `rpcCall` is enabled for all addresses.
 
+-   `<network or coin shortcut>_ALTERNATIVE_SENDTX_URLS` - Comma-separated list of alternative EVM `eth_sendRawTransaction` providers, used for private/MEV-protected transaction submission. The prefix is the configured `network` value when present (for example `OP`, `BASE`, `POL`, `BSC`, `ARB`, `AVAX`), otherwise the coin shortcut (for example `ETH`). If omitted, Blockbook sends transactions through the normal backend RPC.
+
+-   `<network or coin shortcut>_ALTERNATIVE_SENDTX_ONLY` - Set to `TRUE` to use only the alternative send transaction provider and avoid fallback to the normal backend RPC if alternative submission fails.
+
+-   `<network or coin shortcut>_ALTERNATIVE_FETCH_MEMPOOL_TX` - Set to `TRUE` to fetch and cache transactions submitted through the alternative provider, so Blockbook can expose them as pending even if they are not visible in the public backend mempool. When the alternative provider is enabled, the default alternative cache timeout is 5 minutes and the default Blockbook EVM mempool timeout is 10 minutes; both can be overridden in coin config with `alternativeMempoolTxTimeout` and `mempoolTxTimeout`.
+
+    WebSocket `sendTransaction` can bypass the alternative provider for a single request by setting `disableAlternativeRPC` to `true`.
+
 ## Build-time variables
 
 -   `BB_BUILD_ENV` - Selects the active RPC URL override family during package/config generation. Defaults to `dev`.

--- a/tests/dbtestdata/fakechain_ethereumtype.go
+++ b/tests/dbtestdata/fakechain_ethereumtype.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"strconv"
+	"time"
 
 	"github.com/trezor/blockbook/bchain"
 )
@@ -19,7 +20,7 @@ func NewFakeBlockChainEthereumType(parser bchain.BlockChainParser) (bchain.Block
 }
 
 func (c *fakeBlockChainEthereumType) CreateMempool(chain bchain.BlockChain) (bchain.Mempool, error) {
-	return bchain.NewMempoolEthereumType(chain, 1, false), nil
+	return bchain.NewMempoolEthereumType(chain, time.Hour, false), nil
 }
 
 func (c *fakeBlockChainEthereumType) GetChainInfo() (v *bchain.ChainInfo, err error) {


### PR DESCRIPTION
Alternative/private relays (MEV protection) often expire pending transactions an they keep hanging in blockbook mempool for hours.

Extending infura fees period