### PR TITLE
Deduplicate address descriptors before counting and fix matching function

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1367,15 +1367,31 @@ func (s *WebsocketServer) unmarshalAddresses(params []byte) ([]string, bool, err
 	if len(r.Addresses) > limit {
 		return nil, false, api.NewAPIError("addresses max "+strconv.Itoa(limit), true)
 	}
-	rv := make([]string, len(r.Addresses))
-	for i, a := range r.Addresses {
+	rv := make([]string, 0, len(r.Addresses))
+	for _, a := range r.Addresses {
 		ad, err := s.chainParser.GetAddrDescFromAddress(a)
 		if err != nil {
 			return nil, false, api.NewAPIError("Invalid address "+strconv.Quote(a)+", "+err.Error(), true)
 		}
-		rv[i] = string(ad)
+		rv = append(rv, string(ad))
 	}
-	return rv, r.NewBlockTxs, nil
+	return deduplicateAddressDescriptors(rv), r.NewBlockTxs, nil
+}
+
+func deduplicateAddressDescriptors(addrDesc []string) []string {
+	if len(addrDesc) < 2 {
+		return addrDesc
+	}
+	seen := make(map[string]struct{}, len(addrDesc))
+	rv := addrDesc[:0]
+	for _, ads := range addrDesc {
+		if _, exists := seen[ads]; exists {
+			continue
+		}
+		seen[ads] = struct{}{}
+		rv = append(rv, ads)
+	}
+	return rv
 }
 
 // doUnsubscribeAddresses removes all address subscriptions for a channel.
@@ -1404,6 +1420,7 @@ func (s *WebsocketServer) doUnsubscribeAddresses(c *websocketChannel) {
 // If newBlockTxs is enabled, the channel receives both mempool notifications and
 // confirmed notifications detected from newly connected blocks.
 func (s *WebsocketServer) subscribeAddresses(c *websocketChannel, addrDesc []string, newBlockTxs bool, req *WsReq) (res interface{}, err error) {
+	addrDesc = deduplicateAddressDescriptors(addrDesc)
 	s.addressSubscriptionsLock.Lock()
 	defer s.addressSubscriptionsLock.Unlock()
 	// unsubscribe all previous subscriptions
@@ -1620,7 +1637,7 @@ func (s *WebsocketServer) publishNewBlockTxsByAddr(block *bchain.Block) {
 			populateBitcoinVinAddrDescs(vins, s.getBitcoinVinAddrDesc)
 		}
 		matchStart := time.Now()
-		subscribed := s.getNewTxSubscriptions(vins, tx.Vout, tokenTransfers, internalTransfers)
+		subscribed := s.getNewTxSubscriptions(vins, tx.Vout, tokenTransfers, internalTransfers, true)
 		observeNewBlockTxDuration(s.metrics, "match", matchStart)
 		if len(subscribed) > 0 {
 			incNewBlockTxMetric(s.metrics, "matched", "success", 1)
@@ -1725,15 +1742,30 @@ func (s *WebsocketServer) sendOnNewTxAddr(stringAddressDescriptor string, tx *ap
 	}
 }
 
-func (s *WebsocketServer) getNewTxSubscriptions(vins []bchain.MempoolVin, vouts []bchain.Vout, tokenTransfers bchain.TokenTransfers, internalTransfers []bchain.EthereumInternalTransfer) map[string]struct{} {
+func (s *WebsocketServer) getNewTxSubscriptions(vins []bchain.MempoolVin, vouts []bchain.Vout, tokenTransfers bchain.TokenTransfers, internalTransfers []bchain.EthereumInternalTransfer, newBlockTxsOnly bool) map[string]struct{} {
 	// check if there is any subscription in inputs, outputs and transfers
 	s.addressSubscriptionsLock.Lock()
 	defer s.addressSubscriptionsLock.Unlock()
 	subscribed := make(map[string]struct{})
+	hasSubscription := func(sad string) bool {
+		as, ok := s.addressSubscriptions[sad]
+		if !ok || len(as) == 0 {
+			return false
+		}
+		if !newBlockTxsOnly {
+			return true
+		}
+		for _, details := range as {
+			if details.publishNewBlockTxs {
+				return true
+			}
+		}
+		return false
+	}
 	processAddress := func(address string) {
 		if addrDesc, err := s.chainParser.GetAddrDescFromAddress(address); err == nil && len(addrDesc) > 0 {
 			sad := string(addrDesc)
-			if as, ok := s.addressSubscriptions[sad]; ok && len(as) > 0 {
+			if hasSubscription(sad) {
 				subscribed[sad] = struct{}{}
 			}
 		}
@@ -1741,14 +1773,14 @@ func (s *WebsocketServer) getNewTxSubscriptions(vins []bchain.MempoolVin, vouts 
 	processVout := func(vout bchain.Vout) {
 		if addrDesc, err := s.chainParser.GetAddrDescFromVout(&vout); err == nil && len(addrDesc) > 0 {
 			sad := string(addrDesc)
-			if as, ok := s.addressSubscriptions[sad]; ok && len(as) > 0 {
+			if hasSubscription(sad) {
 				subscribed[sad] = struct{}{}
 			}
 		}
 	}
 	for i := range vins {
 		if sad := string(vins[i].AddrDesc); len(sad) > 0 {
-			if as, ok := s.addressSubscriptions[sad]; ok && len(as) > 0 {
+			if hasSubscription(sad) {
 				subscribed[sad] = struct{}{}
 			}
 		} else if s.chainParser.GetChainType() == bchain.ChainBitcoinType {
@@ -1790,7 +1822,7 @@ func (s *WebsocketServer) onNewTxAsync(tx *bchain.MempoolTx, subscribed map[stri
 
 // OnNewTx is a callback that broadcasts info about a tx affecting subscribed address
 func (s *WebsocketServer) OnNewTx(tx *bchain.MempoolTx) {
-	subscribed := s.getNewTxSubscriptions(tx.Vin, tx.Vout, tx.TokenTransfers, nil)
+	subscribed := s.getNewTxSubscriptions(tx.Vin, tx.Vout, tx.TokenTransfers, nil, false)
 	if len(s.newTransactionSubscriptions) > 0 || len(subscribed) > 0 {
 		if s.trackWork() {
 			go func() {

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -534,6 +534,28 @@ func TestUnmarshalAddressesRejectsTooManyNewBlockTxAddresses(t *testing.T) {
 	}
 }
 
+func TestUnmarshalAddressesDeduplicatesDescriptors(t *testing.T) {
+	parser, _ := setupChain(t)
+	params, err := json.Marshal(WsSubscribeAddressesReq{
+		Addresses: []string{dbtestdata.Addr1, dbtestdata.Addr1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &WebsocketServer{chainParser: parser}
+	addresses, newBlockTxs, err := s.unmarshalAddresses(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newBlockTxs {
+		t.Fatal("newBlockTxs = true, want false")
+	}
+	if len(addresses) != 1 {
+		t.Fatalf("len(addresses) = %d, want 1", len(addresses))
+	}
+}
+
 func TestSetConfirmedBlockTxMetadataSetsConfirmedFields(t *testing.T) {
 	tx := bchain.Tx{
 		Confirmations: 0,
@@ -729,7 +751,7 @@ func TestPopulateBitcoinVinAddrDescsEnablesSenderOnlyMatching(t *testing.T) {
 		},
 	}
 
-	withoutResolvedVins := s.getNewTxSubscriptions(vins, tx.Vout, nil, nil)
+	withoutResolvedVins := s.getNewTxSubscriptions(vins, tx.Vout, nil, nil, true)
 	if _, ok := withoutResolvedVins[string(addr3Desc)]; ok {
 		t.Fatal("sender subscription unexpectedly matched before vin descriptor resolution")
 	}
@@ -745,9 +767,40 @@ func TestPopulateBitcoinVinAddrDescsEnablesSenderOnlyMatching(t *testing.T) {
 		}
 	})
 
-	withResolvedVins := s.getNewTxSubscriptions(vins, tx.Vout, nil, nil)
+	withResolvedVins := s.getNewTxSubscriptions(vins, tx.Vout, nil, nil, true)
 	if _, ok := withResolvedVins[string(addr3Desc)]; !ok {
 		t.Fatal("sender subscription did not match after vin descriptor resolution")
+	}
+}
+
+func TestGetNewTxSubscriptionsFiltersMempoolOnlyForNewBlockTxs(t *testing.T) {
+	parser, _ := setupChain(t)
+	addrDesc, err := parser.GetAddrDescFromAddress(dbtestdata.Addr1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stringAddrDesc := string(addrDesc)
+	dummy := &websocketChannel{}
+	s := &WebsocketServer{
+		addressSubscriptions: map[string]map[*websocketChannel]*addressDetails{
+			stringAddrDesc: {dummy: {requestID: "mempool-only", publishNewBlockTxs: false}},
+		},
+	}
+	vins := []bchain.MempoolVin{{AddrDesc: addrDesc}}
+
+	mempoolSubscribed := s.getNewTxSubscriptions(vins, nil, nil, nil, false)
+	if _, ok := mempoolSubscribed[stringAddrDesc]; !ok {
+		t.Fatal("mempool notification did not match mempool-only subscriber")
+	}
+	newBlockSubscribed := s.getNewTxSubscriptions(vins, nil, nil, nil, true)
+	if _, ok := newBlockSubscribed[stringAddrDesc]; ok {
+		t.Fatal("newBlockTxs matching included mempool-only subscriber")
+	}
+
+	s.addressSubscriptions[stringAddrDesc][dummy].publishNewBlockTxs = true
+	newBlockSubscribed = s.getNewTxSubscriptions(vins, nil, nil, nil, true)
+	if _, ok := newBlockSubscribed[stringAddrDesc]; !ok {
+		t.Fatal("newBlockTxs matching did not include newBlockTxs subscriber")
 	}
 }
 


### PR DESCRIPTION
the matching function currently matches any address subscriber, including mempool-only subscribers, and only filters `newBlockTxs` later during send: [server/websocket.go](/home/lisak/src/trezor/blockbook/server/websocket.go:1736), [server/websocket.go](/home/lisak/src/trezor/blockbook/server/websocket.go:1712). That means one `newBlockTxs=true` client can cause confirmed-block conversion work for addresses subscribed by normal Suite clients.

1. **Fix matching so confirmed-block processing only matches `publishNewBlockTxs` subscribers.**
   Add a `newBlockTxsOnly` mode or separate helper/map, so `publishNewBlockTxsByAddr` does not treat mempool-only subscribers as matches. This reduces expensive tx conversion and Ethereum receipt RPCs without changing public behavior.

2. **Deduplicate address descriptors before counting.**
   Right now duplicate addresses in one `newBlockTxs=true` subscribe can inflate `newBlockTxsSubscriptionCount`, and unsubscribe may only decrement once. That can leave the count permanently above zero and keep per-block scanning enabled. Dedupe in `unmarshalAddresses` or before `subscribeAddresses` mutates state.
