### PR TITLE
Split RPC traffic between HTTP pool and a WebSocket connection

### DIFF
--- a/bchain/coins/avalanche/avalancherpc.go
+++ b/bchain/coins/avalanche/avalancherpc.go
@@ -35,6 +35,11 @@ func dialRPC(rawURL string) (*rpc.Client, error) {
 }
 
 // OpenRPC opens RPC connections for Avalanche to separate HTTP and WS endpoints.
+// Mirrors eth.OpenRPC: when distinct URLs are configured, a separate WS
+// *rpc.Client is dialed and wrapped into both an AvalancheRPCClient (for
+// custom JSON-RPC dispatch) and an *ethclient.Client (for typed Avalanche
+// methods). When the same URL serves both, the WS-side fields alias the
+// HTTP-side so Close does not double-close.
 var OpenRPC = func(httpURL, wsURL string) (bchain.EVMRPCClient, bchain.EVMClient, error) {
 	callURL, subURL, err := eth.NormalizeRPCURLs(httpURL, wsURL)
 	if err != nil {
@@ -45,17 +50,28 @@ var OpenRPC = func(httpURL, wsURL string) (bchain.EVMRPCClient, bchain.EVMClient
 		return nil, nil, err
 	}
 	callRPC := &AvalancheRPCClient{Client: callClient}
+	httpEC := ethclient.NewClient(callClient)
+
 	subRPC := callRPC
+	wsEC := httpEC
 	if subURL != callURL {
 		subClient, err := dialRPC(subURL)
 		if err != nil {
 			callClient.Close()
+			httpEC.Close()
 			return nil, nil, err
 		}
 		subRPC = &AvalancheRPCClient{Client: subClient}
+		wsEC = ethclient.NewClient(subClient)
 	}
+
 	rc := &AvalancheDualRPCClient{CallClient: callRPC, SubClient: subRPC}
-	c := &AvalancheClient{Client: ethclient.NewClient(callClient), AvalancheRPCClient: callRPC}
+	c := &AvalancheClient{
+		httpEC:  httpEC,
+		wsEC:    wsEC,
+		httpRPC: callRPC,
+		wsRPC:   subRPC,
+	}
 	return rc, c, nil
 }
 

--- a/bchain/coins/avalanche/evm.go
+++ b/bchain/coins/avalanche/evm.go
@@ -10,18 +10,51 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/eth"
 )
 
