### PR TITLE
Chain tip syncing on websocket connection

### DIFF
--- a/bchain/coins/avalanche/evm.go
+++ b/bchain/coins/avalanche/evm.go
@@ -48,36 +48,8 @@ type AvalancheRPCClient struct {
 	*rpc.Client
 }
 
-// AvalancheDualRPCClient routes calls and subscriptions to separate RPC clients.
-type AvalancheDualRPCClient struct {
-	CallClient *AvalancheRPCClient
-	SubClient  *AvalancheRPCClient
-}
-
-// CallContext forwards JSON-RPC calls to the HTTP client with Avalanche-specific handling.
-func (c *AvalancheDualRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	return c.CallClient.CallContext(ctx, result, method, args...)
-}
-
-// BatchCallContext forwards batch JSON-RPC calls to the HTTP client.
-func (c *AvalancheDualRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
-	return c.CallClient.BatchCallContext(ctx, batch)
-}
-
-// EthSubscribe forwards subscriptions to the WebSocket client.
-func (c *AvalancheDualRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
-	return c.SubClient.EthSubscribe(ctx, channel, args...)
-}
-
-// Close shuts down both underlying clients.
-func (c *AvalancheDualRPCClient) Close() {
-	if c.SubClient != nil {
-		c.SubClient.Close()
-	}
-	if c.CallClient != nil && c.CallClient != c.SubClient {
-		c.CallClient.Close()
-	}
-}
+// AvalancheDualRPCClient routes ordinary calls over HTTP and subscriptions/chain-tip calls over WebSocket.
+type AvalancheDualRPCClient = bchain.DualEVMRPCClient
 
 // EthSubscribe subscribes to events and returns a client subscription that implements the EVMClientSubscription interface
 func (c *AvalancheRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
@@ -102,6 +74,11 @@ func (c *AvalancheRPCClient) CallContext(ctx context.Context, result interface{}
 		return err
 	}
 	return nil
+}
+
+// CallContextWithIntent performs a JSON-RPC call on this client.
+func (c *AvalancheRPCClient) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return c.CallContext(ctx, result, method, args...)
 }
 
 // AvalancheHeader wraps a block header to implement the EVMHeader interface

--- a/bchain/coins/eth/contract_batch_test.go
+++ b/bchain/coins/eth/contract_batch_test.go
@@ -30,6 +30,10 @@ func (m *mockBatchRPC) CallContext(ctx context.Context, result interface{}, meth
 	return errors.New("not implemented")
 }
 
