### PR TITLE
Stop ERC20 batch fallback from amplifying RPC calls

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -1260,7 +1260,7 @@ func (w *Worker) getEthereumTypeAddressBalances(addrDesc bchain.AddressDescripto
 				}
 				erc20Contracts = append(erc20Contracts, c.Contract)
 			}
-			if len(erc20Contracts) >= 1 {
+			if len(erc20Contracts) > 1 {
 				balances, err := w.chain.EthereumTypeGetErc20ContractBalances(addrDesc, erc20Contracts)
 				if err != nil {
 					glog.Warningf("EthereumTypeGetErc20ContractBalances addr %v: %v", addrDesc, err)

--- a/api/worker.go
+++ b/api/worker.go
@@ -1047,7 +1047,7 @@ func computePaging(count, page, itemsOnPage int) (Paging, int, int, int) {
 	}, from, to, page
 }
 
-func (w *Worker) getEthereumContractBalance(addrDesc bchain.AddressDescriptor, index int, c *db.AddrContract, details AccountDetails, ticker *common.CurrencyRatesTicker, secondaryCoin string, erc20Balance *big.Int) (*Token, error) {
+func (w *Worker) getEthereumContractBalance(addrDesc bchain.AddressDescriptor, index int, c *db.AddrContract, details AccountDetails, ticker *common.CurrencyRatesTicker, secondaryCoin string, erc20Balance *big.Int, erc20Batched bool) (*Token, error) {
 	standard := bchain.EthereumTokenStandardMap[c.Standard]
 	ci, validContract, err := w.getContractDescriptorInfo(c.Contract, standard)
 	if err != nil {
@@ -1068,8 +1068,11 @@ func (w *Worker) getEthereumContractBalance(addrDesc bchain.AddressDescriptor, i
 		if c.Standard == bchain.FungibleToken {
 			// get Erc20 Contract Balance from blockchain, balance obtained from adding and subtracting transfers is not correct
 			// Prefer pre-fetched batch balance when available to avoid redundant RPC calls.
+			// If the contract was already part of a batch attempt, skip the per-contract fallback:
+			// a nil result there indicates the call failed or returned an unparseable value, and
+			// retrying as a single call would only amplify RPC load without changing the outcome.
 			b := erc20Balance
-			if b == nil {
+			if b == nil && !erc20Batched {
 				b, err = w.chain.EthereumTypeGetErc20ContractBalance(addrDesc, c.Contract)
 				if err != nil {
 					// return nil, nil, nil, errors.Annotatef(err, "EthereumTypeGetErc20ContractBalance %v %v", addrDesc, c.Contract)
@@ -1257,17 +1260,18 @@ func (w *Worker) getEthereumTypeAddressBalances(addrDesc bchain.AddressDescripto
 				}
 				erc20Contracts = append(erc20Contracts, c.Contract)
 			}
-			if len(erc20Contracts) > 1 {
+			if len(erc20Contracts) >= 1 {
 				balances, err := w.chain.EthereumTypeGetErc20ContractBalances(addrDesc, erc20Contracts)
 				if err != nil {
 					glog.Warningf("EthereumTypeGetErc20ContractBalances addr %v: %v", addrDesc, err)
 				} else if len(balances) == len(erc20Contracts) {
-					// Keep only successful batch results; missing entries will trigger per-contract calls.
+					// Record every batched contract as a key, even when the value is nil. Map presence
+					// signals that the batch already covered this contract so the consumer must not
+					// fall back to a single call - that fallback was the source of N-fold RPC
+					// amplification when batches returned per-element errors or unparseable results.
 					erc20Balances = make(map[string]*big.Int, len(erc20Contracts))
 					for i, bal := range balances {
-						if bal != nil {
-							erc20Balances[string(erc20Contracts[i])] = bal
-						}
+						erc20Balances[string(erc20Contracts[i])] = bal
 					}
 				}
 			}
@@ -1284,12 +1288,14 @@ func (w *Worker) getEthereumTypeAddressBalances(addrDesc bchain.AddressDescripto
 					// filter only transactions of this contract
 					filter.Vout = i + db.ContractIndexOffset
 				}
-				// Use prefetched batch balances when available; nil triggers per-contract RPC in helper.
+				// Use prefetched batch balances when available. Map presence (not value) marks the
+				// contract as batched so the helper skips its per-contract RPC fallback.
 				var erc20Balance *big.Int
+				var erc20Batched bool
 				if erc20Balances != nil {
-					erc20Balance = erc20Balances[string(c.Contract)]
+					erc20Balance, erc20Batched = erc20Balances[string(c.Contract)]
 				}
-				t, err := w.getEthereumContractBalance(addrDesc, i+db.ContractIndexOffset, c, details, ticker, secondaryCoin, erc20Balance)
+				t, err := w.getEthereumContractBalance(addrDesc, i+db.ContractIndexOffset, c, details, ticker, secondaryCoin, erc20Balance, erc20Batched)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -519,6 +519,10 @@ func (b *EthereumRPC) erc20BalancesBatchAtBlock(batcher batchCaller, callData st
 	defer cancel()
 	if err := batcher.BatchCallContext(ctx, batch); err != nil {
 		b.observeEthCallError("batch", "rpc")
+		// Distinct fallback metric so monitoring can alert on this path even
+		// though we suppress the error to keep callers (e.g. account info)
+		// usable on transient batch-level RPC failures.
+		b.ObserveChainDataFallback("erc20_batch", "rpc")
 		glog.Warningf("erc20 batch eth_call failed: %v, falling back to single calls", err)
 		balances := make([]*big.Int, len(contractDescs))
 		for i, contractDesc := range contractDescs {

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -519,7 +519,21 @@ func (b *EthereumRPC) erc20BalancesBatchAtBlock(batcher batchCaller, callData st
 	defer cancel()
 	if err := batcher.BatchCallContext(ctx, batch); err != nil {
 		b.observeEthCallError("batch", "rpc")
-		return nil, err
+		glog.Warningf("erc20 batch eth_call failed: %v, falling back to single calls", err)
+		balances := make([]*big.Int, len(contractDescs))
+		for i, contractDesc := range contractDescs {
+			data, err := b.EthereumTypeRpcCallAtBlock(callData, hexutil.Encode(contractDesc), "", blockNumber)
+			if err != nil {
+				glog.Warningf("erc20 single eth_call fallback failed for %s: %v", hexutil.Encode(contractDesc), err)
+				continue
+			}
+			balances[i] = parseSimpleNumericProperty(data)
+			if balances[i] == nil {
+				b.observeEthCallError("single", "invalid")
+				glog.Warningf("erc20 single eth_call invalid result for %s: %q", hexutil.Encode(contractDesc), data)
+			}
+		}
+		return balances, nil
 	}
 	balances := make([]*big.Int, len(contractDescs))
 	for i := range batch {
@@ -529,7 +543,7 @@ func (b *EthereumRPC) erc20BalancesBatchAtBlock(batcher batchCaller, callData st
 				continue
 			}
 			glog.Warningf("erc20 batch eth_call failed for %s: %v", hexutil.Encode(contractDescs[i]), batch[i].Error)
-			// In case of batch failure, retry missing/failed elements as single calls.
+			// In case of individual element failure in a successful batch, retry it as a single call.
 			data, err := b.EthereumTypeRpcCallAtBlock(callData, hexutil.Encode(contractDescs[i]), "", blockNumber)
 			if err != nil {
 				glog.Warningf("erc20 single eth_call fallback failed for %s: %v", hexutil.Encode(contractDescs[i]), err)
@@ -542,7 +556,8 @@ func (b *EthereumRPC) erc20BalancesBatchAtBlock(batcher batchCaller, callData st
 			}
 			continue
 		}
-		// Leave nil on parse failures so callers can retry per contract if needed.
+		// Leave nil on parse failures; retrying as a single call is unlikely to help
+		// as malformed returns usually indicate non-conforming contract implementations.
 		balances[i] = parseSimpleNumericProperty(results[i])
 		if balances[i] == nil {
 			b.observeEthCallError("batch", "invalid")

--- a/bchain/coins/eth/contract_batch_test.go
+++ b/bchain/coins/eth/contract_batch_test.go
@@ -78,6 +78,7 @@ type rpcCall struct {
 type mockBatchCallRPC struct {
 	batchResults map[string]string
 	batchErrors  map[string]error
+	batchRPCErr  error
 	callResults  map[string]string
 	callErrors   map[string]error
 	batchCalls   []rpcCall
@@ -120,6 +121,9 @@ func (m *mockBatchCallRPC) CallContext(ctx context.Context, result interface{}, 
 }
 
 func (m *mockBatchCallRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
+	if m.batchRPCErr != nil {
+		return m.batchRPCErr
+	}
 	for i := range batch {
 		elem := &batch[i]
 		if elem.Method != "eth_call" {
@@ -263,6 +267,92 @@ func TestErc20BalancesBatchFallback(t *testing.T) {
 	}
 	if mock.calls[0].data != callData {
 		t.Fatalf("expected fallback call data %q, got %q", callData, mock.calls[0].data)
+	}
+}
+
+func TestErc20BalancesBatchWholeBatchRPCError(t *testing.T) {
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000011")
+	contractA := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	contractB := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	contractAKey := hexutil.Encode(contractA.Bytes())
+	contractBKey := hexutil.Encode(contractB.Bytes())
+	callData := erc20BalanceOfCallData(bchain.AddressDescriptor(addr.Bytes()))
+	mock := &mockBatchCallRPC{
+		batchRPCErr: errors.New("connection reset"),
+		callResults: map[string]string{
+			contractAKey: fmt.Sprintf("0x%064x", 11),
+			contractBKey: fmt.Sprintf("0x%064x", 22),
+		},
+	}
+	rpcClient := &EthereumRPC{
+		RPC:     mock,
+		Timeout: time.Second,
+	}
+	balances, err := rpcClient.erc20BalancesBatch(mock, callData, []bchain.AddressDescriptor{
+		bchain.AddressDescriptor(contractA.Bytes()),
+		bchain.AddressDescriptor(contractB.Bytes()),
+	})
+	if err != nil {
+		t.Fatalf("expected nil error after fallback, got %v", err)
+	}
+	if len(balances) != 2 {
+		t.Fatalf("expected 2 balances, got %d", len(balances))
+	}
+	if balances[0] == nil || balances[0].Cmp(big.NewInt(11)) != 0 {
+		t.Fatalf("unexpected balance[0]: %v", balances[0])
+	}
+	if balances[1] == nil || balances[1].Cmp(big.NewInt(22)) != 0 {
+		t.Fatalf("unexpected balance[1]: %v", balances[1])
+	}
+	if len(mock.calls) != 2 {
+		t.Fatalf("expected 2 single-call fallbacks, got %d", len(mock.calls))
+	}
+	gotTos := map[string]bool{mock.calls[0].to: true, mock.calls[1].to: true}
+	if !gotTos[contractAKey] || !gotTos[contractBKey] {
+		t.Fatalf("expected fallbacks for both contracts, got %+v", mock.calls)
+	}
+	for _, call := range mock.calls {
+		if call.data != callData {
+			t.Fatalf("unexpected fallback call data: %q", call.data)
+		}
+	}
+}
+
+func TestErc20BalancesBatchWholeBatchRPCErrorPartialSingleFailure(t *testing.T) {
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000011")
+	contractA := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	contractB := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	contractAKey := hexutil.Encode(contractA.Bytes())
+	contractBKey := hexutil.Encode(contractB.Bytes())
+	callData := erc20BalanceOfCallData(bchain.AddressDescriptor(addr.Bytes()))
+	mock := &mockBatchCallRPC{
+		batchRPCErr: errors.New("connection reset"),
+		callResults: map[string]string{
+			contractAKey: fmt.Sprintf("0x%064x", 11),
+		},
+		callErrors: map[string]error{
+			contractBKey: errors.New("still broken"),
+		},
+	}
+	rpcClient := &EthereumRPC{
+		RPC:     mock,
+		Timeout: time.Second,
+	}
+	balances, err := rpcClient.erc20BalancesBatch(mock, callData, []bchain.AddressDescriptor{
+		bchain.AddressDescriptor(contractA.Bytes()),
+		bchain.AddressDescriptor(contractB.Bytes()),
+	})
+	if err != nil {
+		t.Fatalf("expected nil error after fallback, got %v", err)
+	}
+	if len(balances) != 2 {
+		t.Fatalf("expected 2 balances, got %d", len(balances))
+	}
+	if balances[0] == nil || balances[0].Cmp(big.NewInt(11)) != 0 {
+		t.Fatalf("unexpected balance[0]: %v", balances[0])
+	}
+	if balances[1] != nil {
+		t.Fatalf("expected balance[1] to be nil after single-call failure, got %v", balances[1])
 	}
 }
 


### PR DESCRIPTION
When a batched balanceOf returned per-element errors or unparseable results, the worker fell back to a single eth_call per affected contract — a wallet with N tokens could turn into N+1 RPCs on a single bad batch, and parse failures triggered retries that were never going to succeed (malformed returns indicate non-conforming contracts, not transient faults).