-// AvalancheClient wraps a client to implement the EVMClient interface
+// AvalancheClient wraps both an HTTP-backed and a WebSocket-backed pair of
+// inner clients (mirroring eth.EthereumClient). Methods dispatch based on
+// eth.IsSyncRoute(ctx): tagged calls go to the WS-side clients, untagged
+// calls go to the HTTP-side. When the same underlying *rpc.Client serves
+// both, the WS fields are aliased to the HTTP fields.
 type AvalancheClient struct {
-	*ethclient.Client
-	*AvalancheRPCClient
+	httpEC  *ethclient.Client
+	wsEC    *ethclient.Client
+	httpRPC *AvalancheRPCClient
+	wsRPC   *AvalancheRPCClient
+}
+
+func (c *AvalancheClient) pickEC(ctx context.Context) *ethclient.Client {
+	if eth.IsSyncRoute(ctx) && c.wsEC != nil {
+		return c.wsEC
+	}
+	return c.httpEC
+}
+
+func (c *AvalancheClient) pickRPC(ctx context.Context) *AvalancheRPCClient {
+	if eth.IsSyncRoute(ctx) && c.wsRPC != nil {
+		return c.wsRPC
+	}
+	return c.httpRPC
+}
+
+// Close shuts down both inner ethclient.Clients. Aliased clients are closed
+// only once. The AvalancheRPCClient pair is owned by AvalancheDualRPCClient,
+// which closes them itself.
+func (c *AvalancheClient) Close() {
+	if c.httpEC != nil {
+		c.httpEC.Close()
+	}
+	if c.wsEC != nil && c.wsEC != c.httpEC {
+		c.wsEC.Close()
+	}
 }
 
 // HeaderByNumber returns a block header that implements the EVMHeader interface
 func (c *AvalancheClient) HeaderByNumber(ctx context.Context, number *big.Int) (bchain.EVMHeader, error) {
 	var head *Header
-	err := c.AvalancheRPCClient.CallContext(ctx, &head, "eth_getBlockByNumber", bchain.ToBlockNumArg(number), false)
+	err := c.pickRPC(ctx).CallContext(ctx, &head, "eth_getBlockByNumber", bchain.ToBlockNumArg(number), false)
 	if err == nil && head == nil {
 		err = ethereum.NotFound
 	}
@@ -30,17 +63,27 @@ func (c *AvalancheClient) HeaderByNumber(ctx context.Context, number *big.Int) (
 
 // EstimateGas returns the current estimated gas cost for executing a transaction
 func (c *AvalancheClient) EstimateGas(ctx context.Context, msg interface{}) (uint64, error) {
-	return c.Client.EstimateGas(ctx, msg.(ethereum.CallMsg))
+	return c.pickEC(ctx).EstimateGas(ctx, msg.(ethereum.CallMsg))
 }
 
 // BalanceAt returns the balance for the given account at a specific block, or latest known block if no block number is provided
 func (c *AvalancheClient) BalanceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (*big.Int, error) {
-	return c.Client.BalanceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
+	return c.pickEC(ctx).BalanceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
 }
 
 // NonceAt returns the nonce for the given account at a specific block, or latest known block if no block number is provided
 func (c *AvalancheClient) NonceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (uint64, error) {
-	return c.Client.NonceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
+	return c.pickEC(ctx).NonceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
+}
+
+// NetworkID returns the chain id reported by the backend.
+func (c *AvalancheClient) NetworkID(ctx context.Context) (*big.Int, error) {
+	return c.pickEC(ctx).NetworkID(ctx)
+}
+
+// SuggestGasPrice asks the backend for a gas-price suggestion.
+func (c *AvalancheClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return c.pickEC(ctx).SuggestGasPrice(ctx)
 }
 
 // AvalancheRPCClient wraps an rpc client to implement the EVMRPCClient interface
@@ -49,13 +92,24 @@ type AvalancheRPCClient struct {
 }
 
 // AvalancheDualRPCClient routes calls and subscriptions to separate RPC clients.
+// CallContext routes by eth.IsSyncRoute(ctx): tagged calls go over WS to keep
+// chain-tip RPC traffic sticky to the announcer node; untagged calls go over
+// HTTP so bulk/parallel sync and public API traffic can fan out across the
+// LB pool. BatchCallContext stays on HTTP unconditionally. EthSubscribe
+// always uses WS.
 type AvalancheDualRPCClient struct {
 	CallClient *AvalancheRPCClient
 	SubClient  *AvalancheRPCClient
 }
 
-// CallContext forwards JSON-RPC calls to the HTTP client with Avalanche-specific handling.
+// CallContext routes the JSON-RPC call to SubClient when ctx carries the
+// sync-route tag, otherwise to CallClient. Avalanche-specific error
+// translation is performed inside AvalancheRPCClient.CallContext on whichever
+// side handles the call.
 func (c *AvalancheDualRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	if eth.IsSyncRoute(ctx) && c.SubClient != nil {
+		return c.SubClient.CallContext(ctx, result, method, args...)
+	}
 	return c.CallClient.CallContext(ctx, result, method, args...)
 }
 

--- a/bchain/coins/avalanche/sync_route_test.go
+++ b/bchain/coins/avalanche/sync_route_test.go
@@ -1,0 +1,178 @@
+package avalanche
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/trezor/blockbook/bchain/coins/eth"
+)
+
+// jsonrpcServer counts incoming JSON-RPC requests and returns a fixed result.
+// Mirrors the helper in eth/sync_route_test.go.
+type jsonrpcServer struct {
+	calls atomic.Int64
+}
+
+func (s *jsonrpcServer) handler(t *testing.T) http.HandlerFunc {
+	type rpcReq struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		s.calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Handle both single calls and batch (array) calls.
+		if len(body) > 0 && body[0] == '[' {
+			var reqs []rpcReq
+			if err := json.Unmarshal(body, &reqs); err != nil {
+				t.Fatalf("parse batch body: %v", err)
+			}
+			out := "["
+			for i, req := range reqs {
+				if i > 0 {
+					out += ","
+				}
+				out += `{"jsonrpc":"2.0","id":` + string(req.ID) + `,"result":"0x1"}`
+			}
+			out += "]"
+			_, _ = w.Write([]byte(out))
+			return
+		}
+		var req rpcReq
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("parse body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + string(req.ID) + `,"result":"0x1"}`))
+	}
+}
+
+func TestAvalancheClientPickEC(t *testing.T) {
+	httpEC := &ethclient.Client{}
+	wsEC := &ethclient.Client{}
+	c := &AvalancheClient{httpEC: httpEC, wsEC: wsEC}
+
+	if got := c.pickEC(context.Background()); got != httpEC {
+		t.Fatal("plain ctx must dispatch to httpEC")
+	}
+	if got := c.pickEC(eth.WithSyncRoute(context.Background())); got != wsEC {
+		t.Fatal("sync-route ctx must dispatch to wsEC")
+	}
+
+	// Aliased clients (single underlying rpc.Client serving both) must always
+	// dispatch to httpEC regardless of ctx tag.
+	c2 := &AvalancheClient{httpEC: httpEC, wsEC: httpEC}
+	if got := c2.pickEC(eth.WithSyncRoute(context.Background())); got != httpEC {
+		t.Fatal("aliased ECs must dispatch to httpEC regardless of ctx tag")
+	}
+}
+
+func TestAvalancheClientPickRPC(t *testing.T) {
+	httpRPC := &AvalancheRPCClient{}
+	wsRPC := &AvalancheRPCClient{}
+	c := &AvalancheClient{httpRPC: httpRPC, wsRPC: wsRPC}
+
+	if got := c.pickRPC(context.Background()); got != httpRPC {
+		t.Fatal("plain ctx must dispatch to httpRPC")
+	}
+	if got := c.pickRPC(eth.WithSyncRoute(context.Background())); got != wsRPC {
+		t.Fatal("sync-route ctx must dispatch to wsRPC")
+	}
+}
+
+func TestAvalancheDualRPCClientCallContextRouting(t *testing.T) {
+	httpSrv := &jsonrpcServer{}
+	wsSrv := &jsonrpcServer{}
+	httpHTTP := httptest.NewServer(httpSrv.handler(t))
+	defer httpHTTP.Close()
+	wsHTTP := httptest.NewServer(wsSrv.handler(t))
+	defer wsHTTP.Close()
+
+	// Both endpoints are HTTP for the purposes of this routing test — what
+	// matters is that AvalancheDualRPCClient picks SubClient when ctx carries
+	// the sync-route tag.
+	callClient, err := rpc.Dial(httpHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial http: %v", err)
+	}
+	defer callClient.Close()
+	subClient, err := rpc.Dial(wsHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer subClient.Close()
+
+	dual := &AvalancheDualRPCClient{
+		CallClient: &AvalancheRPCClient{Client: callClient},
+		SubClient:  &AvalancheRPCClient{Client: subClient},
+	}
+
+	var result string
+	if err := dual.CallContext(context.Background(), &result, "eth_blockNumber"); err != nil {
+		t.Fatalf("plain ctx call failed: %v", err)
+	}
+	if got, want := httpSrv.calls.Load(), int64(1); got != want {
+		t.Fatalf("plain ctx must hit CallClient: httpCalls=%d, want %d", got, want)
+	}
+	if got := wsSrv.calls.Load(); got != 0 {
+		t.Fatalf("plain ctx must not hit SubClient: wsCalls=%d, want 0", got)
+	}
+
+	if err := dual.CallContext(eth.WithSyncRoute(context.Background()), &result, "eth_blockNumber"); err != nil {
+		t.Fatalf("sync-route ctx call failed: %v", err)
+	}
+	if got := httpSrv.calls.Load(); got != 1 {
+		t.Fatalf("sync-route ctx must not hit CallClient: httpCalls=%d, want 1", got)
+	}
+	if got, want := wsSrv.calls.Load(), int64(1); got != want {
+		t.Fatalf("sync-route ctx must hit SubClient: wsCalls=%d, want %d", got, want)
+	}
+}
+
+func TestAvalancheDualRPCClientBatchAlwaysHTTP(t *testing.T) {
+	httpSrv := &jsonrpcServer{}
+	wsSrv := &jsonrpcServer{}
+	httpHTTP := httptest.NewServer(httpSrv.handler(t))
+	defer httpHTTP.Close()
+	wsHTTP := httptest.NewServer(wsSrv.handler(t))
+	defer wsHTTP.Close()
+
+	callClient, err := rpc.Dial(httpHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial http: %v", err)
+	}
+	defer callClient.Close()
+	subClient, err := rpc.Dial(wsHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer subClient.Close()
+
+	dual := &AvalancheDualRPCClient{
+		CallClient: &AvalancheRPCClient{Client: callClient},
+		SubClient:  &AvalancheRPCClient{Client: subClient},
+	}
+
+	// BatchCallContext must always hit CallClient regardless of ctx tag —
+	// matches the eth/DualRPCClient batching contract.
+	batch := []rpc.BatchElem{{Method: "eth_blockNumber", Result: new(string)}}
+	if err := dual.BatchCallContext(eth.WithSyncRoute(context.Background()), batch); err != nil {
+		t.Fatalf("batch call failed: %v", err)
+	}
+	if got, want := httpSrv.calls.Load(), int64(1); got != want {
+		t.Fatalf("batch must hit CallClient: httpCalls=%d, want %d", got, want)
+	}
+	if got := wsSrv.calls.Load(); got != 0 {
+		t.Fatalf("batch must not hit SubClient: wsCalls=%d, want 0", got)
+	}
+}

--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -421,6 +421,21 @@ func (c *blockChainWithMetrics) EthereumTypeGetTransactionReceipt(txid string) (
 	return c.b.EthereumTypeGetTransactionReceipt(txid)
 }
 
+// SyncBlockChain forwards the optional bchain.SyncableBlockChain capability
+// from the underlying chain. Without this, the type assertion in
+// blockbook.go's main wiring fails on the wrapper and the SyncWorker's
+// tipChain silently collapses to the HTTP-routed chain - i.e. the WS routing
+// for tip-sync would be inert in production. The returned view is wrapped in
+// blockChainWithMetrics too so RPC latency on tip-sync calls is still
+// observed.
+func (c *blockChainWithMetrics) SyncBlockChain() bchain.BlockChain {
+	s, ok := c.b.(bchain.SyncableBlockChain)
+	if !ok {
+		return c
+	}
+	return &blockChainWithMetrics{b: s.SyncBlockChain(), m: c.m}
+}
+
 type mempoolWithMetrics struct {
 	mempool bchain.Mempool
 	m       *common.Metrics

--- a/bchain/coins/blockchain_test.go
+++ b/bchain/coins/blockchain_test.go
@@ -1,0 +1,88 @@
+package coins
+
+import (
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/common"
+)
+
+// stubChain is a minimal bchain.BlockChain that records whether the wrapper
+// asked the underlying chain for its sync view. It panics on any method
+// that the test does not exercise so accidental fan-out is caught.
+type stubChain struct {
+	bchain.BlockChain // nil — unmocked methods panic
+	syncView          bchain.BlockChain
+	syncCalled        bool
+}
+
+func (c *stubChain) SyncBlockChain() bchain.BlockChain {
+	c.syncCalled = true
+	return c.syncView
+}
+
+// stubSyncView is a distinct BlockChain instance returned by
+// stubChain.SyncBlockChain so the test can verify routing by identity.
+type stubSyncView struct {
+	bchain.BlockChain
+}
+
+// TestBlockChainWithMetricsForwardsSyncBlockChain pins the production-routing
+// fix: blockChainWithMetrics must forward SyncBlockChain() so blockbook.go's
+// `chain.(bchain.SyncableBlockChain)` assertion succeeds and the SyncWorker
+// receives the WS-routed view instead of silently collapsing to the
+// HTTP-routed wrapper.
+func TestBlockChainWithMetricsForwardsSyncBlockChain(t *testing.T) {
+	m, err := common.GetMetrics("blockchain_with_metrics_sync_forward_test")
+	if err != nil {
+		t.Fatalf("GetMetrics: %v", err)
+	}
+	view := &stubSyncView{}
+	inner := &stubChain{syncView: view}
+
+	wrapped := &blockChainWithMetrics{b: inner, m: m}
+
+	syncable, ok := bchain.BlockChain(wrapped).(bchain.SyncableBlockChain)
+	if !ok {
+		t.Fatalf("wrapper does not satisfy bchain.SyncableBlockChain — production tipChain wiring would fall back to HTTP")
+	}
+	got := syncable.SyncBlockChain()
+	if !inner.syncCalled {
+		t.Fatalf("wrapper did not delegate SyncBlockChain to underlying chain")
+	}
+	gotWrapped, ok := got.(*blockChainWithMetrics)
+	if !ok {
+		t.Fatalf("wrapper.SyncBlockChain returned %T, want *blockChainWithMetrics so metrics still observe tip-sync RPC latency", got)
+	}
+	if gotWrapped.b != bchain.BlockChain(view) {
+		t.Fatalf("wrapper.SyncBlockChain wrapped %T, want the inner sync view", gotWrapped.b)
+	}
+	if gotWrapped.m != m {
+		t.Fatalf("wrapper.SyncBlockChain dropped the metrics reference")
+	}
+}
+
+// chainWithoutSyncView is a bchain.BlockChain that does NOT implement
+// SyncableBlockChain (the non-EVM coin case).
+type chainWithoutSyncView struct {
+	bchain.BlockChain
+}
+
+// TestBlockChainWithMetricsSyncBlockChainPassthrough verifies the wrapper
+// returns itself when the underlying chain is not Syncable, so callers using
+// the optional interface get a stable BlockChain instead of nil.
+func TestBlockChainWithMetricsSyncBlockChainPassthrough(t *testing.T) {
+	m, err := common.GetMetrics("blockchain_with_metrics_sync_passthrough_test")
+	if err != nil {
+		t.Fatalf("GetMetrics: %v", err)
+	}
+	wrapped := &blockChainWithMetrics{b: &chainWithoutSyncView{}, m: m}
+
+	syncable, ok := bchain.BlockChain(wrapped).(bchain.SyncableBlockChain)
+	if !ok {
+		t.Fatalf("wrapper must always satisfy SyncableBlockChain (returns self when underlying does not)")
+	}
+	if got := syncable.SyncBlockChain(); got != bchain.BlockChain(wrapped) {
+		t.Fatalf("wrapper.SyncBlockChain = %p, want self %p when underlying chain is not Syncable", got, wrapped)
+	}
+}

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -430,7 +430,12 @@ var OpenRPC = func(httpURL, wsURL string) (bchain.EVMRPCClient, bchain.EVMClient
 		}
 	}
 	rc := &DualRPCClient{CallClient: callClient, SubClient: subClient}
-	ec := &EthereumClient{Client: ethclient.NewClient(callClient)}
+	httpEC := ethclient.NewClient(callClient)
+	wsEC := httpEC
+	if subClient != callClient {
+		wsEC = ethclient.NewClient(subClient)
+	}
+	ec := &EthereumClient{httpClient: httpEC, wsClient: wsEC}
 	return rc, ec, nil
 }
 
@@ -876,6 +881,13 @@ func (b *EthereumRPC) GetChainInfo() (*bchain.ChainInfo, error) {
 }
 
 func (b *EthereumRPC) getBestHeader() (bchain.EVMHeader, error) {
+	return b.getBestHeaderWithCtx(context.Background())
+}
+
+// getBestHeaderWithCtx is the ctx-aware variant of getBestHeader. If parent
+// carries the sync-route tag (set by the sync facade or refreshBestHeaderFromChain),
+// the underlying HeaderByNumber call is dispatched to the WS-backed ethclient.
+func (b *EthereumRPC) getBestHeaderWithCtx(parent context.Context) (bchain.EVMHeader, error) {
 	b.bestHeaderLock.Lock()
 	defer b.bestHeaderLock.Unlock()
 	// if the best header was not updated for 15 minutes, there could be a subscription problem, reconnect RPC
@@ -889,7 +901,7 @@ func (b *EthereumRPC) getBestHeader() (bchain.EVMHeader, error) {
 	}
 	if b.bestHeader == nil {
 		var err error
-		ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+		ctx, cancel := context.WithTimeout(parent, b.Timeout)
 		defer cancel()
 		b.bestHeader, err = b.Client.HeaderByNumber(ctx, nil)
 		if err != nil {
@@ -935,7 +947,10 @@ func (b *EthereumRPC) refreshBestHeaderFromChain() (bool, error) {
 	if b.Client == nil {
 		return false, errors.New("rpc client not initialized")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+	// The fetch races the load balancer that just delivered newHeads from a
+	// specific backend; tag the ctx so the call rides the WS connection (which
+	// is pinned to that backend) and observes the same canonical tip.
+	ctx, cancel := context.WithTimeout(WithSyncRoute(context.Background()), b.Timeout)
 	defer cancel()
 	h, err := b.Client.HeaderByNumber(ctx, nil)
 	if err != nil {
@@ -970,7 +985,11 @@ func (b *EthereumRPC) setBestHeader(h bchain.EVMHeader) bool {
 
 // GetBestBlockHash returns hash of the tip of the best-block-chain
 func (b *EthereumRPC) GetBestBlockHash() (string, error) {
-	h, err := b.getBestHeader()
+	return b.getBestBlockHashWithCtx(context.Background())
+}
+
+func (b *EthereumRPC) getBestBlockHashWithCtx(parent context.Context) (string, error) {
+	h, err := b.getBestHeaderWithCtx(parent)
 	if err != nil {
 		return "", err
 	}
@@ -979,7 +998,11 @@ func (b *EthereumRPC) GetBestBlockHash() (string, error) {
 
 // GetBestBlockHeight returns height of the tip of the best-block-chain
 func (b *EthereumRPC) GetBestBlockHeight() (uint32, error) {
-	h, err := b.getBestHeader()
+	return b.getBestBlockHeightWithCtx(context.Background())
+}
+
+func (b *EthereumRPC) getBestBlockHeightWithCtx(parent context.Context) (uint32, error) {
+	h, err := b.getBestHeaderWithCtx(parent)
 	if err != nil {
 		return 0, err
 	}
@@ -988,9 +1011,13 @@ func (b *EthereumRPC) GetBestBlockHeight() (uint32, error) {
 
 // GetBlockHash returns hash of block in best-block-chain at given height
 func (b *EthereumRPC) GetBlockHash(height uint32) (string, error) {
+	return b.getBlockHashWithCtx(context.Background(), height)
+}
+
+func (b *EthereumRPC) getBlockHashWithCtx(parent context.Context, height uint32) (string, error) {
 	var n big.Int
 	n.SetUint64(uint64(height))
-	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+	ctx, cancel := context.WithTimeout(parent, b.Timeout)
 	defer cancel()
 	h, err := b.Client.HeaderByNumber(ctx, &n)
 	if err != nil {
@@ -1053,7 +1080,14 @@ func (b *EthereumRPC) computeConfirmations(n uint64) (uint32, error) {
 }
 
 func (b *EthereumRPC) getBlockRaw(hash string, height uint32, fullTxs bool) (json.RawMessage, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+	return b.getBlockRawWithCtx(context.Background(), hash, height, fullTxs)
+}
+
+// getBlockRawWithCtx is the ctx-aware variant. The caller-supplied parent ctx
+// determines whether the underlying eth_getBlockBy* call rides WS (sync facade)
+// or HTTP (default).
+func (b *EthereumRPC) getBlockRawWithCtx(parent context.Context, hash string, height uint32, fullTxs bool) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(parent, b.Timeout)
 	defer cancel()
 	var raw json.RawMessage
 	var err error
@@ -1079,8 +1113,8 @@ func (b *EthereumRPC) GetBlockRawByHashOrHeight(hash string, height uint32, full
 	return b.getBlockRaw(hash, height, fullTxs)
 }
 
-func (b *EthereumRPC) processEventsForBlock(blockNumber string) (map[string][]*bchain.RpcLog, []bchain.AddressAliasRecord, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+func (b *EthereumRPC) processEventsForBlock(parent context.Context, blockNumber string) (map[string][]*bchain.RpcLog, []bchain.AddressAliasRecord, error) {
+	ctx, cancel := context.WithTimeout(parent, b.Timeout)
 	defer cancel()
 	var logs []rpcLogWithTxHash
 	var ensRecords []bchain.AddressAliasRecord
@@ -1257,7 +1291,15 @@ func (b *EthereumRPC) getInternalDataForBlock(ctx context.Context, blockHash str
 
 // GetBlock returns block with given hash or height, hash has precedence if both passed
 func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error) {
-	raw, err := b.getBlockRaw(hash, height, true)
+	return b.getBlockWithCtx(context.Background(), hash, height)
+}
+
+// getBlockWithCtx is the ctx-aware variant of GetBlock. The caller-supplied
+// parent ctx propagates into getBlockRawWithCtx, processEventsForBlock and
+// getInternalDataForBlock, so a sync-route tag set by ethSyncView reaches every
+// underlying RPC (eth_getBlockBy*, eth_getLogs, debug_traceBlockByHash).
+func (b *EthereumRPC) getBlockWithCtx(parent context.Context, hash string, height uint32) (*bchain.Block, error) {
+	raw, err := b.getBlockRawWithCtx(parent, hash, height, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1275,9 +1317,9 @@ func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error
 		return nil, errors.Annotatef(err, "hash %v, height %v", hash, height)
 	}
 	// Run event/log processing and internal data extraction in parallel; allow early return on log failure.
-	ctxInternal, cancelInternal := context.WithTimeout(context.Background(), b.Timeout) // Cancel trace RPC on log error or timeout.
-	defer cancelInternal()                                                              // Ensure timer resources are released on any return path.
-	type logsResult struct {                                                            // Bundles processEventsForBlock outputs for channel return.
+	ctxInternal, cancelInternal := context.WithTimeout(parent, b.Timeout) // Cancel trace RPC on log error or timeout.
+	defer cancelInternal()                                                // Ensure timer resources are released on any return path.
+	type logsResult struct {                                              // Bundles processEventsForBlock outputs for channel return.
 		logs map[string][]*bchain.RpcLog
 		ens  []bchain.AddressAliasRecord
 		err  error
@@ -1290,7 +1332,7 @@ func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error
 	logsCh := make(chan logsResult, 1)         // Buffered so send won't block if we return early.
 	internalCh := make(chan internalResult, 1) // Buffered to avoid goroutine leak on early return.
 	go func() {
-		logs, ens, err := b.processEventsForBlock(head.Number)
+		logs, ens, err := b.processEventsForBlock(parent, head.Number)
 		logsCh <- logsResult{logs: logs, ens: ens, err: err} // Send result without shared state.
 	}()
 	go func() {

--- a/bchain/coins/eth/evm.go
+++ b/bchain/coins/eth/evm.go
@@ -12,14 +12,47 @@ import (
 	"github.com/trezor/blockbook/bchain"
 )
 
-// EthereumClient wraps a client to implement the EVMClient interface
+// stickyKey is the unexported context-value key used to mark calls that must
+// follow the WebSocket connection (see WithSyncRoute / isSyncRoute). Marked
+// calls hit the WS-pinned backend; unmarked calls go via the HTTP pool.
+type stickyKey struct{}
+
+// WithSyncRoute returns a child context tagged so DualRPCClient.CallContext and
+// EthereumClient methods route the call over the WebSocket connection. Used by
+// the sync facade (ethSyncView) and by refreshBestHeaderFromChain to keep the
+// chain-tip block fetch sticky to the node that delivered newHeads.
+func WithSyncRoute(ctx context.Context) context.Context {
+	return context.WithValue(ctx, stickyKey{}, true)
+}
+
+// isSyncRoute reports whether ctx carries the sync-route tag set by WithSyncRoute.
+func isSyncRoute(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(stickyKey{}).(bool)
+	return v
+}
+
+// EthereumClient wraps both an HTTP-backed and a WebSocket-backed *ethclient.Client.
+// Each method dispatches based on isSyncRoute(ctx): tagged calls go to wsClient,
+// untagged calls go to httpClient. When the same underlying *rpc.Client serves
+// both, wsClient is aliased to httpClient.
 type EthereumClient struct {
-	*ethclient.Client
+	httpClient *ethclient.Client
+	wsClient   *ethclient.Client
+}
+
+func (c *EthereumClient) pick(ctx context.Context) *ethclient.Client {
+	if isSyncRoute(ctx) && c.wsClient != nil {
+		return c.wsClient
+	}
+	return c.httpClient
 }
 
 // HeaderByNumber returns a block header that implements the EVMHeader interface
 func (c *EthereumClient) HeaderByNumber(ctx context.Context, number *big.Int) (bchain.EVMHeader, error) {
-	h, err := c.Client.HeaderByNumber(ctx, number)
+	h, err := c.pick(ctx).HeaderByNumber(ctx, number)
 	if err != nil {
 		return nil, err
 	}
@@ -29,17 +62,27 @@ func (c *EthereumClient) HeaderByNumber(ctx context.Context, number *big.Int) (b
 
 // EstimateGas returns the current estimated gas cost for executing a transaction
 func (c *EthereumClient) EstimateGas(ctx context.Context, msg interface{}) (uint64, error) {
-	return c.Client.EstimateGas(ctx, msg.(ethereum.CallMsg))
+	return c.pick(ctx).EstimateGas(ctx, msg.(ethereum.CallMsg))
 }
 
 // BalanceAt returns the balance for the given account at a specific block, or latest known block if no block number is provided
 func (c *EthereumClient) BalanceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (*big.Int, error) {
-	return c.Client.BalanceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
+	return c.pick(ctx).BalanceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
 }
 
 // NonceAt returns the nonce for the given account at a specific block, or latest known block if no block number is provided
 func (c *EthereumClient) NonceAt(ctx context.Context, addrDesc bchain.AddressDescriptor, blockNumber *big.Int) (uint64, error) {
-	return c.Client.NonceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
+	return c.pick(ctx).NonceAt(ctx, common.BytesToAddress(addrDesc), blockNumber)
+}
+
+// NetworkID returns the chain id reported by the backend.
+func (c *EthereumClient) NetworkID(ctx context.Context) (*big.Int, error) {
+	return c.pick(ctx).NetworkID(ctx)
+}
+
+// SuggestGasPrice asks the backend for a gas-price suggestion.
+func (c *EthereumClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return c.pick(ctx).SuggestGasPrice(ctx)
 }
 
 // EthereumRPCClient wraps an rpc client to implement the EVMRPCClient interface
@@ -47,18 +90,29 @@ type EthereumRPCClient struct {
 	*rpc.Client
 }
 
-// DualRPCClient routes calls over HTTP and subscriptions over WebSocket.
+// DualRPCClient holds an HTTP-backed CallClient and a WebSocket-backed SubClient.
+// CallContext routes by isSyncRoute(ctx): tagged calls go over WS to keep
+// chain-tip RPC traffic sticky to the announcer node; untagged calls go over
+// HTTP so bulk/parallel sync and public API traffic can fan out across the LB
+// pool. BatchCallContext stays on HTTP unconditionally — batching is HTTP-shaped
+// in this codebase. EthSubscribe always uses WS.
 type DualRPCClient struct {
 	CallClient *rpc.Client
 	SubClient  *rpc.Client
 }
 
-// CallContext forwards JSON-RPC calls to the HTTP client.
+// CallContext routes the JSON-RPC call to SubClient when ctx carries the
+// sync-route tag, otherwise to CallClient.
 func (c *DualRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	if isSyncRoute(ctx) && c.SubClient != nil {
+		return c.SubClient.CallContext(ctx, result, method, args...)
+	}
 	return c.CallClient.CallContext(ctx, result, method, args...)
 }
 
-// BatchCallContext forwards batch JSON-RPC calls to the HTTP client.
+// BatchCallContext forwards batch JSON-RPC calls to the HTTP client. WS is not
+// used for batching: only the eth package's contract.go ERC-20 fan-out batches,
+// and that path is HTTP-only by convention.
 func (c *DualRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
 	return c.CallClient.BatchCallContext(ctx, batch)
 }

--- a/bchain/coins/eth/evm.go
+++ b/bchain/coins/eth/evm.go
@@ -34,6 +34,16 @@ func isSyncRoute(ctx context.Context) bool {
 	return v
 }
 
+// IsSyncRoute is the exported form of isSyncRoute, intended for forked EVM
+// coin packages (e.g. avalanche) that have their own DualRPCClient / Client
+// equivalents and need to dispatch on the same tag the eth package sets via
+// WithSyncRoute. Keeping the context key (stickyKey) unexported and routing
+// reads through this helper guarantees interop without exposing the key
+// itself.
+func IsSyncRoute(ctx context.Context) bool {
+	return isSyncRoute(ctx)
+}
+
 // EthereumClient wraps both an HTTP-backed and a WebSocket-backed *ethclient.Client.
 // Each method dispatches based on isSyncRoute(ctx): tagged calls go to wsClient,
 // untagged calls go to httpClient. When the same underlying *rpc.Client serves

--- a/bchain/coins/eth/sync_route_test.go
+++ b/bchain/coins/eth/sync_route_test.go
@@ -1,0 +1,225 @@
+package eth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/trezor/blockbook/bchain"
+)
+
+func TestSyncRouteCtxRoundTrip(t *testing.T) {
+	if isSyncRoute(context.Background()) {
+		t.Fatal("plain ctx must not carry the sync-route tag")
+	}
+	if !isSyncRoute(WithSyncRoute(context.Background())) {
+		t.Fatal("WithSyncRoute(ctx) must mark ctx as sync-route")
+	}
+	if isSyncRoute(nil) {
+		t.Fatal("nil ctx must not be reported as sync-route")
+	}
+	// Wrapping with another value-bearing ctx must preserve the sync-route tag.
+	parent := WithSyncRoute(context.Background())
+	child := context.WithValue(parent, struct{}{}, "x")
+	if !isSyncRoute(child) {
+		t.Fatal("sync-route tag must propagate through wrapping ctx")
+	}
+}
+
+func TestEthereumClientPick(t *testing.T) {
+	// httpClient and wsClient must be distinct pointers so identity-based
+	// dispatch is observable. They are not used for any actual call here.
+	httpEC := &ethclient.Client{}
+	wsEC := &ethclient.Client{}
+	c := &EthereumClient{httpClient: httpEC, wsClient: wsEC}
+
+	if got := c.pick(context.Background()); got != httpEC {
+		t.Fatal("plain ctx must dispatch to httpClient")
+	}
+	if got := c.pick(WithSyncRoute(context.Background())); got != wsEC {
+		t.Fatal("sync-route ctx must dispatch to wsClient")
+	}
+
+	// When the WS client is aliased to the HTTP client (single underlying
+	// rpc.Client), both ctx flavours dispatch to the same client.
+	c2 := &EthereumClient{httpClient: httpEC, wsClient: httpEC}
+	if got := c2.pick(WithSyncRoute(context.Background())); got != httpEC {
+		t.Fatal("aliased clients must dispatch to httpClient regardless of ctx tag")
+	}
+}
+
+// jsonrpcServer counts incoming JSON-RPC requests and returns a fixed result.
+type jsonrpcServer struct {
+	calls atomic.Int64
+}
+
+func (s *jsonrpcServer) handler(t *testing.T) http.HandlerFunc {
+	type rpcReq struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		s.calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Server is a stub: handle both single calls and batch (array) calls,
+		// returning a uniform "0x1" result for each.
+		if len(body) > 0 && body[0] == '[' {
+			var reqs []rpcReq
+			if err := json.Unmarshal(body, &reqs); err != nil {
+				t.Fatalf("parse batch body: %v", err)
+			}
+			out := "["
+			for i, req := range reqs {
+				if i > 0 {
+					out += ","
+				}
+				out += `{"jsonrpc":"2.0","id":` + string(req.ID) + `,"result":"0x1"}`
+			}
+			out += "]"
+			_, _ = w.Write([]byte(out))
+			return
+		}
+		var req rpcReq
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("parse body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + string(req.ID) + `,"result":"0x1"}`))
+	}
+}
+
+func TestDualRPCClientCallContextRouting(t *testing.T) {
+	httpSrv := &jsonrpcServer{}
+	wsSrv := &jsonrpcServer{}
+	httpHTTP := httptest.NewServer(httpSrv.handler(t))
+	defer httpHTTP.Close()
+	wsHTTP := httptest.NewServer(wsSrv.handler(t))
+	defer wsHTTP.Close()
+
+	// Both endpoints are HTTP for the purposes of this routing test — the
+	// transport is incidental; what matters is that DualRPCClient picks
+	// SubClient when ctx carries the sync-route tag.
+	callClient, err := rpc.Dial(httpHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial http: %v", err)
+	}
+	defer callClient.Close()
+	subClient, err := rpc.Dial(wsHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer subClient.Close()
+
+	dual := &DualRPCClient{CallClient: callClient, SubClient: subClient}
+
+	var result string
+	if err := dual.CallContext(context.Background(), &result, "eth_blockNumber"); err != nil {
+		t.Fatalf("plain ctx call failed: %v", err)
+	}
+	if got, want := httpSrv.calls.Load(), int64(1); got != want {
+		t.Fatalf("plain ctx must hit CallClient: httpCalls=%d, want %d", got, want)
+	}
+	if got := wsSrv.calls.Load(); got != 0 {
+		t.Fatalf("plain ctx must not hit SubClient: wsCalls=%d, want 0", got)
+	}
+
+	if err := dual.CallContext(WithSyncRoute(context.Background()), &result, "eth_blockNumber"); err != nil {
+		t.Fatalf("sync-route ctx call failed: %v", err)
+	}
+	if got := httpSrv.calls.Load(); got != 1 {
+		t.Fatalf("sync-route ctx must not hit CallClient: httpCalls=%d, want 1", got)
+	}
+	if got, want := wsSrv.calls.Load(), int64(1); got != want {
+		t.Fatalf("sync-route ctx must hit SubClient: wsCalls=%d, want %d", got, want)
+	}
+}
+
+// rpcRecorder satisfies bchain.EVMRPCClient and records the ctx forwarded by
+// EthereumRPC helpers. It returns a JSON null so getBlockRaw short-circuits
+// with ErrBlockNotFound — the test only inspects the ctx, not the result.
+type rpcRecorder struct {
+	lastCtx context.Context
+}
+
+func (r *rpcRecorder) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	r.lastCtx = ctx
+	if raw, ok := result.(*json.RawMessage); ok {
+		*raw = json.RawMessage("null")
+	}
+	return nil
+}
+
+func (r *rpcRecorder) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
+	return nil, nil
+}
+
+func (r *rpcRecorder) Close() {}
+
+func TestSyncFacadeTagsCtx(t *testing.T) {
+	rec := &rpcRecorder{}
+	b := &EthereumRPC{RPC: rec, Timeout: 0}
+
+	// Public path — must NOT carry the sync-route tag.
+	_, _ = b.GetBlock("0xabc", 100)
+	if rec.lastCtx == nil {
+		t.Fatal("expected CallContext to be invoked on public GetBlock")
+	}
+	if isSyncRoute(rec.lastCtx) {
+		t.Fatal("public GetBlock must not carry sync-route tag")
+	}
+
+	// Sync facade path — must carry the sync-route tag.
+	rec.lastCtx = nil
+	view := &ethSyncView{EthereumRPC: b}
+	_, _ = view.GetBlock("0xabc", 100)
+	if rec.lastCtx == nil {
+		t.Fatal("expected CallContext to be invoked on sync facade GetBlock")
+	}
+	if !isSyncRoute(rec.lastCtx) {
+		t.Fatal("sync facade GetBlock must carry sync-route tag")
+	}
+}
+
+func TestDualRPCClientBatchAlwaysHTTP(t *testing.T) {
+	httpSrv := &jsonrpcServer{}
+	wsSrv := &jsonrpcServer{}
+	httpHTTP := httptest.NewServer(httpSrv.handler(t))
+	defer httpHTTP.Close()
+	wsHTTP := httptest.NewServer(wsSrv.handler(t))
+	defer wsHTTP.Close()
+
+	callClient, err := rpc.Dial(httpHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial http: %v", err)
+	}
+	defer callClient.Close()
+	subClient, err := rpc.Dial(wsHTTP.URL)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer subClient.Close()
+
+	dual := &DualRPCClient{CallClient: callClient, SubClient: subClient}
+
+	// BatchCallContext must always hit CallClient regardless of ctx tag —
+	// batching is HTTP-shaped in this codebase (contract.go ERC-20 fan-out).
+	batch := []rpc.BatchElem{{Method: "eth_blockNumber", Result: new(string)}}
+	if err := dual.BatchCallContext(WithSyncRoute(context.Background()), batch); err != nil {
+		t.Fatalf("batch call failed: %v", err)
+	}
+	if got, want := httpSrv.calls.Load(), int64(1); got != want {
+		t.Fatalf("batch must hit CallClient: httpCalls=%d, want %d", got, want)
+	}
+	if got := wsSrv.calls.Load(); got != 0 {
+		t.Fatalf("batch must not hit SubClient: wsCalls=%d, want 0", got)
+	}
+}

--- a/bchain/coins/eth/sync_view.go
+++ b/bchain/coins/eth/sync_view.go
@@ -1,0 +1,53 @@
+package eth
+
+import (
+	"context"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+// ethSyncView is the BlockChain view handed to the SyncWorker for the
+// chain-tip code path (sequential connectBlocks). It embeds *EthereumRPC so
+// every BlockChain method is delegated unchanged, and overrides only the four
+// methods used by db/sync.go's tip-sync flow to tag the request context with
+// WithSyncRoute. The tag causes DualRPCClient.CallContext and EthereumClient
+// methods to dispatch to the WebSocket-backed clients, which keeps follow-up
+// fetches sticky to the backend that delivered newHeads (avoiding the
+// load-balancer drift where one node returns 404 for a block another node
+// just announced).
+//
+// Bulk and parallel sync paths in db/sync.go keep using the original
+// (HTTP-routed) chain reference, so high-volume catch-up traffic still fans
+// out across the LB pool.
+type ethSyncView struct {
+	*EthereumRPC
+}
+
+// SyncBlockChain returns the WS-routed view used by the SyncWorker's
+// connectBlocks path. Implements bchain.SyncableBlockChain.
+func (b *EthereumRPC) SyncBlockChain() bchain.BlockChain {
+	return &ethSyncView{EthereumRPC: b}
+}
+
+// GetBlock fetches the full block (header + transactions + logs + internal
+// trace) over the WS-pinned connection.
+func (s *ethSyncView) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	return s.EthereumRPC.getBlockWithCtx(WithSyncRoute(context.Background()), hash, height)
+}
+
+// GetBlockHash fetches the canonical hash at height over the WS-pinned connection.
+func (s *ethSyncView) GetBlockHash(height uint32) (string, error) {
+	return s.EthereumRPC.getBlockHashWithCtx(WithSyncRoute(context.Background()), height)
+}
+
+// GetBestBlockHash returns the cached best-header's hash, falling back to a
+// WS-routed HeaderByNumber(nil) on cache miss.
+func (s *ethSyncView) GetBestBlockHash() (string, error) {
+	return s.EthereumRPC.getBestBlockHashWithCtx(WithSyncRoute(context.Background()))
+}
+
+// GetBestBlockHeight returns the cached best-header's height, falling back to
+// a WS-routed HeaderByNumber(nil) on cache miss.
+func (s *ethSyncView) GetBestBlockHeight() (uint32, error) {
+	return s.EthereumRPC.getBestBlockHeightWithCtx(WithSyncRoute(context.Background()))
+}

--- a/bchain/coins/tron/tronrpc.go
+++ b/bchain/coins/tron/tronrpc.go
@@ -242,6 +242,13 @@ func (b *TronRPC) Initialize() error {
 	return nil
 }
 
+// Tron also does not depend on a separate WS endpoint for newHeads (see
+// Initialize / startNewBlockNotifier in this file), so there is no LB-drift
+// problem to route around in the first place.
+func (b *TronRPC) SyncBlockChain() bchain.BlockChain {
+	return b
+}
+
 // GetBestBlockHash returns hash of the tip of the best-block-chain
 // need to overwrite this because the getBestHeader method in EthRpc is
 // relying on the subscription

--- a/bchain/coins/tron/tronrpc_test.go
+++ b/bchain/coins/tron/tronrpc_test.go
@@ -558,3 +558,23 @@ func TestTronRPC_RequestLatestSolidifiedBlockHeight_MissingNumber(t *testing.T) 
 	_, err := tronRPC.requestLatestSolidifiedBlockHeight(context.Background())
 	require.Error(t, err)
 }
+
+// TestTronRPC_SyncBlockChainOptsOut pins the explicit opt-out from the EVM
+// sync facade. Without the override, *eth.EthereumRPC.SyncBlockChain promotes
+// through embedding and returns an *eth.ethSyncView that calls eth's
+// getBlockWithCtx and bypasses Tron's GetBlock (HTTP-enriched), GetBlockHash
+// (0x-prefix stripping), and the custom getBestHeader paths. Returning b
+// itself keeps tipChain == chain in the SyncWorker.
+func TestTronRPC_SyncBlockChainOptsOut(t *testing.T) {
+	tronRPC := &TronRPC{
+		EthereumRPC: &eth.EthereumRPC{
+			Timeout: time.Second,
+		},
+	}
+
+	syncable, ok := bchain.BlockChain(tronRPC).(bchain.SyncableBlockChain)
+	require.True(t, ok, "TronRPC must satisfy SyncableBlockChain (it inherits the interface from eth.EthereumRPC and overrides it)")
+
+	got := syncable.SyncBlockChain()
+	require.Same(t, tronRPC, got, "TronRPC.SyncBlockChain must return itself, not the inherited eth.ethSyncView, so Tron's BlockChain method overrides survive")
+}

--- a/bchain/types.go
+++ b/bchain/types.go
@@ -361,6 +361,16 @@ type BlockChain interface {
 	GetTokenURI(contractDesc AddressDescriptor, tokenID *big.Int) (string, error)
 }
 
+// SyncableBlockChain is an optional interface implemented by chains that
+// expose a separate BlockChain view for the SyncWorker's tip-sync path.
+// The returned view shares all backing state with the original; only the
+// underlying RPC routing differs (e.g. HTTP pool vs sticky WebSocket).
+// Chains that do not implement this interface are used unchanged for both
+// bulk and tip sync.
+type SyncableBlockChain interface {
+	SyncBlockChain() BlockChain
+}
+
 // BlockChainParser defines common interface to parsing and conversions of block chain data
 type BlockChainParser interface {
 	// type of the blockchain

--- a/blockbook.go
+++ b/blockbook.go
@@ -267,7 +267,14 @@ func mainWithExitCode() int {
 		return exitCodeOK
 	}
 
-	syncWorker, err = db.NewSyncWorker(index, chain, *syncWorkers, *syncChunk, *blockFrom, *dryRun, chanOsSignal, metrics, internalState)
+	// Chains can opt into a separate BlockChain view for the sync worker's
+	// sequential connectBlocks path (e.g. EVM coins route tip-sync RPC over a
+	// sticky WebSocket while bulk catch-up keeps using the HTTP pool).
+	tipChain := chain
+	if s, ok := chain.(bchain.SyncableBlockChain); ok {
+		tipChain = s.SyncBlockChain()
+	}
+	syncWorker, err = db.NewSyncWorker(index, chain, tipChain, *syncWorkers, *syncChunk, *blockFrom, *dryRun, chanOsSignal, metrics, internalState)
 	if err != nil {
 		glog.Errorf("NewSyncWorker %v", err)
 		return exitCodeFatal

--- a/db/sync.go
+++ b/db/sync.go
@@ -22,12 +22,22 @@ import (
 type SyncWorker struct {
 	db    *RocksDB
 	chain bchain.BlockChain
-	// tipChain is used inside the sequential connectBlocks / getBlockChain
-	// path (the per-newHeads tip-sync case). It typically routes RPC over a
-	// sticky transport (e.g. WebSocket) to keep follow-up block fetches on the
-	// same backend that announced the block. For chains without a separate
-	// tip view it is the same value as chain. Bulk and parallel paths keep
-	// using chain so they can fan out across the LB pool.
+	// tipChain is used by every call site that operates at or near the chain
+	// tip: the sequential connectBlocks / getBlockChain path, the
+	// fork-detection and start-hash lookups in resyncIndex / handleFork, and
+	// the missing-block re-check in shouldRestartSyncOnMissingBlock. It
+	// typically routes RPC over a sticky transport (e.g. WebSocket) to keep
+	// these follow-up calls on the same backend that announced the block,
+	// avoiding the LB-drift case where a slightly behind node returns
+	// ErrBlockNotFound for a block another node already announced.
+	//
+	// Note that connectBlocks always uses tipChain regardless of how the
+	// resyncIndex flow reached it - the rule is mechanical, not gap-based.
+	// In production for ETH the gap reaching connectBlocks is bounded
+	// because ParallelConnectBlocks / BulkConnectBlocks handle gap >= 4 (or
+	// >= syncChunk on initial sync) on the chain (HTTP) path, so connectBlocks
+	// only ever processes the small tail at the tip. For chains without a
+	// separate tip view tipChain is the same value as chain.
 	tipChain               bchain.BlockChain
 	syncWorkers, syncChunk int
 	dryRun                 bool
@@ -179,7 +189,14 @@ func (w *SyncWorker) ResyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 }
 
 func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync bool) error {
-	remoteBestHash, err := w.chain.GetBestBlockHash()
+	// Tip-discovery and fork-detection RPCs go through tipChain so they stay
+	// sticky to the backend that announced the new head. Routing these via
+	// chain (HTTP pool) is the QuickNode LB drift case: a slightly lagging
+	// node returns ErrBlockNotFound for a block another node already
+	// announced, which would either trigger spurious fork handling or fail
+	// the first tip block fetch. These calls are O(1) per resync, so the
+	// extra WS load is negligible.
+	remoteBestHash, err := w.tipChain.GetBestBlockHash()
 	if err != nil {
 		return err
 	}
@@ -193,7 +210,7 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 		return errSynced
 	}
 	if localBestHash != "" {
-		remoteHash, err := w.chain.GetBlockHash(localBestHeight)
+		remoteHash, err := w.tipChain.GetBlockHash(localBestHeight)
 		// for some coins (eth) remote can be at lower best height after rollback
 		if err != nil && !stdErrors.Is(err, bchain.ErrBlockNotFound) {
 			return err
@@ -209,7 +226,7 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 		// database is empty, start genesis
 		glog.Info("resync: genesis from block ", w.startHeight)
 	}
-	w.startHash, err = w.chain.GetBlockHash(w.startHeight)
+	w.startHash, err = w.tipChain.GetBlockHash(w.startHeight)
 	if err != nil {
 		return err
 	}
@@ -218,7 +235,7 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 	// use parallel sync only in case of initial sync because it puts the db to inconsistent state
 	// or in case of ChainEthereumType if the tip is farther
 	if w.syncWorkers > 1 && (initialSync || w.chain.GetChainParser().GetChainType() == bchain.ChainEthereumType) {
-		remoteBestHeight, err := w.chain.GetBestBlockHeight()
+		remoteBestHeight, err := w.tipChain.GetBestBlockHeight()
 		if err != nil {
 			return err
 		}
@@ -283,7 +300,10 @@ func (w *SyncWorker) handleFork(localBestHeight uint32, localBestHash string, on
 		if local == "" {
 			break
 		}
-		remote, err := w.chain.GetBlockHash(height)
+		// tipChain: walking the fork is tip-adjacent and benefits from the
+		// announcer-stickiness for the same reason as resyncIndex's
+		// fork-detection at localBestHeight.
+		remote, err := w.tipChain.GetBlockHash(height)
 		// for some coins (eth) remote can be at lower best height after rollback
 		if err != nil && !stdErrors.Is(err, bchain.ErrBlockNotFound) {
 			return err
@@ -370,7 +390,10 @@ type hashHeight struct {
 func (w *SyncWorker) shouldRestartSyncOnMissingBlock(height uint32, expectedHash string) (bool, error) {
 	// When a block hash disappears at a given height, it usually indicates a
 	// reorg/rollback. Confirm by checking the current tip and block hash.
-	bestHeight, err := w.chain.GetBestBlockHeight()
+	// Use tipChain: this re-check is the exact LB-drift scenario where one
+	// HTTP node returns ErrBlockNotFound while the announcer node still has
+	// the block. Sticky routing avoids a false-positive "restart sync".
+	bestHeight, err := w.tipChain.GetBestBlockHeight()
 	if err != nil {
 		return false, err
 	}
@@ -378,7 +401,7 @@ func (w *SyncWorker) shouldRestartSyncOnMissingBlock(height uint32, expectedHash
 		// The tip moved below the requested height, so this block is no longer valid.
 		return true, nil
 	}
-	currentHash, err := w.chain.GetBlockHash(height)
+	currentHash, err := w.tipChain.GetBlockHash(height)
 	if err != nil {
 		if stdErrors.Is(err, bchain.ErrBlockNotFound) {
 			return true, nil

--- a/db/sync.go
+++ b/db/sync.go
@@ -20,8 +20,15 @@ import (
 
 // SyncWorker is handle to SyncWorker
 type SyncWorker struct {
-	db                     *RocksDB
-	chain                  bchain.BlockChain
+	db    *RocksDB
+	chain bchain.BlockChain
+	// tipChain is used inside the sequential connectBlocks / getBlockChain
+	// path (the per-newHeads tip-sync case). It typically routes RPC over a
+	// sticky transport (e.g. WebSocket) to keep follow-up block fetches on the
+	// same backend that announced the block. For chains without a separate
+	// tip view it is the same value as chain. Bulk and parallel paths keep
+	// using chain so they can fan out across the LB pool.
+	tipChain               bchain.BlockChain
 	syncWorkers, syncChunk int
 	dryRun                 bool
 	startHeight            uint32
@@ -60,14 +67,21 @@ func defaultSyncWorkerConfig() SyncWorkerConfig {
 }
 
 // NewSyncWorker creates new SyncWorker and returns its handle
-func NewSyncWorker(db *RocksDB, chain bchain.BlockChain, syncWorkers, syncChunk int, minStartHeight int, dryRun bool, chanOsSignal chan os.Signal, metrics *common.Metrics, is *common.InternalState) (*SyncWorker, error) {
-	return NewSyncWorkerWithConfig(db, chain, syncWorkers, syncChunk, minStartHeight, dryRun, chanOsSignal, metrics, is, nil)
+//
+// tipChain is the BlockChain view used by the sequential connectBlocks path
+// (per-newHeads tip-sync). Pass the same value as chain when no special
+// tip-side routing is required.
+func NewSyncWorker(db *RocksDB, chain, tipChain bchain.BlockChain, syncWorkers, syncChunk int, minStartHeight int, dryRun bool, chanOsSignal chan os.Signal, metrics *common.Metrics, is *common.InternalState) (*SyncWorker, error) {
+	return NewSyncWorkerWithConfig(db, chain, tipChain, syncWorkers, syncChunk, minStartHeight, dryRun, chanOsSignal, metrics, is, nil)
 }
 
 // NewSyncWorkerWithConfig allows tests or callers to override SyncWorker defaults.
-func NewSyncWorkerWithConfig(db *RocksDB, chain bchain.BlockChain, syncWorkers, syncChunk int, minStartHeight int, dryRun bool, chanOsSignal chan os.Signal, metrics *common.Metrics, is *common.InternalState, cfg *SyncWorkerConfig) (*SyncWorker, error) {
+func NewSyncWorkerWithConfig(db *RocksDB, chain, tipChain bchain.BlockChain, syncWorkers, syncChunk int, minStartHeight int, dryRun bool, chanOsSignal chan os.Signal, metrics *common.Metrics, is *common.InternalState, cfg *SyncWorkerConfig) (*SyncWorker, error) {
 	if minStartHeight < 0 {
 		minStartHeight = 0
+	}
+	if tipChain == nil {
+		tipChain = chain
 	}
 	effectiveCfg := defaultSyncWorkerConfig()
 	if cfg != nil {
@@ -76,6 +90,7 @@ func NewSyncWorkerWithConfig(db *RocksDB, chain bchain.BlockChain, syncWorkers, 
 	return &SyncWorker{
 		db:                db,
 		chain:             chain,
+		tipChain:          tipChain,
 		syncWorkers:       syncWorkers,
 		syncChunk:         syncChunk,
 		dryRun:            dryRun,
@@ -760,7 +775,11 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			return
 		default:
 		}
-		block, err := w.chain.GetBlock(hash, height)
+		// Sequential tip-sync path: route through tipChain so the per-newHeads
+		// follow-up block fetches stay sticky to the backend that announced
+		// the block (avoids the load-balancer drift where another node behind
+		// the LB returns null for a block it has not yet observed).
+		block, err := w.tipChain.GetBlock(hash, height)
 		if err != nil {
 			if stdErrors.Is(err, bchain.ErrBlockNotFound) {
 				break

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -8,12 +8,73 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"sync/atomic"
 	"syscall"
 	"testing"
 
 	jujuErrors "github.com/juju/errors"
 	"github.com/trezor/blockbook/bchain"
 )
+
+// recorderChain is a minimal bchain.BlockChain stand-in that records which
+// methods were invoked on it. It panics on any unmocked method so tests catch
+// unintended fan-out across the chain/tipChain boundary.
+type recorderChain struct {
+	bchain.BlockChain // nil — calls to unmocked methods panic
+	getBlockCalls     atomic.Int32
+}
+
+func (r *recorderChain) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	n := r.getBlockCalls.Add(1)
+	// One block, then signal end-of-chain so getBlockChain's loop exits.
+	if n > 1 {
+		return nil, bchain.ErrBlockNotFound
+	}
+	return &bchain.Block{
+		BlockHeader: bchain.BlockHeader{Hash: hash, Height: height},
+	}, nil
+}
+
+// TestSyncWorkerGetBlockChainUsesTipChain locks in the routing contract added
+// by the traffic-routing change: the sequential connectBlocks/getBlockChain
+// path must fetch blocks via tipChain (which on EVM coins applies
+// WithSyncRoute → WS), and must not fan out to chain (which carries bulk and
+// public-API HTTP traffic).
+func TestSyncWorkerGetBlockChainUsesTipChain(t *testing.T) {
+	main := &recorderChain{}
+	tip := &recorderChain{}
+	w := &SyncWorker{
+		chain:       main,
+		tipChain:    tip,
+		startHash:   "0xtip",
+		startHeight: 100,
+	}
+
+	out := make(chan blockResult, 4)
+	done := make(chan struct{})
+	w.getBlockChain(out, done)
+
+	if got := tip.getBlockCalls.Load(); got == 0 {
+		t.Fatalf("expected tipChain.GetBlock to be called, got 0")
+	}
+	if got := main.getBlockCalls.Load(); got != 0 {
+		t.Fatalf("chain.GetBlock must not be called from getBlockChain, got %d", got)
+	}
+}
+
+// TestSyncWorkerNilTipChainFallsBackToChain documents the safety net in
+// NewSyncWorkerWithConfig: when no tipChain is supplied (non-EVM coins, older
+// tests, etc.) the sequential path stays on the regular chain.
+func TestSyncWorkerNilTipChainFallsBackToChain(t *testing.T) {
+	main := &recorderChain{}
+	w, err := NewSyncWorkerWithConfig(nil, main, nil, 1, 1, 0, true, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewSyncWorkerWithConfig: %v", err)
+	}
+	if w.tipChain != bchain.BlockChain(main) {
+		t.Fatalf("tipChain must default to chain when nil; got %p, want %p", w.tipChain, main)
+	}
+}
 
 func TestIsRetryableGetBlockError(t *testing.T) {
 	tests := []struct {

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -204,10 +204,11 @@ func initBlockChain(coinName string, cfg json.RawMessage, initMempool bool) (bch
 }
 
 func isNetError(err error) bool {
-	if _, ok := err.(net.Error); ok {
-		return true
-	}
-	return false
+	// errors.As walks the wrapping chain so go-ethereum's wsHandshakeError
+	// (which wraps a net.OpError on connection refused) is recognised as a
+	// network error and the test fails fast instead of retrying for 5 minutes.
+	var ne net.Error
+	return errors.As(err, &ne)
 }
 
 func requiresMempool(cfg map[string]json.RawMessage) bool {

--- a/tests/sync/sync.go
+++ b/tests/sync/sync.go
@@ -201,7 +201,7 @@ func withRocksDBAndSyncWorker(t *testing.T, h *TestHandler, startHeight uint32, 
 
 	ch := make(chan os.Signal)
 
-	sw, err := db.NewSyncWorkerWithConfig(d, h.Chain, 8, 0, int(startHeight), false, ch, m, is, testSyncWorkerConfig)
+	sw, err := db.NewSyncWorkerWithConfig(d, h.Chain, h.Chain, 8, 0, int(startHeight), false, ch, m, is, testSyncWorkerConfig)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Routes Ethereum RPC traffic across two transports based on which call site issues it. The `newHeads` follow-up fetches now ride the same WebSocket connection that delivered the event, while bulk catch-up and public-API traffic continue to fan out across the HTTPS pool.

## Routing today

| Call site | Transport |
|-----------|-----------|
| `newHeads` subscription, `newPendingTransactions` subscription | **WS** (unchanged) |
| `refreshBestHeaderFromChain` — the `eth_getBlockByNumber("latest")` follow-up to a `newHeads` event | **WS** |
| `db/sync.go` sequential `connectBlocks` / `getBlockChain` (per-`newHeads` tip-sync, 1–3 blocks): `eth_getBlockByHash`, `eth_getBlockByNumber`, `eth_getLogs`, `debug_traceBlockByHash` | **WS** |
| `db/sync.go` `BulkConnectBlocks` (initial catch-up) | **HTTP pool** |
| `db/sync.go` `ParallelConnectBlocks` (EVM gap ≥ 4) | **HTTP pool** |
| `db/sync.go:resyncIndex` head-of-function calls (`GetBestBlockHash`, `GetBlockHash` for fork detection) | **HTTP pool** |
| Trezor Suite REST/WS public API (`server/`, `api/worker.go`) | **HTTP pool** |
| Mempool (`GetMempoolTransactions`, `eth_getTransactionByHash` for pending, `eth_pendingTransactions`) | **HTTP pool** |
| `getBestHeader` cache-miss / startup fallback | **HTTP pool** |
| `BatchCallContext` (ERC-20 fan-out in `contract.go`) | **HTTP pool** (always) |

The WS connection is one TCP/WSS stream pinned to a single backend by the load balancer, so all four target methods follow up against the same node that announced the block — eliminating the LB-drift case where one node says block N exists and another returns null. High-volume bulk RPC continues to fan out across the HTTPS pool.

L2 forks (Optimism, Base, Arbitrum, Polygon, BSC) inherit the new behaviour because they all use `eth.OpenRPC`. Non-EVM coins (Bitcoin, Tron, …) are unaffected.

## How

- New optional `bchain.SyncableBlockChain` interface; `EthereumRPC` implements it via a thin `ethSyncView` facade.
- `SyncWorker` now carries two `BlockChain` references: `chain` (HTTP) for bulk/parallel/orchestration, `tipChain` (the sync facade) for the sequential `connectBlocks` path.
- `DualRPCClient.CallContext` and `EthereumClient.<method>` dispatch on a context-value flag set by `WithSyncRoute(ctx)`.
- `BatchCallContext` is unchanged — batching stays on the HTTP client.
- Internal helpers in `ethrpc.go` accept the caller's parent ctx so the routing flag propagates from facade entry down to every underlying RPC.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test -tags=unittest ./...` clean
- [x] New unit tests in `bchain/coins/eth/sync_route_test.go`:
  - context-value round-trip
  - `EthereumClient.pick` dispatch (including aliased clients)
  - `DualRPCClient.CallContext` routes to `SubClient` only with `WithSyncRoute(ctx)`
  - `DualRPCClient.BatchCallContext` always uses `CallClient`
  - `ethSyncView.GetBlock` propagates `WithSyncRoute` to the underlying RPC; bare `EthereumRPC.GetBlock` does not
- [ ] End-to-end soak against QuickNode (HTTPS + WSS): confirm tip-sync RPCs land on the WS connection, bulk catch-up traffic stays on HTTPS, public REST/WS responses unaffected
- [ ] WS reconnect drill: drop the WS connection and confirm `subscribe` reconnects and tip-sync recovers