+func (m *mockBatchRPC) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return m.CallContext(ctx, result, method, args...)
+}
+
 func (m *mockBatchRPC) Close() {}
 
 func (m *mockBatchRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
@@ -118,6 +122,10 @@ func (m *mockBatchCallRPC) CallContext(ctx context.Context, result interface{}, 
 	}
 	*out = res
 	return nil
+}
+
+func (m *mockBatchCallRPC) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return m.CallContext(ctx, result, method, args...)
 }
 
 func (m *mockBatchCallRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -190,6 +190,73 @@ type EthereumRPC struct {
 	multicall3ProbeSF singleflight.Group
 }
 
+type rpcIntentHeader struct {
+	hash       string
+	number     *big.Int
+	difficulty *big.Int
+}
+
+func (h *rpcIntentHeader) Hash() string {
+	return h.hash
+}
+
+func (h *rpcIntentHeader) Number() *big.Int {
+	return h.number
+}
+
+func (h *rpcIntentHeader) Difficulty() *big.Int {
+	return h.difficulty
+}
+
+func (b *EthereumRPC) callContextWithSyncIntent(ctx context.Context, intent bchain.SyncIntent, result interface{}, method string, args ...interface{}) error {
+	if intent == bchain.SyncIntentChainTip {
+		return b.RPC.CallContextWithIntent(ctx, bchain.EVMRPCIntentChainTip, result, method, args...)
+	}
+	return b.RPC.CallContext(ctx, result, method, args...)
+}
+
+func (b *EthereumRPC) headerByNumberWithSyncIntent(ctx context.Context, intent bchain.SyncIntent, number *big.Int) (bchain.EVMHeader, error) {
+	if intent != bchain.SyncIntentChainTip {
+		return b.Client.HeaderByNumber(ctx, number)
+	}
+	var head rpcHeader
+	err := b.callContextWithSyncIntent(ctx, intent, &head, "eth_getBlockByNumber", bchain.ToBlockNumArg(number), false)
+	if err != nil {
+		return nil, err
+	}
+	if head.Hash == "" || head.Number == "" {
+		return nil, ethereum.NotFound
+	}
+	n, err := hexutil.DecodeBig(head.Number)
+	if err != nil {
+		return nil, errors.Annotatef(err, "number %v", head.Number)
+	}
+	difficulty := big.NewInt(0)
+	if head.Difficulty != "" {
+		difficulty, err = hexutil.DecodeBig(head.Difficulty)
+		if err != nil {
+			return nil, errors.Annotatef(err, "difficulty %v", head.Difficulty)
+		}
+	}
+	return &rpcIntentHeader{
+		hash:       head.Hash,
+		number:     n,
+		difficulty: difficulty,
+	}, nil
+}
+
+type ethereumRPCSyncIntentView struct {
+	*EthereumRPC
+	intent bchain.SyncIntent
+}
+
+func (b *EthereumRPC) BlockChainForSyncIntent(intent bchain.SyncIntent) bchain.BlockChain {
+	if intent == bchain.SyncIntentChainTip {
+		return &ethereumRPCSyncIntentView{EthereumRPC: b, intent: intent}
+	}
+	return b
+}
+
 // NewEthereumRPC returns new EthRPC instance.
 func NewEthereumRPC(config json.RawMessage, pushHandler func(bchain.NotificationType)) (bchain.BlockChain, error) {
 	var err error
@@ -421,15 +488,17 @@ var OpenRPC = func(httpURL, wsURL string) (bchain.EVMRPCClient, bchain.EVMClient
 	if err != nil {
 		return nil, nil, err
 	}
-	subClient := callClient
+	callRPC := &EthereumRPCClient{Client: callClient}
+	subRPC := callRPC
 	if subURL != callURL {
-		subClient, err = dialRPC(subURL)
+		subClient, err := dialRPC(subURL)
 		if err != nil {
 			callClient.Close()
 			return nil, nil, err
 		}
+		subRPC = &EthereumRPCClient{Client: subClient}
 	}
-	rc := &DualRPCClient{CallClient: callClient, SubClient: subClient}
+	rc := &DualRPCClient{CallClient: callRPC, SubClient: subRPC}
 	ec := &EthereumClient{Client: ethclient.NewClient(callClient)}
 	return rc, ec, nil
 }
@@ -891,7 +960,7 @@ func (b *EthereumRPC) getBestHeader() (bchain.EVMHeader, error) {
 		var err error
 		ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		defer cancel()
-		b.bestHeader, err = b.Client.HeaderByNumber(ctx, nil)
+		b.bestHeader, err = b.headerByNumberWithSyncIntent(ctx, bchain.SyncIntentDefault, nil)
 		if err != nil {
 			b.bestHeader = nil
 			return nil, err
@@ -937,7 +1006,7 @@ func (b *EthereumRPC) refreshBestHeaderFromChain() (bool, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 	defer cancel()
-	h, err := b.Client.HeaderByNumber(ctx, nil)
+	h, err := b.headerByNumberWithSyncIntent(ctx, bchain.SyncIntentChainTip, nil)
 	if err != nil {
 		return false, err
 	}
@@ -986,13 +1055,56 @@ func (b *EthereumRPC) GetBestBlockHeight() (uint32, error) {
 	return uint32(h.Number().Uint64()), nil
 }
 
+func (b *EthereumRPC) getBestHeaderWithSyncIntent(intent bchain.SyncIntent) (bchain.EVMHeader, error) {
+	b.bestHeaderLock.Lock()
+	if b.bestHeader != nil && b.bestHeader.Number() != nil {
+		h := b.bestHeader
+		b.bestHeaderLock.Unlock()
+		return h, nil
+	}
+	b.bestHeaderLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+	defer cancel()
+	h, err := b.headerByNumberWithSyncIntent(ctx, intent, nil)
+	if err != nil {
+		return nil, err
+	}
+	b.setBestHeader(h)
+	return h, nil
+}
+
+func (v *ethereumRPCSyncIntentView) GetBestBlockHash() (string, error) {
+	h, err := v.EthereumRPC.getBestHeaderWithSyncIntent(v.intent)
+	if err != nil {
+		return "", err
+	}
+	return h.Hash(), nil
+}
+
+func (v *ethereumRPCSyncIntentView) GetBestBlockHeight() (uint32, error) {
+	h, err := v.EthereumRPC.getBestHeaderWithSyncIntent(v.intent)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(h.Number().Uint64()), nil
+}
+
 // GetBlockHash returns hash of block in best-block-chain at given height
 func (b *EthereumRPC) GetBlockHash(height uint32) (string, error) {
+	return b.getBlockHashWithSyncIntent(bchain.SyncIntentDefault, height)
+}
+
+func (v *ethereumRPCSyncIntentView) GetBlockHash(height uint32) (string, error) {
+	return v.EthereumRPC.getBlockHashWithSyncIntent(v.intent, height)
+}
+
+func (b *EthereumRPC) getBlockHashWithSyncIntent(intent bchain.SyncIntent, height uint32) (string, error) {
 	var n big.Int
 	n.SetUint64(uint64(height))
 	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 	defer cancel()
-	h, err := b.Client.HeaderByNumber(ctx, &n)
+	h, err := b.headerByNumberWithSyncIntent(ctx, intent, &n)
 	if err != nil {
 		if err == ethereum.NotFound || stdErrors.Is(err, bchain.ErrBlockNotFound) {
 			return "", bchain.ErrBlockNotFound
@@ -1053,18 +1165,25 @@ func (b *EthereumRPC) computeConfirmations(n uint64) (uint32, error) {
 }
 
 func (b *EthereumRPC) getBlockRaw(hash string, height uint32, fullTxs bool) (json.RawMessage, error) {
+	return b.getBlockRawWithSyncIntent(bchain.SyncIntentDefault, hash, height, fullTxs)
+}
+
+func (b *EthereumRPC) getBlockRawWithSyncIntent(intent bchain.SyncIntent, hash string, height uint32, fullTxs bool) (json.RawMessage, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 	defer cancel()
 	var raw json.RawMessage
 	var err error
+	if hash == "pending" {
+		intent = bchain.SyncIntentDefault
+	}
 	if hash != "" {
 		if hash == "pending" {
-			err = b.RPC.CallContext(ctx, &raw, "eth_getBlockByNumber", hash, fullTxs)
+			err = b.callContextWithSyncIntent(ctx, intent, &raw, "eth_getBlockByNumber", hash, fullTxs)
 		} else {
-			err = b.RPC.CallContext(ctx, &raw, "eth_getBlockByHash", ethcommon.HexToHash(hash), fullTxs)
+			err = b.callContextWithSyncIntent(ctx, intent, &raw, "eth_getBlockByHash", ethcommon.HexToHash(hash), fullTxs)
 		}
 	} else {
-		err = b.RPC.CallContext(ctx, &raw, "eth_getBlockByNumber", fmt.Sprintf("%#x", height), fullTxs)
+		err = b.callContextWithSyncIntent(ctx, intent, &raw, "eth_getBlockByNumber", fmt.Sprintf("%#x", height), fullTxs)
 	}
 	if err != nil {
 		return nil, errors.Annotatef(err, "hash %v, height %v", hash, height)
@@ -1080,11 +1199,15 @@ func (b *EthereumRPC) GetBlockRawByHashOrHeight(hash string, height uint32, full
 }
 
 func (b *EthereumRPC) processEventsForBlock(blockNumber string) (map[string][]*bchain.RpcLog, []bchain.AddressAliasRecord, error) {
+	return b.processEventsForBlockWithSyncIntent(bchain.SyncIntentDefault, blockNumber)
+}
+
+func (b *EthereumRPC) processEventsForBlockWithSyncIntent(intent bchain.SyncIntent, blockNumber string) (map[string][]*bchain.RpcLog, []bchain.AddressAliasRecord, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 	defer cancel()
 	var logs []rpcLogWithTxHash
 	var ensRecords []bchain.AddressAliasRecord
-	err := b.RPC.CallContext(ctx, &logs, "eth_getLogs", map[string]interface{}{
+	err := b.callContextWithSyncIntent(ctx, intent, &logs, "eth_getLogs", map[string]interface{}{
 		"fromBlock": blockNumber,
 		"toBlock":   blockNumber,
 	})
@@ -1257,7 +1380,15 @@ func (b *EthereumRPC) getInternalDataForBlock(ctx context.Context, blockHash str
 
 // GetBlock returns block with given hash or height, hash has precedence if both passed
 func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error) {
-	raw, err := b.getBlockRaw(hash, height, true)
+	return b.getBlockWithSyncIntent(bchain.SyncIntentDefault, hash, height)
+}
+
+func (v *ethereumRPCSyncIntentView) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	return v.EthereumRPC.getBlockWithSyncIntent(v.intent, hash, height)
+}
+
+func (b *EthereumRPC) getBlockWithSyncIntent(intent bchain.SyncIntent, hash string, height uint32) (*bchain.Block, error) {
+	raw, err := b.getBlockRawWithSyncIntent(intent, hash, height, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1290,7 +1421,7 @@ func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error
 	logsCh := make(chan logsResult, 1)         // Buffered so send won't block if we return early.
 	internalCh := make(chan internalResult, 1) // Buffered to avoid goroutine leak on early return.
 	go func() {
-		logs, ens, err := b.processEventsForBlock(head.Number)
+		logs, ens, err := b.processEventsForBlockWithSyncIntent(intent, head.Number)
 		logsCh <- logsResult{logs: logs, ens: ens, err: err} // Send result without shared state.
 	}()
 	go func() {

--- a/bchain/coins/eth/ethrpc_chain_tip_intent_test.go
+++ b/bchain/coins/eth/ethrpc_chain_tip_intent_test.go
@@ -1,0 +1,203 @@
+package eth
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+type recordingIntentRPC struct {
+	mu          sync.Mutex
+	normalCalls []string
+	intentCalls []string
+}
+
+func (r *recordingIntentRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
+	return nil, nil
+}
+
+func (r *recordingIntentRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	r.mu.Lock()
+	r.normalCalls = append(r.normalCalls, method)
+	r.mu.Unlock()
+	return setRecordingIntentRPCResult(result, method)
+}
+
+func (r *recordingIntentRPC) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	if intent == bchain.EVMRPCIntentChainTip {
+		r.mu.Lock()
+		r.intentCalls = append(r.intentCalls, method)
+		r.mu.Unlock()
+		return setRecordingIntentRPCResult(result, method)
+	}
+	return r.CallContext(ctx, result, method, args...)
+}
+
+func (r *recordingIntentRPC) Close() {}
+
+func setRecordingIntentRPCResult(result interface{}, method string) error {
+	switch v := result.(type) {
+	case *json.RawMessage:
+		*v = json.RawMessage(`{"hash":"0x1234","parentHash":"0x0123","difficulty":"0x0","number":"0x7b","timestamp":"0x1","size":"0x2","transactions":[]}`)
+	case *rpcHeader:
+		*v = rpcHeader{Hash: "0xws", ParentHash: "0x01", Number: "0x7b", Difficulty: "0x0", Time: "0x1", Size: "0x2"}
+	case *[]rpcLogWithTxHash:
+		*v = nil
+	case *[]rpcTraceResult:
+		*v = nil
+	default:
+		return nil
+	}
+	return nil
+}
+
+type stubIntentEVMClient struct {
+	headerCalls []string
+}
+
+func (s *stubIntentEVMClient) NetworkID(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(1), nil
+}
+
+func (s *stubIntentEVMClient) HeaderByNumber(ctx context.Context, number *big.Int) (bchain.EVMHeader, error) {
+	if number == nil {
+		s.headerCalls = append(s.headerCalls, "latest")
+	} else {
+		s.headerCalls = append(s.headerCalls, number.String())
+	}
+	return &rpcIntentHeader{
+		hash:       "0xhttp",
+		number:     big.NewInt(123),
+		difficulty: big.NewInt(0),
+	}, nil
+}
+
+func (s *stubIntentEVMClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(1), nil
+}
+
+func (s *stubIntentEVMClient) EstimateGas(ctx context.Context, msg interface{}) (uint64, error) {
+	return 0, nil
+}
+
+func (s *stubIntentEVMClient) BalanceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+func (s *stubIntentEVMClient) NonceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
+
+func newIntentTestEthereumRPC(rpc *recordingIntentRPC, client *stubIntentEVMClient) *EthereumRPC {
+	return &EthereumRPC{
+		Client:      client,
+		RPC:         rpc,
+		Timeout:     time.Second,
+		ChainConfig: &Configuration{},
+		bestHeader: &rpcIntentHeader{
+			hash:       "0xbest",
+			number:     big.NewInt(200),
+			difficulty: big.NewInt(0),
+		},
+	}
+}
+
+func TestDefaultEthereumBlockReadsStayOnHTTP(t *testing.T) {
+	rpc := &recordingIntentRPC{}
+	client := &stubIntentEVMClient{}
+	b := newIntentTestEthereumRPC(rpc, client)
+
+	if got, err := b.GetBlockHash(123); err != nil {
+		t.Fatalf("GetBlockHash() error = %v", err)
+	} else if got != "0xhttp" {
+		t.Fatalf("GetBlockHash() = %q, want 0xhttp", got)
+	}
+	if _, err := b.getBlockRaw("0x1234", 0, true); err != nil {
+		t.Fatalf("getBlockRaw() error = %v", err)
+	}
+	if _, _, err := b.processEventsForBlock("0x7b"); err != nil {
+		t.Fatalf("processEventsForBlock() error = %v", err)
+	}
+
+	if len(rpc.intentCalls) != 0 {
+		t.Fatalf("intentCalls = %v, want none", rpc.intentCalls)
+	}
+	if want := []string{"eth_getBlockByHash", "eth_getLogs"}; !reflect.DeepEqual(rpc.normalCalls, want) {
+		t.Fatalf("normalCalls = %v, want %v", rpc.normalCalls, want)
+	}
+	if want := []string{"123"}; !reflect.DeepEqual(client.headerCalls, want) {
+		t.Fatalf("headerCalls = %v, want %v", client.headerCalls, want)
+	}
+}
+
+func TestChainTipSyncViewRoutesTargetReadsToIntentClient(t *testing.T) {
+	rpc := &recordingIntentRPC{}
+	b := newIntentTestEthereumRPC(rpc, &stubIntentEVMClient{})
+	b.bestHeader = nil
+	view := b.BlockChainForSyncIntent(bchain.SyncIntentChainTip)
+
+	if got, err := view.GetBestBlockHash(); err != nil {
+		t.Fatalf("GetBestBlockHash() error = %v", err)
+	} else if got != "0xws" {
+		t.Fatalf("GetBestBlockHash() = %q, want 0xws", got)
+	}
+	if got, err := view.GetBlockHash(123); err != nil {
+		t.Fatalf("GetBlockHash() error = %v", err)
+	} else if got != "0xws" {
+		t.Fatalf("GetBlockHash() = %q, want 0xws", got)
+	}
+	if _, err := view.GetBlock("0x1234", 0); err != nil {
+		t.Fatalf("GetBlock() error = %v", err)
+	}
+
+	want := []string{"eth_getBlockByNumber", "eth_getBlockByNumber", "eth_getBlockByHash", "eth_getLogs"}
+	if !reflect.DeepEqual(rpc.intentCalls, want) {
+		t.Fatalf("intentCalls = %v, want %v", rpc.intentCalls, want)
+	}
+	if len(rpc.normalCalls) != 0 {
+		t.Fatalf("normalCalls = %v, want none", rpc.normalCalls)
+	}
+}
+
+func TestChainTipSyncIntentKeepsPendingBlockOnHTTP(t *testing.T) {
+	rpc := &recordingIntentRPC{}
+	b := newIntentTestEthereumRPC(rpc, &stubIntentEVMClient{})
+
+	if _, err := b.getBlockRawWithSyncIntent(bchain.SyncIntentChainTip, "pending", 0, false); err != nil {
+		t.Fatalf("getBlockRawWithSyncIntent(pending) error = %v", err)
+	}
+	if len(rpc.intentCalls) != 0 {
+		t.Fatalf("intentCalls = %v, want none", rpc.intentCalls)
+	}
+	if want := []string{"eth_getBlockByNumber"}; !reflect.DeepEqual(rpc.normalCalls, want) {
+		t.Fatalf("normalCalls = %v, want %v", rpc.normalCalls, want)
+	}
+}
+
+func TestChainTipSyncIntentKeepsInternalTraceOnHTTP(t *testing.T) {
+	rpc := &recordingIntentRPC{}
+	b := newIntentTestEthereumRPC(rpc, &stubIntentEVMClient{})
+	view := b.BlockChainForSyncIntent(bchain.SyncIntentChainTip)
+
+	processInternalTransactions := bchain.ProcessInternalTransactions
+	bchain.ProcessInternalTransactions = true
+	defer func() {
+		bchain.ProcessInternalTransactions = processInternalTransactions
+	}()
+
+	if _, err := view.GetBlock("0x1234", 0); err != nil {
+		t.Fatalf("GetBlock() error = %v", err)
+	}
+	if want := []string{"eth_getBlockByHash", "eth_getLogs"}; !reflect.DeepEqual(rpc.intentCalls, want) {
+		t.Fatalf("intentCalls = %v, want %v", rpc.intentCalls, want)
+	}
+	if want := []string{"debug_traceBlockByHash"}; !reflect.DeepEqual(rpc.normalCalls, want) {
+		t.Fatalf("normalCalls = %v, want %v", rpc.normalCalls, want)
+	}
+}

--- a/bchain/coins/eth/ethrpc_trace_test.go
+++ b/bchain/coins/eth/ethrpc_trace_test.go
@@ -27,6 +27,10 @@ func (m *mockTraceRPC) CallContext(ctx context.Context, result interface{}, meth
 	return nil
 }
 
+func (m *mockTraceRPC) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return m.CallContext(ctx, result, method, args...)
+}
+
 func (m *mockTraceRPC) Close() {}
 
 func TestNewEthereumRPCRejectsInvalidTraceTimeout(t *testing.T) {

--- a/bchain/coins/eth/evm.go
+++ b/bchain/coins/eth/evm.go
@@ -47,40 +47,8 @@ type EthereumRPCClient struct {
 	*rpc.Client
 }
 
-// DualRPCClient routes calls over HTTP and subscriptions over WebSocket.
-type DualRPCClient struct {
-	CallClient *rpc.Client
-	SubClient  *rpc.Client
-}
-
-// CallContext forwards JSON-RPC calls to the HTTP client.
-func (c *DualRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	return c.CallClient.CallContext(ctx, result, method, args...)
-}
-
-// BatchCallContext forwards batch JSON-RPC calls to the HTTP client.
-func (c *DualRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
-	return c.CallClient.BatchCallContext(ctx, batch)
-}
-
-// EthSubscribe forwards subscriptions to the WebSocket client.
-func (c *DualRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
-	sub, err := c.SubClient.EthSubscribe(ctx, channel, args...)
-	if err != nil {
-		return nil, err
-	}
-	return &EthereumClientSubscription{ClientSubscription: sub}, nil
-}
-
-// Close shuts down both underlying clients.
-func (c *DualRPCClient) Close() {
-	if c.SubClient != nil {
-		c.SubClient.Close()
-	}
-	if c.CallClient != nil && c.CallClient != c.SubClient {
-		c.CallClient.Close()
-	}
-}
+// DualRPCClient routes ordinary calls over HTTP and subscriptions/chain-tip calls over WebSocket.
+type DualRPCClient = bchain.DualEVMRPCClient
 
 // EthSubscribe subscribes to events and returns a client subscription that implements the EVMClientSubscription interface
 func (c *EthereumRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
@@ -90,6 +58,11 @@ func (c *EthereumRPCClient) EthSubscribe(ctx context.Context, channel interface{
 	}
 
 	return &EthereumClientSubscription{ClientSubscription: sub}, nil
+}
+
+// CallContextWithIntent performs a JSON-RPC call on this client.
+func (c *EthereumRPCClient) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return c.CallContext(ctx, result, method, args...)
 }
 
 // EthereumHeader wraps a block header to implement the EVMHeader interface

--- a/bchain/coins/eth/multicall_test.go
+++ b/bchain/coins/eth/multicall_test.go
@@ -338,6 +338,10 @@ func (m *mockMulticallRPC) CallContext(ctx context.Context, result interface{}, 
 	}
 }
 
+func (m *mockMulticallRPC) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return m.CallContext(ctx, result, method, args...)
+}
+
 func TestMulticallAggregate3EndToEnd(t *testing.T) {
 	expected := []bchain.EthereumMulticallResult{
 		{Success: true, Data: "0xdeadbeef"},

--- a/bchain/coins/optimism/evm.go
+++ b/bchain/coins/optimism/evm.go
@@ -39,6 +39,11 @@ func (c *OptimismRPCClient) CallContext(ctx context.Context, result interface{},
 	return nil
 }
 
+// CallContextWithIntent performs a JSON-RPC call on this client.
+func (c *OptimismRPCClient) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return c.CallContext(ctx, result, method, args...)
+}
+
 // BatchCallContext forwards batch JSON-RPC calls to the underlying client.
 func (c *OptimismRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
 	return c.Client.BatchCallContext(ctx, batch)

--- a/bchain/coins/tron/evm.go
+++ b/bchain/coins/tron/evm.go
@@ -245,6 +245,11 @@ func (c *TronRPCClient) CallContext(ctx context.Context, result interface{}, met
 	return json.Unmarshal(rawData, result)
 }
 
+// CallContextWithIntent performs a JSON-RPC call on this client.
+func (c *TronRPCClient) CallContextWithIntent(ctx context.Context, intent bchain.EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	return c.CallContext(ctx, result, method, args...)
+}
+
 // fixStateRoot works around Tron JSON-RPC returning stateRoot in a format incompatible with go-ethereum
 // Issue: Tron returns stateRoot as "0x" (empty) or with incorrect length, which causes go-ethereum
 // deserialization to fail since it expects a valid 32-byte hash (66 chars: "0x" + 64 hex digits)

--- a/bchain/coins/tron/tron_chain_tip_sync_test.go
+++ b/bchain/coins/tron/tron_chain_tip_sync_test.go
@@ -1,0 +1,19 @@
+package tron
+
+import (
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/eth"
+)
+
+func TestTronChainTipSyncIntentUsesTronPath(t *testing.T) {
+	b := &TronRPC{
+		EthereumRPC: &eth.EthereumRPC{},
+		ChainConfig: &TronConfiguration{},
+	}
+
+	if got := b.BlockChainForSyncIntent(bchain.SyncIntentChainTip); got != b {
+		t.Fatal("Tron chain-tip sync intent did not return the Tron chain")
+	}
+}

--- a/bchain/coins/tron/tronrpc.go
+++ b/bchain/coins/tron/tronrpc.go
@@ -205,6 +205,10 @@ var OpenRPC = func(url, _ string) (bchain.EVMRPCClient, bchain.EVMClient, error)
 	return rpcClient, tc, nil
 }
 
+func (b *TronRPC) BlockChainForSyncIntent(intent bchain.SyncIntent) bchain.BlockChain {
+	return b
+}
+
 // Initialize Tron RPC
 func (b *TronRPC) Initialize() error {
 	b.OpenRPC = OpenRPC

--- a/bchain/evm_interface.go
+++ b/bchain/evm_interface.go
@@ -23,7 +23,62 @@ type EVMClient interface {
 type EVMRPCClient interface {
 	EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (EVMClientSubscription, error)
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	CallContextWithIntent(ctx context.Context, intent EVMRPCIntent, result interface{}, method string, args ...interface{}) error
 	Close()
+}
+
+// EVMRPCIntent describes why a JSON-RPC call is being made, so routing can be
+// explicit without changing the public BlockChain methods.
+type EVMRPCIntent int
+
+const (
+	EVMRPCIntentDefault EVMRPCIntent = iota
+	EVMRPCIntentChainTip
+)
+
+// EVMBatchRPCClient provides batch JSON-RPC calls in addition to the base RPC client.
+type EVMBatchRPCClient interface {
+	EVMRPCClient
+	BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error
+}
+
+// DualEVMRPCClient routes ordinary calls over one RPC client and subscriptions/chain-tip calls over another.
+type DualEVMRPCClient struct {
+	CallClient EVMBatchRPCClient
+	SubClient  EVMRPCClient
+}
+
+// CallContext forwards JSON-RPC calls to the ordinary call client.
+func (c *DualEVMRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return c.CallClient.CallContext(ctx, result, method, args...)
+}
+
+// CallContextWithIntent forwards chain-tip JSON-RPC calls to the subscription client.
+func (c *DualEVMRPCClient) CallContextWithIntent(ctx context.Context, intent EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	if intent == EVMRPCIntentChainTip {
+		return c.SubClient.CallContextWithIntent(ctx, intent, result, method, args...)
+	}
+	return c.CallClient.CallContextWithIntent(ctx, intent, result, method, args...)
+}
+
+// BatchCallContext forwards batch JSON-RPC calls to the ordinary call client.
+func (c *DualEVMRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
+	return c.CallClient.BatchCallContext(ctx, batch)
+}
+
+// EthSubscribe forwards subscriptions to the subscription client.
+func (c *DualEVMRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (EVMClientSubscription, error) {
+	return c.SubClient.EthSubscribe(ctx, channel, args...)
+}
+
+// Close shuts down both underlying clients.
+func (c *DualEVMRPCClient) Close() {
+	if c.SubClient != nil {
+		c.SubClient.Close()
+	}
+	if c.CallClient != nil && c.CallClient != c.SubClient {
+		c.CallClient.Close()
+	}
 }
 
 // EVMHeader provides access to the necessary header data for evm chain sync

--- a/bchain/evm_interface_test.go
+++ b/bchain/evm_interface_test.go
@@ -1,0 +1,64 @@
+package bchain
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type recordingEVMBatchRPCClient struct {
+	calls []string
+}
+
+func (c *recordingEVMBatchRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (EVMClientSubscription, error) {
+	c.calls = append(c.calls, "subscribe")
+	return nil, nil
+}
+
+func (c *recordingEVMBatchRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	c.calls = append(c.calls, "call:"+method)
+	return nil
+}
+
+func (c *recordingEVMBatchRPCClient) CallContextWithIntent(ctx context.Context, intent EVMRPCIntent, result interface{}, method string, args ...interface{}) error {
+	c.calls = append(c.calls, "intent:"+method)
+	return nil
+}
+
+func (c *recordingEVMBatchRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
+	c.calls = append(c.calls, "batch")
+	return nil
+}
+
+func (c *recordingEVMBatchRPCClient) Close() {}
+
+func TestDualEVMRPCClientRoutesByIntent(t *testing.T) {
+	callClient := &recordingEVMBatchRPCClient{}
+	subClient := &recordingEVMBatchRPCClient{}
+	client := &DualEVMRPCClient{CallClient: callClient, SubClient: subClient}
+
+	if err := client.CallContext(context.Background(), nil, "eth_call"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.BatchCallContext(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CallContextWithIntent(context.Background(), EVMRPCIntentDefault, nil, "eth_blockNumber"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.EthSubscribe(context.Background(), nil, "newHeads"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CallContextWithIntent(context.Background(), EVMRPCIntentChainTip, nil, "eth_getBlockByHash"); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"call:eth_call", "batch", "intent:eth_blockNumber"}; !reflect.DeepEqual(callClient.calls, want) {
+		t.Fatalf("call client calls = %v, want %v", callClient.calls, want)
+	}
+	if want := []string{"subscribe", "intent:eth_getBlockByHash"}; !reflect.DeepEqual(subClient.calls, want) {
+		t.Fatalf("subscription client calls = %v, want %v", subClient.calls, want)
+	}
+}

--- a/bchain/types.go
+++ b/bchain/types.go
@@ -308,6 +308,29 @@ type MempoolBatcher interface {
 	GetRawTransactionsForMempoolBatch(txids []string) (map[string]*Tx, error)
 }
 
+// SyncIntent describes why the index sync is reading chain data.
+type SyncIntent int
+
+const (
+	SyncIntentDefault SyncIntent = iota
+	SyncIntentChainTip
+)
+
+// BlockChainSyncIntentProvider optionally returns a chain view specialized for a sync intent.
+type BlockChainSyncIntentProvider interface {
+	BlockChainForSyncIntent(intent SyncIntent) BlockChain
+}
+
+// BlockChainForSyncIntent returns an intent-specific chain view when the chain supports it.
+func BlockChainForSyncIntent(chain BlockChain, intent SyncIntent) BlockChain {
+	if provider, ok := chain.(BlockChainSyncIntentProvider); ok {
+		if intentChain := provider.BlockChainForSyncIntent(intent); intentChain != nil {
+			return intentChain
+		}
+	}
+	return chain
+}
+
 // BlockChain defines common interface to block chain daemon
 type BlockChain interface {
 	// life-cycle methods

--- a/blockbook.go
+++ b/blockbook.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -110,6 +111,7 @@ var (
 	callbacksOnNewTx              []bchain.OnNewTxFunc
 	callbacksOnNewFiatRatesTicker []fiat.OnNewFiatRatesTicker
 	chanOsSignal                  chan os.Signal
+	chainTipSyncIndexRequested    atomic.Bool
 )
 
 func init() {
@@ -544,16 +546,23 @@ func newInternalState(config *common.Config, d *db.RocksDB, enableSubNewTx bool)
 func syncIndexLoop() {
 	defer close(chanSyncIndexDone)
 	glog.Info("syncIndexLoop starting")
+	resync := func(intent bchain.SyncIntent) error {
+		return syncWorker.ResyncIndexWithIntent(onNewBlock, false, intent)
+	}
 	// resync index about every 15 minutes if there are no chanSyncIndex requests, with debounce 1 second
 	common.TickAndDebounce(time.Duration(*resyncIndexPeriodMs)*time.Millisecond, time.Duration(*resyncIndexDebounceMs)*time.Millisecond, chanSyncIndex, func() {
-		if err := syncWorker.ResyncIndex(onNewBlock, false); err != nil {
+		intent := bchain.SyncIntentDefault
+		if chainTipSyncIndexRequested.Swap(false) {
+			intent = bchain.SyncIntentChainTip
+		}
+		if err := resync(intent); err != nil {
 			if err == db.ErrOperationInterrupted || common.IsInShutdown() {
 				return
 			}
 			glog.Error("syncIndexLoop ", errors.ErrorStack(err), ", will retry...")
 			// retry once in case of random network error, after a slight delay
 			time.Sleep(time.Millisecond * 2500)
-			if err := syncWorker.ResyncIndex(onNewBlock, false); err != nil {
+			if err := resync(intent); err != nil {
 				if err == db.ErrOperationInterrupted || common.IsInShutdown() {
 					return
 				}
@@ -665,6 +674,7 @@ func pushSynchronizationHandler(nt bchain.NotificationType) {
 		return
 	}
 	if nt == bchain.NotificationNewBlock {
+		chainTipSyncIndexRequested.Store(true)
 		chanSyncIndex <- struct{}{}
 	} else if nt == bchain.NotificationNewTx {
 		chanSyncMempool <- struct{}{}

--- a/db/sync.go
+++ b/db/sync.go
@@ -126,10 +126,15 @@ func (w *SyncWorker) updateBackendInfo() {
 // ResyncIndex synchronizes index to the top of the blockchain
 // onNewBlock is called when new block is connected, but not in initial parallel sync
 func (w *SyncWorker) ResyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {
+	return w.ResyncIndexWithIntent(onNewBlock, initialSync, bchain.SyncIntentDefault)
+}
+
+// ResyncIndexWithIntent synchronizes index using a chain view selected for the sync intent.
+func (w *SyncWorker) ResyncIndexWithIntent(onNewBlock bchain.OnNewBlockFunc, initialSync bool, intent bchain.SyncIntent) error {
 	start := time.Now()
 	w.is.StartedSync()
 
-	err := w.resyncIndex(onNewBlock, initialSync)
+	err := w.resyncIndex(onNewBlock, initialSync, intent)
 
 	// update backend info after each resync
 	w.updateBackendInfo()
@@ -163,8 +168,19 @@ func (w *SyncWorker) ResyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 	return err
 }
 
-func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {
-	remoteBestHash, err := w.chain.GetBestBlockHash()
+func (w *SyncWorker) chainForSyncIntent(intent bchain.SyncIntent) bchain.BlockChain {
+	return bchain.BlockChainForSyncIntent(w.chain, intent)
+}
+
+func (w *SyncWorker) canUseParallelSync(intent bchain.SyncIntent, initialSync bool, chain bchain.BlockChain) bool {
+	return (intent != bchain.SyncIntentChainTip || chain == w.chain) &&
+		w.syncWorkers > 1 &&
+		(initialSync || chain.GetChainParser().GetChainType() == bchain.ChainEthereumType)
+}
+
+func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync bool, intent bchain.SyncIntent) error {
+	syncChain := w.chainForSyncIntent(intent)
+	remoteBestHash, err := syncChain.GetBestBlockHash()
 	if err != nil {
 		return err
 	}
@@ -178,7 +194,7 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 		return errSynced
 	}
 	if localBestHash != "" {
-		remoteHash, err := w.chain.GetBlockHash(localBestHeight)
+		remoteHash, err := syncChain.GetBlockHash(localBestHeight)
 		// for some coins (eth) remote can be at lower best height after rollback
 		if err != nil && !stdErrors.Is(err, bchain.ErrBlockNotFound) {
 			return err
@@ -194,7 +210,7 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 		// database is empty, start genesis
 		glog.Info("resync: genesis from block ", w.startHeight)
 	}
-	w.startHash, err = w.chain.GetBlockHash(w.startHeight)
+	w.startHash, err = syncChain.GetBlockHash(w.startHeight)
 	if err != nil {
 		return err
 	}
@@ -202,8 +218,8 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 	// use parallel routine to load majority of blocks
 	// use parallel sync only in case of initial sync because it puts the db to inconsistent state
 	// or in case of ChainEthereumType if the tip is farther
-	if w.syncWorkers > 1 && (initialSync || w.chain.GetChainParser().GetChainType() == bchain.ChainEthereumType) {
-		remoteBestHeight, err := w.chain.GetBestBlockHeight()
+	if w.canUseParallelSync(intent, initialSync, syncChain) {
+		remoteBestHeight, err := syncChain.GetBestBlockHeight()
 		if err != nil {
 			return err
 		}
@@ -220,16 +236,16 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 				if err != nil {
 					if stdErrors.Is(err, errResync) {
 						// block hash changed during parallel sync, restart the full resync
-						return w.resyncIndex(onNewBlock, initialSync)
+						return w.resyncIndex(onNewBlock, initialSync, bchain.SyncIntentDefault)
 					}
 					return err
 				}
 				// after parallel load finish the sync using standard way,
 				// new blocks may have been created in the meantime
-				return w.resyncIndex(onNewBlock, initialSync)
+				return w.resyncIndex(onNewBlock, initialSync, bchain.SyncIntentDefault)
 			}
 		}
-		if w.chain.GetChainParser().GetChainType() == bchain.ChainEthereumType {
+		if syncChain.GetChainParser().GetChainType() == bchain.ChainEthereumType {
 			syncWorkers := uint32(4)
 			if remoteBestHeight-w.startHeight >= syncWorkers {
 				glog.Infof("resync: parallel sync of blocks %d-%d, using %d workers", w.startHeight, remoteBestHeight, syncWorkers)
@@ -239,19 +255,19 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 				if err != nil {
 					if stdErrors.Is(err, errResync) {
 						// block hash changed during parallel sync, restart the full resync
-						return w.resyncIndex(onNewBlock, initialSync)
+						return w.resyncIndex(onNewBlock, initialSync, bchain.SyncIntentDefault)
 					}
 					return err
 				}
 				// after parallel load finish the sync using standard way,
 				// new blocks may have been created in the meantime
-				return w.resyncIndex(onNewBlock, initialSync)
+				return w.resyncIndex(onNewBlock, initialSync, bchain.SyncIntentDefault)
 			}
 		}
 	}
-	err = w.connectBlocks(onNewBlock, initialSync)
+	err = w.connectBlocks(syncChain, onNewBlock, initialSync)
 	if stdErrors.Is(err, errFork) || stdErrors.Is(err, errResync) {
-		return w.resyncIndex(onNewBlock, initialSync)
+		return w.resyncIndex(onNewBlock, initialSync, bchain.SyncIntentDefault)
 	}
 	return err
 }
@@ -281,15 +297,15 @@ func (w *SyncWorker) handleFork(localBestHeight uint32, localBestHash string, on
 	if err := w.DisconnectBlocks(height+1, localBestHeight, hashes); err != nil {
 		return err
 	}
-	return w.resyncIndex(onNewBlock, initialSync)
+	return w.resyncIndex(onNewBlock, initialSync, bchain.SyncIntentDefault)
 }
 
-func (w *SyncWorker) connectBlocks(onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {
+func (w *SyncWorker) connectBlocks(chain bchain.BlockChain, onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {
 	bch := make(chan blockResult, 8)
 	done := make(chan struct{})
 	defer close(done)
 
-	go w.getBlockChain(bch, done)
+	go w.getBlockChain(chain, bch, done)
 
 	var lastRes, empty blockResult
 
@@ -747,7 +763,7 @@ type blockResult struct {
 	err   error
 }
 
-func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
+func (w *SyncWorker) getBlockChain(chain bchain.BlockChain, out chan blockResult, done chan struct{}) {
 	defer close(out)
 
 	hash := w.startHash
@@ -760,7 +776,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			return
 		default:
 		}
-		block, err := w.chain.GetBlock(hash, height)
+		block, err := chain.GetBlock(hash, height)
 		if err != nil {
 			if stdErrors.Is(err, bchain.ErrBlockNotFound) {
 				break

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -4,8 +4,10 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	stdErrors "errors"
 	"io"
+	"math/big"
 	"net"
 	"net/url"
 	"syscall"
@@ -13,6 +15,7 @@ import (
 
 	jujuErrors "github.com/juju/errors"
 	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/eth"
 )
 
 func TestIsRetryableGetBlockError(t *testing.T) {
@@ -117,5 +120,137 @@ func TestIsRetryableGetBlockError(t *testing.T) {
 				t.Fatalf("isRetryableGetBlockError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+type syncIntentTestChain struct {
+	parser  bchain.BlockChainParser
+	tip     bchain.BlockChain
+	intents []bchain.SyncIntent
+}
+
+func (c *syncIntentTestChain) BlockChainForSyncIntent(intent bchain.SyncIntent) bchain.BlockChain {
+	c.intents = append(c.intents, intent)
+	if intent == bchain.SyncIntentChainTip && c.tip != nil {
+		return c.tip
+	}
+	return c
+}
+
+func (c *syncIntentTestChain) Initialize() error { return nil }
+func (c *syncIntentTestChain) CreateMempool(bchain.BlockChain) (bchain.Mempool, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) InitializeMempool(bchain.AddrDescForOutpointFunc, bchain.OnNewTxFunc) error {
+	return nil
+}
+func (c *syncIntentTestChain) Shutdown(ctx context.Context) error         { return nil }
+func (c *syncIntentTestChain) IsTestnet() bool                            { return false }
+func (c *syncIntentTestChain) GetNetworkName() string                     { return "" }
+func (c *syncIntentTestChain) GetSubversion() string                      { return "" }
+func (c *syncIntentTestChain) GetCoinName() string                        { return "" }
+func (c *syncIntentTestChain) GetChainInfo() (*bchain.ChainInfo, error)   { return nil, nil }
+func (c *syncIntentTestChain) GetBestBlockHash() (string, error)          { return "", nil }
+func (c *syncIntentTestChain) GetBestBlockHeight() (uint32, error)        { return 0, nil }
+func (c *syncIntentTestChain) GetBlockHash(height uint32) (string, error) { return "", nil }
+func (c *syncIntentTestChain) GetBlockHeader(hash string) (*bchain.BlockHeader, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetBlockInfo(hash string) (*bchain.BlockInfo, error) { return nil, nil }
+func (c *syncIntentTestChain) GetBlockRaw(hash string) (string, error)             { return "", nil }
+func (c *syncIntentTestChain) GetMempoolTransactions() ([]string, error)           { return nil, nil }
+func (c *syncIntentTestChain) GetTransaction(txid string) (*bchain.Tx, error)      { return nil, nil }
+func (c *syncIntentTestChain) GetTransactionForMempool(txid string) (*bchain.Tx, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetTransactionSpecific(tx *bchain.Tx) (json.RawMessage, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetAddressChainExtraData(addrDesc bchain.AddressDescriptor) (json.RawMessage, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) EstimateSmartFee(blocks int, conservative bool) (big.Int, error) {
+	return big.Int{}, nil
+}
+func (c *syncIntentTestChain) EstimateFee(blocks int) (big.Int, error)           { return big.Int{}, nil }
+func (c *syncIntentTestChain) LongTermFeeRate() (*bchain.LongTermFeeRate, error) { return nil, nil }
+func (c *syncIntentTestChain) SendRawTransaction(tx string, disableAlternativeRPC bool) (string, error) {
+	return "", nil
+}
+func (c *syncIntentTestChain) GetMempoolEntry(txid string) (*bchain.MempoolEntry, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetContractInfo(contractDesc bchain.AddressDescriptor) (*bchain.ContractInfo, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetChainParser() bchain.BlockChainParser { return c.parser }
+func (c *syncIntentTestChain) EthereumTypeGetBalance(addrDesc bchain.AddressDescriptor) (*big.Int, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetNonce(addrDesc bchain.AddressDescriptor) (uint64, error) {
+	return 0, nil
+}
+func (c *syncIntentTestChain) EthereumTypeEstimateGas(params map[string]interface{}) (uint64, error) {
+	return 0, nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetEip1559Fees() (*bchain.Eip1559Fees, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetErc20ContractBalance(addrDesc, contractDesc bchain.AddressDescriptor) (*big.Int, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetErc20ContractBalances(addrDesc bchain.AddressDescriptor, contractDescs []bchain.AddressDescriptor) ([]*big.Int, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetSupportedStakingPools() []string { return nil }
+func (c *syncIntentTestChain) EthereumTypeGetStakingPoolsData(addrDesc bchain.AddressDescriptor) ([]bchain.StakingPoolData, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) EthereumTypeRpcCall(data, to, from string) (string, error) {
+	return "", nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetRawTransaction(txid string) (string, error) {
+	return "", nil
+}
+func (c *syncIntentTestChain) EthereumTypeGetTransactionReceipt(txid string) (*bchain.RpcReceipt, error) {
+	return nil, nil
+}
+func (c *syncIntentTestChain) GetTokenURI(contractDesc bchain.AddressDescriptor, tokenID *big.Int) (string, error) {
+	return "", nil
+}
+
+func TestSyncWorkerChainForSyncIntent(t *testing.T) {
+	parser := eth.NewEthereumParser(1, false)
+	tip := &syncIntentTestChain{parser: parser}
+	base := &syncIntentTestChain{parser: parser, tip: tip}
+	w := &SyncWorker{chain: base}
+
+	if got := w.chainForSyncIntent(bchain.SyncIntentDefault); got != base {
+		t.Fatal("default sync intent did not use base chain")
+	}
+	if got := w.chainForSyncIntent(bchain.SyncIntentChainTip); got != tip {
+		t.Fatal("chain-tip sync intent did not use chain-tip view")
+	}
+	if len(base.intents) != 2 || base.intents[0] != bchain.SyncIntentDefault || base.intents[1] != bchain.SyncIntentChainTip {
+		t.Fatalf("intents = %v, want [default chain-tip]", base.intents)
+	}
+}
+
+func TestSyncWorkerChainTipIntentSkipsParallelSync(t *testing.T) {
+	chain := &syncIntentTestChain{parser: eth.NewEthereumParser(1, false)}
+	tip := &syncIntentTestChain{parser: eth.NewEthereumParser(1, false)}
+	w := &SyncWorker{chain: chain, syncWorkers: 4}
+
+	if !w.canUseParallelSync(bchain.SyncIntentDefault, false, chain) {
+		t.Fatal("default Ethereum sync should allow parallel sync")
+	}
+	if !w.canUseParallelSync(bchain.SyncIntentChainTip, false, chain) {
+		t.Fatal("chain-tip sync on the default chain should keep normal parallel behavior")
+	}
+	if w.canUseParallelSync(bchain.SyncIntentChainTip, false, tip) {
+		t.Fatal("chain-tip sync on a specialized chain view should stay sequential")
 	}
 }

--- a/db/test_helper.go
+++ b/db/test_helper.go
@@ -11,7 +11,7 @@ func SetBlockChain(w *SyncWorker, chain bchain.BlockChain) {
 }
 
 func ConnectBlocks(w *SyncWorker, onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {
-	return w.connectBlocks(onNewBlock, initialSync)
+	return w.connectBlocks(w.chain, onNewBlock, initialSync)
 }
 
 func HandleFork(w *SyncWorker, localBestHeight uint32, localBestHash string, onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,9 +40,12 @@ Good examples of coin configuration are
       `BB_PROD_RPC_URL_HTTP_<coin alias>` variable (for example,
       `BB_BUILD_ENV=dev BB_DEV_RPC_URL_HTTP_ethereum=http://backend_hostname:1234`), which is used as-is during
       template generation. `BB_BUILD_ENV` defaults to `dev`.
-    * `rpc_url_ws_template` – Template that defines URL of back-end WebSocket RPC service for subscriptions. You can
-      override it at build time by setting the selected `BB_DEV_RPC_URL_WS_<coin alias>` or
-      `BB_PROD_RPC_URL_WS_<coin alias>` variable and it should point to the same host as `rpc_url_template`.
+    * `rpc_url_ws_template` – Template that defines URL of back-end WebSocket RPC service for subscriptions. For
+      Ethereum-type chains, new-block-notification chain-tip reads (`eth_getBlockByNumber`, `eth_getBlockByHash`,
+      `eth_getLogs`) also use this WebSocket RPC connection; historical sync, bulk sync, API requests, traces,
+      contract calls, receipts, fee calls, and other non-tip RPC calls remain on `rpc_url_template`. You can override
+      it at build time by setting the selected `BB_DEV_RPC_URL_WS_<coin alias>` or `BB_PROD_RPC_URL_WS_<coin alias>`
+      variable and it should point to the same host as `rpc_url_template`.
     * `rpc_user` – User name of back-end RPC service, used by both Blockbook and back-end configuration templates.
     * `rpc_pass` – Password of back-end RPC service, used by both Blockbook and back-end configuration templates.
     * `rpc_timeout` – RPC timeout used by Blockbook.


### PR DESCRIPTION
Since quicknode is loadbalancing requests, we need to sync the chain-tip on a single WS connection that we use to receive the `newHeads` event, consequently all the following rpc calls :
```
  eth_getBlockByNumber("latest", false)
  eth_getBlockByNumber(height, false)
  eth_getBlockByHash(hash, true)
  eth_getLogs({ fromBlock: height, toBlock: height })
```
That are currently `https` would happen on that particular WS connection...

That would solve a very unpleasant situation when we receive `newHeads` about new block from Node A and fetching the block returns 404 because the following requests were received by Node B which is behind.

All the remaining rpc calls like should remain HTTP as they are now and therefore be loadbalanced by quicknode's LB : 
 - Historical sync / bulk sync / catch-up
 - Trezor Suite client WebSocket/Rest requests (there may be some subscriptions, but unrelated to syncing)