### PR TITLE
Sync stalls prevention + retry transient missing-tip block fetches before unwinding to ResyncIndex

### DIFF
--- a/bchain/coins/btc/bitcoinrpc.go
+++ b/bchain/coins/btc/bitcoinrpc.go
@@ -42,6 +42,13 @@ func (b *BitcoinRPC) SetMetrics(metrics *common.Metrics) {
 	b.metrics = metrics
 }
 
+// AverageBlockTimeDuration exposes the chain's nominal block cadence so the
+// blockbook_average_block_time_seconds gauge can normalize tip-age alerts
+// across coins. Returns an error if the config didn't set averageBlockTimeMs.
+func (b *BitcoinRPC) AverageBlockTimeDuration() (time.Duration, error) {
+	return b.ChainConfig.AverageBlockTimeDuration()
+}
+
 // Configuration represents json config file
 type Configuration struct {
 	CoinName                     string `json:"coin_name"`
@@ -71,6 +78,20 @@ type Configuration struct {
 	MempoolGolombFilterP         uint8  `json:"mempool_golomb_filter_p,omitempty"`
 	MempoolFilterScripts         string `json:"mempool_filter_scripts,omitempty"`
 	MempoolFilterUseZeroedKey    bool   `json:"mempool_filter_use_zeroed_key,omitempty"`
+	// AverageBlockTimeMs is the chain's nominal block cadence in ms.
+	// Optional on UTXO chains; when set it is exposed as the
+	// blockbook_average_block_time_seconds gauge for alert normalization.
+	AverageBlockTimeMs int `json:"averageBlockTimeMs,omitempty"`
+}
+
+// AverageBlockTimeDuration returns AverageBlockTimeMs as a time.Duration.
+// Returns an error when unset so callers can distinguish "no configured cadence"
+// from a real zero — matching the EVM Configuration helper.
+func (c *Configuration) AverageBlockTimeDuration() (time.Duration, error) {
+	if c.AverageBlockTimeMs <= 0 {
+		return 0, errors.Errorf("averageBlockTimeMs must be a positive integer")
+	}
+	return time.Duration(c.AverageBlockTimeMs) * time.Millisecond, nil
 }
 
 // NewBitcoinRPC returns new BitcoinRPC instance.

--- a/bchain/coins/btc/bitcoinrpc.go
+++ b/bchain/coins/btc/bitcoinrpc.go
@@ -49,6 +49,16 @@ func (b *BitcoinRPC) AverageBlockTimeDuration() (time.Duration, error) {
 	return b.ChainConfig.AverageBlockTimeDuration()
 }
 
+// MissingBlockRetryOverride exposes the per-chain sync-worker retry override
+// (or nil to use built-in defaults). Consumed by blockbook.go at SyncWorker
+// construction via a duck-typed interface assertion.
+func (b *BitcoinRPC) MissingBlockRetryOverride() *bchain.MissingBlockRetry {
+	if b.ChainConfig == nil {
+		return nil
+	}
+	return b.ChainConfig.MissingBlockRetry
+}
+
 // Configuration represents json config file
 type Configuration struct {
 	CoinName                     string `json:"coin_name"`
@@ -82,6 +92,9 @@ type Configuration struct {
 	// Optional on UTXO chains; when set it is exposed as the
 	// blockbook_average_block_time_seconds gauge for alert normalization.
 	AverageBlockTimeMs int `json:"averageBlockTimeMs,omitempty"`
+	// MissingBlockRetry overrides the sync-worker missing-block retry policy
+	// per chain. All fields are optional; missing fields use built-in defaults.
+	MissingBlockRetry *bchain.MissingBlockRetry `json:"missingBlockRetry,omitempty"`
 }
 
 // AverageBlockTimeDuration returns AverageBlockTimeMs as a time.Duration.

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -101,6 +101,9 @@ type Configuration struct {
 	// AverageBlockTimeMs is the chain's nominal block cadence in ms;
 	// required for EVM coins (translates duration settings to block counts).
 	AverageBlockTimeMs int `json:"averageBlockTimeMs,omitempty"`
+	// MissingBlockRetry overrides the sync-worker missing-block retry policy
+	// per chain. All fields are optional; missing fields use built-in defaults.
+	MissingBlockRetry *bchain.MissingBlockRetry `json:"missingBlockRetry,omitempty"`
 }
 
 func parseNonNegativeDuration(name string, value string) (time.Duration, error) {
@@ -278,6 +281,16 @@ func (b *EthereumRPC) SetMetrics(metrics *common.Metrics) {
 // AverageBlockTimeDuration exposes the chain's nominal block cadence.
 func (b *EthereumRPC) AverageBlockTimeDuration() (time.Duration, error) {
 	return b.ChainConfig.AverageBlockTimeDuration()
+}
+
+// MissingBlockRetryOverride exposes the per-chain sync-worker retry override
+// (or nil to use built-in defaults). Consumed by blockbook.go at SyncWorker
+// construction via a duck-typed interface assertion.
+func (b *EthereumRPC) MissingBlockRetryOverride() *bchain.MissingBlockRetry {
+	if b.ChainConfig == nil {
+		return nil
+	}
+	return b.ChainConfig.MissingBlockRetry
 }
 
 func (b *EthereumRPC) observeEthCall(mode string, count int) {

--- a/bchain/types.go
+++ b/bchain/types.go
@@ -424,3 +424,23 @@ type Mempool interface {
 	GetTransactionTime(txid string) uint32
 	GetTxidFilterEntries(filterScripts string, fromTimestamp uint32) (MempoolTxidFilterEntries, error)
 }
+
+// MissingBlockRetry is the JSON wire shape for per-chain overrides of the
+// sync-worker missing-block retry policy. Each field is optional; zero / missing
+// values fall back to the db package's built-in defaults. Operators set this
+// under `additional_params.missingBlockRetry` in `configs/coins/*.json`.
+type MissingBlockRetry struct {
+	// RetryDelayMs is the sleep between successive GetBlock attempts for the same
+	// missing block in the parallel worker path. The sequential tip path applies
+	// an additional internal cap of 250 ms regardless of this value.
+	RetryDelayMs int `json:"retryDelayMs,omitempty"`
+	// RecheckThreshold is the number of consecutive retryable errors in the
+	// parallel worker before probing the chain via shouldRestartSyncOnMissingBlock.
+	RecheckThreshold int `json:"recheckThreshold,omitempty"`
+	// TipRecheckThreshold is the equivalent threshold once the hash queue is
+	// closed (we are at the tail of a range) or for the sequential tip path.
+	TipRecheckThreshold int `json:"tipRecheckThreshold,omitempty"`
+	// MaxStallMs is the wall-clock budget per stuck block before the retry loop
+	// yields errResync to the outer machinery.
+	MaxStallMs int `json:"maxStallMs,omitempty"`
+}

--- a/blockbook.go
+++ b/blockbook.go
@@ -282,7 +282,24 @@ func mainWithExitCode() int {
 		return exitCodeOK
 	}
 
-	syncWorker, err = db.NewSyncWorker(index, chain, *syncWorkers, *syncChunk, *blockFrom, *dryRun, chanOsSignal, metrics, internalState)
+	// Per-chain missing-block retry override, if any. Coin RPCs that opt in
+	// expose MissingBlockRetryOverride(); chains without the method keep defaults.
+	var syncCfg *db.SyncWorkerConfig
+	if provider, ok := chain.(interface {
+		MissingBlockRetryOverride() *bchain.MissingBlockRetry
+	}); ok {
+		if override := provider.MissingBlockRetryOverride(); override != nil {
+			syncCfg = &db.SyncWorkerConfig{
+				MissingBlockRetry: db.ApplyMissingBlockRetryOverride(override),
+			}
+			glog.Infof("sync: missingBlockRetry override applied: retryDelay=%s recheckThreshold=%d tipRecheckThreshold=%d maxStall=%s",
+				syncCfg.MissingBlockRetry.RetryDelay,
+				syncCfg.MissingBlockRetry.RecheckThreshold,
+				syncCfg.MissingBlockRetry.TipRecheckThreshold,
+				syncCfg.MissingBlockRetry.MaxStallDuration)
+		}
+	}
+	syncWorker, err = db.NewSyncWorkerWithConfig(index, chain, *syncWorkers, *syncChunk, *blockFrom, *dryRun, chanOsSignal, metrics, internalState, syncCfg)
 	if err != nil {
 		glog.Errorf("NewSyncWorker %v", err)
 		return exitCodeFatal

--- a/blockbook.go
+++ b/blockbook.go
@@ -189,6 +189,17 @@ func mainWithExitCode() int {
 		return exitCodeFatal
 	}
 
+	// Chains that expose a configured average block time (currently EVM coins via
+	// EthereumRPC.AverageBlockTimeDuration) publish it as a static gauge so
+	// alerts can normalize the tip-age metric across coins with different cadences.
+	if provider, ok := chain.(interface {
+		AverageBlockTimeDuration() (time.Duration, error)
+	}); ok {
+		if d, err := provider.AverageBlockTimeDuration(); err == nil && d > 0 {
+			metrics.AverageBlockTimeSeconds.Set(d.Seconds())
+		}
+	}
+
 	index, err = db.NewRocksDB(*dbPath, *dbCache, *dbMaxOpenFiles, chain.GetChainParser(), metrics, *extendedIndex)
 	if err != nil {
 		glog.Error("rocksDB: ", err)
@@ -512,6 +523,7 @@ func blockbookAppInfoMetric(db *db.RocksDB, chain bchain.BlockChain, txCache *db
 		"backend_subversion":       subversion,
 		"backend_protocol_version": si.Backend.ProtocolVersion}).Set(float64(0))
 	metrics.BackendBestHeight.Set(float64(si.Backend.Blocks))
+	metrics.BackendTipAgeSeconds.Set(time.Since(is.GetBackendTipLastAdvance()).Seconds())
 	metrics.BlockbookBestHeight.Set(float64(si.Blockbook.BestHeight))
 	return nil
 }

--- a/blockbook.go
+++ b/blockbook.go
@@ -92,8 +92,12 @@ var (
 )
 
 var (
-	chanSyncIndex                 = make(chan struct{})
-	chanSyncMempool               = make(chan struct{})
+	// Buffer 1 + non-blocking sends in pushSynchronizationHandler decouple the
+	// WebSocket/ZMQ source goroutines from sync progress. If sync is stuck inside
+	// TickAndDebounce's f(), additional notifications are dropped here rather
+	// than blocking the source; TickAndDebounce's tick-period backstop still fires.
+	chanSyncIndex                 = make(chan struct{}, 1)
+	chanSyncMempool               = make(chan struct{}, 1)
 	chanStoreInternalState        = make(chan struct{})
 	chanSyncIndexDone             = make(chan struct{})
 	chanSyncMempoolDone           = make(chan struct{})
@@ -677,9 +681,15 @@ func pushSynchronizationHandler(nt bchain.NotificationType) {
 		return
 	}
 	if nt == bchain.NotificationNewBlock {
-		chanSyncIndex <- struct{}{}
+		select {
+		case chanSyncIndex <- struct{}{}:
+		default:
+		}
 	} else if nt == bchain.NotificationNewTx {
-		chanSyncMempool <- struct{}{}
+		select {
+		case chanSyncMempool <- struct{}{}:
+		default:
+		}
 	} else {
 		glog.Error("MQ: unknown notification sent")
 	}

--- a/common/internalstate.go
+++ b/common/internalstate.go
@@ -350,10 +350,15 @@ func (is *InternalState) GetBackendInfo() BackendInfo {
 }
 
 // GetBackendTipLastAdvance returns the wall-clock time when the backend's
-// Blocks height was last observed to advance.
+// Blocks height was last observed to advance. BackendTipLastAdvance is not
+// persisted, so on startup (before the first SetBackendInfo) it is zero; seed
+// it to now on first read so tip-age metrics don't report a bogus huge age.
 func (is *InternalState) GetBackendTipLastAdvance() time.Time {
 	is.mux.Lock()
 	defer is.mux.Unlock()
+	if is.BackendTipLastAdvance.IsZero() {
+		is.BackendTipLastAdvance = time.Now()
+	}
 	return is.BackendTipLastAdvance
 }
 

--- a/common/internalstate.go
+++ b/common/internalstate.go
@@ -91,6 +91,8 @@ type InternalState struct {
 
 	BackendInfo BackendInfo `json:"-" ts_doc:"Information about the connected blockchain backend (not exposed in JSON)."`
 
+	BackendTipLastAdvance time.Time `json:"-" ts_doc:"Wall-clock time when BackendInfo.Blocks was last observed to advance (not exposed in JSON)."`
+
 	// database migrations
 	UtxoChecked            bool `json:"utxoChecked" ts_doc:"Indicates if UTXO consistency checks have been performed."`
 	SortedAddressContracts bool `json:"sortedAddressContracts" ts_doc:"Indicates if address/contract sorting has been completed."`
@@ -328,10 +330,15 @@ func (is *InternalState) GetNetwork() string {
 	return network
 }
 
-// SetBackendInfo sets new BackendInfo
+// SetBackendInfo sets new BackendInfo and records the time when Blocks advances.
+// On the first observation the advance time is seeded to now so the
+// derived tip-age metric reads a meaningful value instead of "since epoch."
 func (is *InternalState) SetBackendInfo(bi *BackendInfo) {
 	is.mux.Lock()
 	defer is.mux.Unlock()
+	if bi.Blocks > is.BackendInfo.Blocks || is.BackendTipLastAdvance.IsZero() {
+		is.BackendTipLastAdvance = time.Now()
+	}
 	is.BackendInfo = *bi
 }
 
@@ -340,6 +347,14 @@ func (is *InternalState) GetBackendInfo() BackendInfo {
 	is.mux.Lock()
 	defer is.mux.Unlock()
 	return is.BackendInfo
+}
+
+// GetBackendTipLastAdvance returns the wall-clock time when the backend's
+// Blocks height was last observed to advance.
+func (is *InternalState) GetBackendTipLastAdvance() time.Time {
+	is.mux.Lock()
+	defer is.mux.Unlock()
+	return is.BackendTipLastAdvance
 }
 
 // Pack marshals internal state to json

--- a/common/metrics.go
+++ b/common/metrics.go
@@ -35,6 +35,8 @@ type Metrics struct {
 	EthCallTokenURI                   *prometheus.CounterVec
 	EthCallStakingPool                *prometheus.CounterVec
 	IndexResyncErrors                 *prometheus.CounterVec
+	IndexBlockNotFoundRetries         prometheus.Counter
+	IndexReorgEvents                  *prometheus.CounterVec
 	IndexDBSize                       prometheus.Gauge
 	ExplorerViews                     *prometheus.CounterVec
 	MempoolSize                       prometheus.Gauge
@@ -289,6 +291,21 @@ func GetMetrics(coin string) (*Metrics, error) {
 			ConstLabels: Labels{"coin": coin},
 		},
 		[]string{"error"},
+	)
+	metrics.IndexBlockNotFoundRetries = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name:        "blockbook_index_block_not_found_retries",
+			Help:        "Number of transient ErrBlockNotFound responses from the backend during sync (load-balanced RPC routing skew, indexer ahead of backend, etc.)",
+			ConstLabels: Labels{"coin": coin},
+		},
+	)
+	metrics.IndexReorgEvents = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "blockbook_index_reorg_events",
+			Help:        "Chain reorganization events detected during sync, by detection path (fork: in-stream prevHash mismatch; resync: missing block hash triggered sync restart; disconnect: local-best fork triggered DB rollback)",
+			ConstLabels: Labels{"coin": coin},
+		},
+		[]string{"type"},
 	)
 	metrics.IndexDBSize = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/common/metrics.go
+++ b/common/metrics.go
@@ -51,6 +51,8 @@ type Metrics struct {
 	DbColumnSize                      *prometheus.GaugeVec
 	BlockbookAppInfo                  *prometheus.GaugeVec
 	BackendBestHeight                 prometheus.Gauge
+	BackendTipAgeSeconds              prometheus.Gauge
+	AverageBlockTimeSeconds           prometheus.Gauge
 	BlockbookBestHeight               prometheus.Gauge
 	ExplorerPendingRequests           *prometheus.GaugeVec
 	WebsocketPendingRequests          *prometheus.GaugeVec
@@ -412,6 +414,20 @@ func GetMetrics(coin string) (*Metrics, error) {
 		prometheus.GaugeOpts{
 			Name:        "blockbook_backend_best_height",
 			Help:        "Block height in backend",
+			ConstLabels: Labels{"coin": coin},
+		},
+	)
+	metrics.BackendTipAgeSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name:        "blockbook_tip_age_seconds",
+			Help:        "Seconds since the backend's best height was last observed to advance",
+			ConstLabels: Labels{"coin": coin},
+		},
+	)
+	metrics.AverageBlockTimeSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name:        "blockbook_average_block_time_seconds",
+			Help:        "Configured average block time for the chain in seconds (0 if unavailable)",
 			ConstLabels: Labels{"coin": coin},
 		},
 	)

--- a/common/metrics.go
+++ b/common/metrics.go
@@ -37,6 +37,7 @@ type Metrics struct {
 	IndexResyncErrors                 *prometheus.CounterVec
 	IndexBlockNotFoundRetries         prometheus.Counter
 	IndexReorgEvents                  *prometheus.CounterVec
+	IndexSyncYields                   *prometheus.CounterVec
 	IndexDBSize                       prometheus.Gauge
 	ExplorerViews                     *prometheus.CounterVec
 	MempoolSize                       prometheus.Gauge
@@ -306,6 +307,14 @@ func GetMetrics(coin string) (*Metrics, error) {
 			ConstLabels: Labels{"coin": coin},
 		},
 		[]string{"type"},
+	)
+	metrics.IndexSyncYields = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "blockbook_index_sync_yields",
+			Help:        "Number of times sync yielded to the outer resync machinery for non-reorg reasons (reason=deadline: MaxStallDuration elapsed in retry loop; reason=probe_failed: chain-state probe failed for the configured streak)",
+			ConstLabels: Labels{"coin": coin},
+		},
+		[]string{"reason"},
 	)
 	metrics.IndexDBSize = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -53,6 +53,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 250,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",

--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -59,7 +59,7 @@
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/arbitrum_nova_archive.json
+++ b/configs/coins/arbitrum_nova_archive.json
@@ -55,7 +55,7 @@
                 "address_aliases": true,
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/avalanche_archive.json
+++ b/configs/coins/avalanche_archive.json
@@ -57,6 +57,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 2000,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "address_aliases": true,
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,

--- a/configs/coins/avalanche_archive.json
+++ b/configs/coins/avalanche_archive.json
@@ -60,7 +60,7 @@
                 "address_aliases": true,
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -61,7 +61,7 @@
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -55,6 +55,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 2000,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",

--- a/configs/coins/bcash.json
+++ b/configs/coins/bcash.json
@@ -56,6 +56,7 @@
             "xpub_magic": 76067358,
             "slip44": 145,
             "additional_params": {
+                "averageBlockTimeMs": 600000,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"bitcoin-cash\", \"periodSeconds\": 900}"

--- a/configs/coins/bitcoin.json
+++ b/configs/coins/bitcoin.json
@@ -66,6 +66,7 @@
             "xpub_magic_segwit_p2sh": 77429938,
             "xpub_magic_segwit_native": 78792518,
             "additional_params": {
+                "averageBlockTimeMs": 600000,
                 "alternative_estimate_fee": "mempoolspaceblock",
                 "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/api/v1/fees/mempool-blocks\", \"periodSeconds\": 20, \"feeRangeIndex\": 5, \"fallbackFeePerKB\": 1000}",
                 "fiat_rates": "coingecko",

--- a/configs/coins/bsc_archive.json
+++ b/configs/coins/bsc_archive.json
@@ -66,7 +66,7 @@
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/56/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "disableMempoolSync": true,
                 "fiat_rates": "coingecko",

--- a/configs/coins/bsc_archive.json
+++ b/configs/coins/bsc_archive.json
@@ -60,6 +60,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 3000,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura-disabled",

--- a/configs/coins/dogecoin.json
+++ b/configs/coins/dogecoin.json
@@ -67,6 +67,7 @@
             "xpub_magic": 49990397,
             "slip44": 3,
             "additional_params": {
+                "averageBlockTimeMs": 60000,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"dogecoin\", \"periodSeconds\": 900}"

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -60,6 +60,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 12000,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "consensusNodeVersion": "http://localhost:7516/eth/v1/node/version",
                 "address_aliases": true,
                 "eip1559Fees": true,

--- a/configs/coins/litecoin.json
+++ b/configs/coins/litecoin.json
@@ -65,6 +65,7 @@
             "xpub_magic_segwit_native": 78792518,
             "slip44": 2,
             "additional_params": {
+                "averageBlockTimeMs": 150000,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"litecoin\", \"periodSeconds\": 900}"

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -55,6 +55,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 2000,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -61,7 +61,7 @@
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/polygon_archive.json
+++ b/configs/coins/polygon_archive.json
@@ -66,7 +66,7 @@
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/137/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
-                "trace_timeout": "20s",
+                "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/polygon_archive.json
+++ b/configs/coins/polygon_archive.json
@@ -60,6 +60,12 @@
             "block_addresses_to_keep": 600,
             "additional_params": {
                 "averageBlockTimeMs": 2000,
+                "missingBlockRetry": {
+                    "retryDelayMs": 1000,
+                    "recheckThreshold": 10,
+                    "tipRecheckThreshold": 3,
+                    "maxStallMs": 60000
+                },
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",

--- a/configs/coins/tron.json
+++ b/configs/coins/tron.json
@@ -54,6 +54,12 @@
               "mempoolTxTimeoutHours": 4,
               "queryBackendOnMempoolResync": true,
               "averageBlockTimeMs": 3000,
+              "missingBlockRetry": {
+                  "retryDelayMs": 1000,
+                  "recheckThreshold": 10,
+                  "tipRecheckThreshold": 3,
+                  "maxStallMs": 60000
+              },
               "fiat_rates": "coingecko",
               "fiat_rates_vs_currencies": "USD,EUR,CNY",
               "fiat_rates_params": "{\"coin\": \"tron\",\"platformIdentifier\": \"tron\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}",

--- a/configs/coins/zcash.json
+++ b/configs/coins/zcash.json
@@ -54,6 +54,7 @@
             "xpub_magic": 76067358,
             "slip44": 133,
             "additional_params": {
+                "averageBlockTimeMs": 75000,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"zcash\", \"periodSeconds\": 900}"

--- a/db/sync.go
+++ b/db/sync.go
@@ -74,24 +74,32 @@ func defaultSyncWorkerConfig() SyncWorkerConfig {
 }
 
 // ApplyMissingBlockRetryOverride overlays the optional bchain.MissingBlockRetry
-// onto the defaults. Zero / unset wire fields keep their default; out-of-range
-// values fall back to the default with a warning logged in the caller.
+// onto the defaults. Zero / unset wire fields keep their default; explicitly set
+// but invalid values (negative, or a TipRecheckThreshold above RecheckThreshold)
+// keep the default and log a warning.
 func ApplyMissingBlockRetryOverride(o *bchain.MissingBlockRetry) MissingBlockRetryConfig {
 	cfg := DefaultMissingBlockRetryConfig()
 	if o == nil {
 		return cfg
 	}
-	if o.RetryDelayMs > 0 {
-		cfg.RetryDelay = time.Duration(o.RetryDelayMs) * time.Millisecond
+	apply := func(field string, v int, set func(int)) {
+		if v == 0 {
+			return // unset: keep default
+		}
+		if v < 0 {
+			glog.Warningf("sync: missingBlockRetry.%s=%d is invalid, keeping default", field, v)
+			return
+		}
+		set(v)
 	}
-	if o.RecheckThreshold > 0 {
-		cfg.RecheckThreshold = o.RecheckThreshold
-	}
-	if o.TipRecheckThreshold > 0 {
-		cfg.TipRecheckThreshold = o.TipRecheckThreshold
-	}
-	if o.MaxStallMs > 0 {
-		cfg.MaxStallDuration = time.Duration(o.MaxStallMs) * time.Millisecond
+	apply("retryDelayMs", o.RetryDelayMs, func(v int) { cfg.RetryDelay = time.Duration(v) * time.Millisecond })
+	apply("recheckThreshold", o.RecheckThreshold, func(v int) { cfg.RecheckThreshold = v })
+	apply("tipRecheckThreshold", o.TipRecheckThreshold, func(v int) { cfg.TipRecheckThreshold = v })
+	apply("maxStallMs", o.MaxStallMs, func(v int) { cfg.MaxStallDuration = time.Duration(v) * time.Millisecond })
+	if cfg.TipRecheckThreshold > cfg.RecheckThreshold {
+		glog.Warningf("sync: missingBlockRetry.tipRecheckThreshold=%d exceeds recheckThreshold=%d, clamping to %d",
+			cfg.TipRecheckThreshold, cfg.RecheckThreshold, cfg.RecheckThreshold)
+		cfg.TipRecheckThreshold = cfg.RecheckThreshold
 	}
 	return cfg
 }
@@ -418,7 +426,7 @@ func (w *SyncWorker) shouldRestartSyncOnMissingBlock(height uint32, expectedHash
 // quiet because transient backend lag (e.g. load-balanced RPC routing skew)
 // is expected. The per-error signal is preserved via the IndexResyncErrors metric.
 func (w *SyncWorker) onRetryableMiss(retries *int, threshold int, label string, height uint32, hash string, err error) (bool, error) {
-	*retries++
+	(*retries)++
 	if *retries < threshold {
 		return false, nil
 	}

--- a/db/sync.go
+++ b/db/sync.go
@@ -543,9 +543,9 @@ func (w *SyncWorker) getBlockWorker(i int, syncWorkers uint32, wg *sync.WaitGrou
 	cfg := w.missingBlockRetry
 GetBlockLoop:
 	for hh := range hch {
-		// Track consecutive not-found errors per block so we only re-check the
+		// Track consecutive retryable errors per block so we only re-check the
 		// chain once the backend has had a chance to catch up.
-		notFoundRetries := 0
+		retries := 0
 		for {
 			// Allow global shutdown or an abort to stop the retry loop promptly.
 			select {
@@ -558,7 +558,7 @@ GetBlockLoop:
 			block, err = w.chain.GetBlock(hh.hash, hh.height)
 			if err != nil {
 				if isRetryableGetBlockError(err) {
-					notFoundRetries++
+					retries++
 					glog.Error("getBlockWorker ", i, " connect block ", hh.height, " ", hh.hash, " error ", err, ". Retrying...")
 					threshold := cfg.RecheckThreshold
 					// Once the hash queue is closed we are at the tail of the range; use
@@ -566,7 +566,7 @@ GetBlockLoop:
 					if hchClosed.Load() == true {
 						threshold = cfg.TipRecheckThreshold
 					}
-					if notFoundRetries >= threshold {
+					if retries >= threshold {
 						restart, checkErr := w.shouldRestartSyncOnMissingBlock(hh.height, hh.hash)
 						if checkErr != nil {
 							glog.Error("getBlockWorker ", i, " missing block check error ", checkErr)
@@ -592,7 +592,7 @@ GetBlockLoop:
 						}
 						return
 					}
-					notFoundRetries = 0
+					retries = 0
 					glog.Error("getBlockWorker ", i, " connect block error ", err, ". Retrying...")
 				}
 				w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
@@ -771,7 +771,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			return
 		default:
 		}
-		notFoundRetries := 0
+		retries := 0
 		var block *bchain.Block
 		var err error
 		for {
@@ -782,7 +782,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			// On the first ErrBlockNotFound, check whether we are past the backend tip
 			// so we exit cleanly at end-of-chain. Subsequent retries skip this RPC and
 			// defer to shouldRestartSyncOnMissingBlock at the threshold tick.
-			if notFoundRetries == 0 && stdErrors.Is(err, bchain.ErrBlockNotFound) {
+			if retries == 0 && stdErrors.Is(err, bchain.ErrBlockNotFound) {
 				bestHeight, bestErr := w.chain.GetBestBlockHeight()
 				if bestErr != nil {
 					out <- blockResult{err: bestErr}
@@ -796,9 +796,9 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 				out <- blockResult{err: err}
 				return
 			}
-			notFoundRetries++
+			retries++
 			glog.Error("getBlockChain connect block ", height, " ", hash, " error ", err, ". Retrying...")
-			if notFoundRetries >= recheckThreshold {
+			if retries >= recheckThreshold {
 				restart, checkErr := w.shouldRestartSyncOnMissingBlock(height, hash)
 				if checkErr != nil {
 					out <- blockResult{err: checkErr}

--- a/db/sync.go
+++ b/db/sync.go
@@ -124,7 +124,9 @@ func NewSyncWorkerWithConfig(db *RocksDB, chain bchain.BlockChain, syncWorkers, 
 	}, nil
 }
 
-var errSynced = errors.New("synced")
+// syncNotNeeded is returned by resyncIndex when the local tip already matches
+// the backend tip. ResyncIndex treats it as a successful no-op.
+var syncNotNeeded = errors.New("sync not needed")
 var errFork = errors.New("fork")
 
 // errResync signals that the parallel/bulk sync should restart because the
@@ -185,8 +187,7 @@ func (w *SyncWorker) ResyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 		w.metrics.BackendTipAgeSeconds.Set(time.Since(w.is.GetBackendTipLastAdvance()).Seconds())
 		w.metrics.BlockbookBestHeight.Set(float64(bh))
 		return err
-	case errSynced:
-		// this is not actually error but flag that resync wasn't necessary
+	case syncNotNeeded:
 		w.is.FinishedSyncNoChange()
 		w.metrics.IndexDBSize.Set(float64(w.db.DatabaseSizeOnDisk()))
 		if initialSync {
@@ -213,7 +214,7 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 	// If the locally indexed block is the same as the best block on the network, we're done.
 	if localBestHash == remoteBestHash {
 		glog.Infof("resync: synced at %d %s", localBestHeight, localBestHash)
-		return errSynced
+		return syncNotNeeded
 	}
 	if localBestHash != "" {
 		remoteHash, err := w.chain.GetBlockHash(localBestHeight)

--- a/db/sync.go
+++ b/db/sync.go
@@ -608,6 +608,7 @@ GetBlockLoop:
 							// outer loop can decide how to recover instead of spinning silently.
 							glog.Errorf("%s: aborting after %d consecutive chain-state probe failures (last: %v)",
 								label, checkErrStreak, checkErr)
+							w.metrics.IndexSyncYields.With(common.Labels{"reason": "probe_failed"}).Inc()
 							select {
 							case abortCh <- checkErr:
 							default:
@@ -630,7 +631,7 @@ GetBlockLoop:
 					if cfg.MaxStallDuration > 0 && time.Since(loopStart) >= cfg.MaxStallDuration {
 						glog.Warningf("%s: block %d %s stall deadline %s exceeded after %d retries (last: %v); yielding to resync",
 							label, hh.height, hh.hash, cfg.MaxStallDuration, retries, err)
-						w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
+						w.metrics.IndexSyncYields.With(common.Labels{"reason": "deadline"}).Inc()
 						select {
 						case abortCh <- errResync:
 						default:
@@ -874,7 +875,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			if maxStall > 0 && time.Since(loopStart) >= maxStall {
 				glog.Warningf("getBlockChain: block %d %s stall deadline %s exceeded after %d retries (last: %v); yielding to resync",
 					height, hash, maxStall, retries, err)
-				w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
+				w.metrics.IndexSyncYields.With(common.Labels{"reason": "deadline"}).Inc()
 				select {
 				case out <- blockResult{err: errResync}:
 				case <-done:

--- a/db/sync.go
+++ b/db/sync.go
@@ -43,6 +43,11 @@ type MissingBlockRetryConfig struct {
 	TipRecheckThreshold int
 	// RetryDelay keeps retry pressure low while still reacting quickly to transient backend gaps.
 	RetryDelay time.Duration
+	// MaxStallDuration caps the wall-clock time a single block fetch may spend
+	// in the retry loop before yielding control to the outer resync machinery.
+	// Without this cap, a backend that keeps returning ErrBlockNotFound while
+	// shouldRestartSyncOnMissingBlock keeps reporting "no reorg" loops forever.
+	MaxStallDuration time.Duration
 }
 
 // SyncWorkerConfig bundles optional tuning knobs for SyncWorker.
@@ -53,9 +58,10 @@ type SyncWorkerConfig struct {
 func defaultSyncWorkerConfig() SyncWorkerConfig {
 	return SyncWorkerConfig{
 		MissingBlockRetry: MissingBlockRetryConfig{
-			RecheckThreshold:    10,              // - RecheckThreshold >= 1
-			RetryDelay:          1 * time.Second, // - TipRecheckThreshold >= 1 && TipRecheckThreshold <= RecheckThreshold
-			TipRecheckThreshold: 3,               // - RetryDelay > 0
+			RecheckThreshold:    10,
+			RetryDelay:          1 * time.Second,
+			TipRecheckThreshold: 3,
+			MaxStallDuration:    60 * time.Second,
 		},
 	}
 }
@@ -561,11 +567,14 @@ func (w *SyncWorker) getBlockWorker(i int, syncWorkers uint32, wg *sync.WaitGrou
 	var block *bchain.Block
 	cfg := w.missingBlockRetry
 	label := "getBlockWorker " + strconv.Itoa(i)
+	const checkErrStreakLimit = 3
 GetBlockLoop:
 	for hh := range hch {
 		// Track consecutive retryable errors per block so we only re-check the
 		// chain once the backend has had a chance to catch up.
 		retries := 0
+		checkErrStreak := 0
+		loopStart := time.Now()
 		for {
 			// Allow global shutdown or an abort to stop the retry loop promptly.
 			select {
@@ -589,10 +598,38 @@ GetBlockLoop:
 					}
 					restart, checkErr := w.onRetryableMiss(&retries, threshold, label, hh.height, hh.hash, err)
 					if checkErr != nil {
-						glog.Error("getBlockWorker ", i, " missing block check error ", checkErr)
-					} else if restart {
-						// The block hash at this height no longer exists; restart sync to realign.
-						glog.Warning("sync: block ", hh.height, " ", hh.hash, " no longer on chain, restarting sync")
+						checkErrStreak++
+						if checkErrStreak == 1 {
+							glog.Warningf("%s: chain-state probe failed for block %d %s (last: %v); will abort after %d consecutive failures",
+								label, hh.height, hh.hash, checkErr, checkErrStreakLimit)
+						}
+						if checkErrStreak >= checkErrStreakLimit {
+							// Backend cannot answer chain-state probes either; surface so the
+							// outer loop can decide how to recover instead of spinning silently.
+							glog.Errorf("%s: aborting after %d consecutive chain-state probe failures (last: %v)",
+								label, checkErrStreak, checkErr)
+							select {
+							case abortCh <- checkErr:
+							default:
+							}
+							return
+						}
+					} else {
+						checkErrStreak = 0
+						if restart {
+							// The block hash at this height no longer exists; restart sync to realign.
+							glog.Warning("sync: block ", hh.height, " ", hh.hash, " no longer on chain, restarting sync")
+							w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
+							select {
+							case abortCh <- errResync:
+							default:
+							}
+							return
+						}
+					}
+					if cfg.MaxStallDuration > 0 && time.Since(loopStart) >= cfg.MaxStallDuration {
+						glog.Warningf("%s: block %d %s stall deadline %s exceeded after %d retries (last: %v); yielding to resync",
+							label, hh.height, hh.hash, cfg.MaxStallDuration, retries, err)
 						w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
 						select {
 						case abortCh <- errResync:
@@ -613,6 +650,8 @@ GetBlockLoop:
 						return
 					}
 					retries = 0
+					checkErrStreak = 0
+					loopStart = time.Now()
 					glog.Error("getBlockWorker ", i, " connect block error ", err, ". Retrying...")
 				}
 				w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
@@ -782,6 +821,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 	if recheckThreshold <= 0 {
 		recheckThreshold = 1
 	}
+	maxStall := cfg.MaxStallDuration
 	// loop until error ErrBlockNotFound
 	for {
 		select {
@@ -792,6 +832,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 		default:
 		}
 		retries := 0
+		loopStart := time.Now()
 		var block *bchain.Block
 		var err error
 		for {
@@ -828,6 +869,17 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			if resync {
 				w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
 				out <- blockResult{err: errResync}
+				return
+			}
+			if maxStall > 0 && time.Since(loopStart) >= maxStall {
+				glog.Warningf("getBlockChain: block %d %s stall deadline %s exceeded after %d retries (last: %v); yielding to resync",
+					height, hash, maxStall, retries, err)
+				w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
+				select {
+				case out <- blockResult{err: errResync}:
+				case <-done:
+				case <-w.chanOsSignal:
+				}
 				return
 			}
 			w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()

--- a/db/sync.go
+++ b/db/sync.go
@@ -146,6 +146,7 @@ func (w *SyncWorker) ResyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 			w.is.FinishedSync(bh)
 		}
 		w.metrics.BackendBestHeight.Set(float64(w.is.BackendInfo.Blocks))
+		w.metrics.BackendTipAgeSeconds.Set(time.Since(w.is.GetBackendTipLastAdvance()).Seconds())
 		w.metrics.BlockbookBestHeight.Set(float64(bh))
 		return err
 	case errSynced:

--- a/db/sync.go
+++ b/db/sync.go
@@ -55,15 +55,45 @@ type SyncWorkerConfig struct {
 	MissingBlockRetry MissingBlockRetryConfig
 }
 
+// DefaultMissingBlockRetryConfig returns the built-in defaults used when no
+// per-chain override is supplied. Exported so blockbook.go can overlay
+// optional bchain.MissingBlockRetry fields onto known-good defaults.
+func DefaultMissingBlockRetryConfig() MissingBlockRetryConfig {
+	return MissingBlockRetryConfig{
+		RecheckThreshold:    10,
+		RetryDelay:          1 * time.Second,
+		TipRecheckThreshold: 3,
+		MaxStallDuration:    60 * time.Second,
+	}
+}
+
 func defaultSyncWorkerConfig() SyncWorkerConfig {
 	return SyncWorkerConfig{
-		MissingBlockRetry: MissingBlockRetryConfig{
-			RecheckThreshold:    10,
-			RetryDelay:          1 * time.Second,
-			TipRecheckThreshold: 3,
-			MaxStallDuration:    60 * time.Second,
-		},
+		MissingBlockRetry: DefaultMissingBlockRetryConfig(),
 	}
+}
+
+// ApplyMissingBlockRetryOverride overlays the optional bchain.MissingBlockRetry
+// onto the defaults. Zero / unset wire fields keep their default; out-of-range
+// values fall back to the default with a warning logged in the caller.
+func ApplyMissingBlockRetryOverride(o *bchain.MissingBlockRetry) MissingBlockRetryConfig {
+	cfg := DefaultMissingBlockRetryConfig()
+	if o == nil {
+		return cfg
+	}
+	if o.RetryDelayMs > 0 {
+		cfg.RetryDelay = time.Duration(o.RetryDelayMs) * time.Millisecond
+	}
+	if o.RecheckThreshold > 0 {
+		cfg.RecheckThreshold = o.RecheckThreshold
+	}
+	if o.TipRecheckThreshold > 0 {
+		cfg.TipRecheckThreshold = o.TipRecheckThreshold
+	}
+	if o.MaxStallMs > 0 {
+		cfg.MaxStallDuration = time.Duration(o.MaxStallMs) * time.Millisecond
+	}
+	return cfg
 }
 
 // NewSyncWorker creates new SyncWorker and returns its handle

--- a/db/sync.go
+++ b/db/sync.go
@@ -779,7 +779,10 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			if err == nil {
 				break
 			}
-			if stdErrors.Is(err, bchain.ErrBlockNotFound) {
+			// On the first ErrBlockNotFound, check whether we are past the backend tip
+			// so we exit cleanly at end-of-chain. Subsequent retries skip this RPC and
+			// defer to shouldRestartSyncOnMissingBlock at the threshold tick.
+			if notFoundRetries == 0 && stdErrors.Is(err, bchain.ErrBlockNotFound) {
 				bestHeight, bestErr := w.chain.GetBestBlockHeight()
 				if bestErr != nil {
 					out <- blockResult{err: bestErr}

--- a/db/sync.go
+++ b/db/sync.go
@@ -280,6 +280,7 @@ func (w *SyncWorker) handleFork(localBestHeight uint32, localBestHash string, on
 		}
 		hashes = append(hashes, local)
 	}
+	w.metrics.IndexReorgEvents.With(common.Labels{"type": "disconnect"}).Inc()
 	if err := w.DisconnectBlocks(height+1, localBestHeight, hashes); err != nil {
 		return err
 	}
@@ -576,6 +577,9 @@ GetBlockLoop:
 			}
 			block, err = w.chain.GetBlock(hh.hash, hh.height)
 			if err != nil {
+				if stdErrors.Is(err, bchain.ErrBlockNotFound) {
+					w.metrics.IndexBlockNotFoundRetries.Inc()
+				}
 				if isRetryableGetBlockError(err) {
 					threshold := cfg.RecheckThreshold
 					// Once the hash queue is closed we are at the tail of the range; use
@@ -589,6 +593,7 @@ GetBlockLoop:
 					} else if restart {
 						// The block hash at this height no longer exists; restart sync to realign.
 						glog.Warning("sync: block ", hh.height, " ", hh.hash, " no longer on chain, restarting sync")
+						w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
 						select {
 						case abortCh <- errResync:
 						default:
@@ -797,7 +802,8 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			// On the first ErrBlockNotFound, check whether we are past the backend tip
 			// so we exit cleanly at end-of-chain. Subsequent retries skip this RPC and
 			// defer to shouldRestartSyncOnMissingBlock at the threshold tick.
-			if retries == 0 && stdErrors.Is(err, bchain.ErrBlockNotFound) {
+			gotNotFound := stdErrors.Is(err, bchain.ErrBlockNotFound)
+			if retries == 0 && gotNotFound {
 				bestHeight, bestErr := w.chain.GetBestBlockHeight()
 				if bestErr != nil {
 					out <- blockResult{err: bestErr}
@@ -806,6 +812,9 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 				if height > bestHeight {
 					return
 				}
+			}
+			if gotNotFound {
+				w.metrics.IndexBlockNotFoundRetries.Inc()
 			}
 			if !isRetryableGetBlockError(err) {
 				out <- blockResult{err: err}
@@ -817,6 +826,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 				return
 			}
 			if resync {
+				w.metrics.IndexReorgEvents.With(common.Labels{"type": "resync"}).Inc()
 				out <- blockResult{err: errResync}
 				return
 			}
@@ -831,6 +841,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 		}
 		if block.Prev != "" && prevHash != "" && prevHash != block.Prev {
 			glog.Infof("sync: fork detected at height %d %s, local prevHash %s, remote prevHash %s", height, block.Hash, prevHash, block.Prev)
+			w.metrics.IndexReorgEvents.With(common.Labels{"type": "fork"}).Inc()
 			out <- blockResult{err: errFork}
 			return
 		}

--- a/db/sync.go
+++ b/db/sync.go
@@ -767,6 +767,8 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 		select {
 		case <-done:
 			return
+		case <-w.chanOsSignal:
+			return
 		default:
 		}
 		notFoundRetries := 0
@@ -806,6 +808,8 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			}
 			select {
 			case <-done:
+				return
+			case <-w.chanOsSignal:
 				return
 			case <-time.After(retryDelay):
 			}

--- a/db/sync.go
+++ b/db/sync.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -373,6 +374,22 @@ func (w *SyncWorker) shouldRestartSyncOnMissingBlock(height uint32, expectedHash
 	return currentHash != expectedHash, nil
 }
 
+// onRetryableMiss bumps the retry count and, once at threshold, rechecks chain
+// state. It emits a single warning at the crossover; below threshold it stays
+// quiet because transient backend lag (e.g. load-balanced RPC routing skew)
+// is expected. The per-error signal is preserved via the IndexResyncErrors metric.
+func (w *SyncWorker) onRetryableMiss(retries *int, threshold int, label string, height uint32, hash string, err error) (bool, error) {
+	*retries++
+	if *retries < threshold {
+		return false, nil
+	}
+	if *retries == threshold {
+		glog.Warningf("%s: block %d %s still missing after %d retries (last: %v); rechecking chain state",
+			label, height, hash, *retries, err)
+	}
+	return w.shouldRestartSyncOnMissingBlock(height, hash)
+}
+
 func isRetryableGetBlockError(err error) bool {
 	if err == nil {
 		return false
@@ -541,6 +558,7 @@ func (w *SyncWorker) getBlockWorker(i int, syncWorkers uint32, wg *sync.WaitGrou
 	var err error
 	var block *bchain.Block
 	cfg := w.missingBlockRetry
+	label := "getBlockWorker " + strconv.Itoa(i)
 GetBlockLoop:
 	for hh := range hch {
 		// Track consecutive retryable errors per block so we only re-check the
@@ -558,27 +576,23 @@ GetBlockLoop:
 			block, err = w.chain.GetBlock(hh.hash, hh.height)
 			if err != nil {
 				if isRetryableGetBlockError(err) {
-					retries++
-					glog.Error("getBlockWorker ", i, " connect block ", hh.height, " ", hh.hash, " error ", err, ". Retrying...")
 					threshold := cfg.RecheckThreshold
 					// Once the hash queue is closed we are at the tail of the range; use
 					// a smaller threshold to avoid stalling on a missing tip block.
 					if hchClosed.Load() == true {
 						threshold = cfg.TipRecheckThreshold
 					}
-					if retries >= threshold {
-						restart, checkErr := w.shouldRestartSyncOnMissingBlock(hh.height, hh.hash)
-						if checkErr != nil {
-							glog.Error("getBlockWorker ", i, " missing block check error ", checkErr)
-						} else if restart {
-							// The block hash at this height no longer exists; restart sync to realign.
-							glog.Warning("sync: block ", hh.height, " ", hh.hash, " no longer on chain, restarting sync")
-							select {
-							case abortCh <- errResync:
-							default:
-							}
-							return
+					restart, checkErr := w.onRetryableMiss(&retries, threshold, label, hh.height, hh.hash, err)
+					if checkErr != nil {
+						glog.Error("getBlockWorker ", i, " missing block check error ", checkErr)
+					} else if restart {
+						// The block hash at this height no longer exists; restart sync to realign.
+						glog.Warning("sync: block ", hh.height, " ", hh.hash, " no longer on chain, restarting sync")
+						select {
+						case abortCh <- errResync:
+						default:
 						}
+						return
 					}
 				} else {
 					// When the hash queue is closed, stop retrying non-retryable errors.
@@ -796,18 +810,14 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 				out <- blockResult{err: err}
 				return
 			}
-			retries++
-			glog.Error("getBlockChain connect block ", height, " ", hash, " error ", err, ". Retrying...")
-			if retries >= recheckThreshold {
-				restart, checkErr := w.shouldRestartSyncOnMissingBlock(height, hash)
-				if checkErr != nil {
-					out <- blockResult{err: checkErr}
-					return
-				}
-				if restart {
-					out <- blockResult{err: errResync}
-					return
-				}
+			resync, checkErr := w.onRetryableMiss(&retries, recheckThreshold, "getBlockChain", height, hash, err)
+			if checkErr != nil {
+				out <- blockResult{err: checkErr}
+				return
+			}
+			if resync {
+				out <- blockResult{err: errResync}
+				return
 			}
 			w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
 			select {

--- a/db/sync.go
+++ b/db/sync.go
@@ -806,6 +806,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 					return
 				}
 			}
+			w.metrics.IndexResyncErrors.With(common.Labels{"error": "failure"}).Inc()
 			select {
 			case <-done:
 				return

--- a/db/sync.go
+++ b/db/sync.go
@@ -753,6 +753,15 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 	hash := w.startHash
 	height := w.startHeight
 	prevHash := ""
+	cfg := w.missingBlockRetry
+	retryDelay := cfg.RetryDelay
+	if retryDelay <= 0 || retryDelay > 250*time.Millisecond {
+		retryDelay = 250 * time.Millisecond
+	}
+	recheckThreshold := cfg.TipRecheckThreshold
+	if recheckThreshold <= 0 {
+		recheckThreshold = 1
+	}
 	// loop until error ErrBlockNotFound
 	for {
 		select {
@@ -760,13 +769,46 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			return
 		default:
 		}
-		block, err := w.chain.GetBlock(hash, height)
-		if err != nil {
-			if stdErrors.Is(err, bchain.ErrBlockNotFound) {
+		notFoundRetries := 0
+		var block *bchain.Block
+		var err error
+		for {
+			block, err = w.chain.GetBlock(hash, height)
+			if err == nil {
 				break
 			}
-			out <- blockResult{err: err}
-			return
+			if stdErrors.Is(err, bchain.ErrBlockNotFound) {
+				bestHeight, bestErr := w.chain.GetBestBlockHeight()
+				if bestErr != nil {
+					out <- blockResult{err: bestErr}
+					return
+				}
+				if height > bestHeight {
+					return
+				}
+			}
+			if !isRetryableGetBlockError(err) {
+				out <- blockResult{err: err}
+				return
+			}
+			notFoundRetries++
+			glog.Error("getBlockChain connect block ", height, " ", hash, " error ", err, ". Retrying...")
+			if notFoundRetries >= recheckThreshold {
+				restart, checkErr := w.shouldRestartSyncOnMissingBlock(height, hash)
+				if checkErr != nil {
+					out <- blockResult{err: checkErr}
+					return
+				}
+				if restart {
+					out <- blockResult{err: errResync}
+					return
+				}
+			}
+			select {
+			case <-done:
+				return
+			case <-time.After(retryDelay):
+			}
 		}
 		if block.Prev != "" && prevHash != "" && prevHash != block.Prev {
 			glog.Infof("sync: fork detected at height %d %s, local prevHash %s, remote prevHash %s", height, block.Hash, prevHash, block.Prev)

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -8,13 +8,31 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	jujuErrors "github.com/juju/errors"
 	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/common"
 )
+
+var (
+	testMetricsOnce sync.Once
+	testMetrics     *common.Metrics
+)
+
+func getTestMetrics(t *testing.T) *common.Metrics {
+	testMetricsOnce.Do(func() {
+		m, err := common.GetMetrics("test")
+		if err != nil {
+			t.Fatalf("GetMetrics: %v", err)
+		}
+		testMetrics = m
+	})
+	return testMetrics
+}
 
 func TestIsRetryableGetBlockError(t *testing.T) {
 	tests := []struct {
@@ -155,7 +173,7 @@ func (c *getBlockChainTestChain) GetBlock(hash string, height uint32) (*bchain.B
 	return nil, bchain.ErrBlockNotFound
 }
 
-func newGetBlockChainTestWorker(chain *getBlockChainTestChain, startHash string, startHeight uint32) *SyncWorker {
+func newGetBlockChainTestWorker(t *testing.T, chain *getBlockChainTestChain, startHash string, startHeight uint32) *SyncWorker {
 	return &SyncWorker{
 		chain:       chain,
 		startHash:   startHash,
@@ -164,6 +182,7 @@ func newGetBlockChainTestWorker(chain *getBlockChainTestChain, startHash string,
 			TipRecheckThreshold: 2,
 			RetryDelay:          time.Millisecond,
 		},
+		metrics: getTestMetrics(t),
 	}
 }
 
@@ -190,7 +209,7 @@ func TestGetBlockChainRetriesSequentialTipBlock(t *testing.T) {
 		},
 		getBlockCalls: map[uint32]int{},
 	}
-	w := newGetBlockChainTestWorker(chain, "h1", 1)
+	w := newGetBlockChainTestWorker(t, chain, "h1", 1)
 
 	results := runGetBlockChain(w)
 	if len(results) != 1 {
@@ -215,7 +234,7 @@ func TestGetBlockChainStopsAboveBestHeight(t *testing.T) {
 		blockErrors:   map[uint32][]error{},
 		getBlockCalls: map[uint32]int{},
 	}
-	w := newGetBlockChainTestWorker(chain, "", 1)
+	w := newGetBlockChainTestWorker(t, chain, "", 1)
 
 	results := runGetBlockChain(w)
 	if len(results) != 0 {
@@ -234,7 +253,7 @@ func TestGetBlockChainMissingBlockChangedHashResyncs(t *testing.T) {
 		blockErrors:   map[uint32][]error{},
 		getBlockCalls: map[uint32]int{},
 	}
-	w := newGetBlockChainTestWorker(chain, "fake-hash", 1)
+	w := newGetBlockChainTestWorker(t, chain, "fake-hash", 1)
 
 	results := runGetBlockChain(w)
 	if len(results) != 1 {
@@ -259,7 +278,7 @@ func TestGetBlockChainNonRetryableErrorReturns(t *testing.T) {
 		},
 		getBlockCalls: map[uint32]int{},
 	}
-	w := newGetBlockChainTestWorker(chain, "h1", 1)
+	w := newGetBlockChainTestWorker(t, chain, "h1", 1)
 
 	results := runGetBlockChain(w)
 	if len(results) != 1 {

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -141,18 +142,28 @@ func TestIsRetryableGetBlockError(t *testing.T) {
 
 type getBlockChainTestChain struct {
 	bchain.BlockChain
-	bestHeight    uint32
-	hashes        map[uint32]string
-	blocks        map[uint32]*bchain.Block
-	blockErrors   map[uint32][]error
-	getBlockCalls map[uint32]int
+	bestHeight       uint32
+	bestHeightErr    error
+	bestHeightCalls  int
+	hashes           map[uint32]string
+	blocks           map[uint32]*bchain.Block
+	blockErrors      map[uint32][]error
+	getBlockCalls    map[uint32]int
+	getBlockHashErr  error
 }
 
 func (c *getBlockChainTestChain) GetBestBlockHeight() (uint32, error) {
+	c.bestHeightCalls++
+	if c.bestHeightErr != nil {
+		return 0, c.bestHeightErr
+	}
 	return c.bestHeight, nil
 }
 
 func (c *getBlockChainTestChain) GetBlockHash(height uint32) (string, error) {
+	if c.getBlockHashErr != nil {
+		return "", c.getBlockHashErr
+	}
 	if hash, ok := c.hashes[height]; ok {
 		return hash, nil
 	}
@@ -289,5 +300,107 @@ func TestGetBlockChainNonRetryableErrorReturns(t *testing.T) {
 	}
 	if calls := chain.getBlockCalls[1]; calls != 1 {
 		t.Fatalf("GetBlock height 1 calls = %d, want 1", calls)
+	}
+}
+
+func TestGetBlockChainWallClockCap(t *testing.T) {
+	// Block 1 exists on chain (so first ErrBlockNotFound does not short-circuit
+	// to "above best height") but GetBlock never produces it. TipRecheckThreshold
+	// is set high enough that the recheck path cannot fire before the cap.
+	chain := &getBlockChainTestChain{
+		bestHeight:    1,
+		hashes:        map[uint32]string{1: "h1"},
+		blocks:        map[uint32]*bchain.Block{},
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := &SyncWorker{
+		chain:       chain,
+		startHash:   "h1",
+		startHeight: 1,
+		missingBlockRetry: MissingBlockRetryConfig{
+			TipRecheckThreshold: 1_000_000,
+			RetryDelay:          time.Millisecond,
+			MaxStallDuration:    50 * time.Millisecond,
+		},
+		metrics: getTestMetrics(t),
+	}
+
+	start := time.Now()
+	results := runGetBlockChain(w)
+	elapsed := time.Since(start)
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if !stdErrors.Is(results[0].err, errResync) {
+		t.Fatalf("error = %v, want errResync", results[0].err)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("wall-clock cap returned in %v, expected at least 50ms", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("wall-clock cap took %v, expected to return shortly after 50ms", elapsed)
+	}
+	if calls := chain.getBlockCalls[1]; calls < 2 {
+		t.Fatalf("GetBlock height 1 calls = %d, want at least 2", calls)
+	}
+}
+
+func TestGetBlockWorkerCheckErrAbortsAfterStreak(t *testing.T) {
+	// GetBlock keeps returning ErrBlockNotFound (retryable). GetBestBlockHeight
+	// fails too, so onRetryableMiss returns (false, checkErr) on every call past
+	// the threshold. After three consecutive checkErrs the worker must surface
+	// the error via abortCh instead of spinning silently.
+	probeErr := stdErrors.New("backend unreachable")
+	chain := &getBlockChainTestChain{
+		bestHeight:    1,
+		bestHeightErr: probeErr,
+		hashes:        map[uint32]string{1: "h1"},
+		blocks:        map[uint32]*bchain.Block{},
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := &SyncWorker{
+		chain: chain,
+		missingBlockRetry: MissingBlockRetryConfig{
+			RecheckThreshold:    1,
+			TipRecheckThreshold: 1,
+			RetryDelay:          time.Millisecond,
+			MaxStallDuration:    10 * time.Second, // do not let the wall-clock cap fire first
+		},
+		metrics: getTestMetrics(t),
+	}
+
+	const workers = 1
+	hch := make(chan hashHeight, workers)
+	bch := make([]chan *bchain.Block, workers)
+	for i := range bch {
+		bch[i] = make(chan *bchain.Block, 1)
+	}
+	var hchClosed atomic.Value
+	hchClosed.Store(true)
+	terminating := make(chan struct{})
+	abortCh := make(chan error, 1)
+	hch <- hashHeight{hash: "h1", height: 1}
+	close(hch)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go w.getBlockWorker(0, workers, &wg, hch, bch, &hchClosed, terminating, abortCh)
+
+	select {
+	case err := <-abortCh:
+		if !stdErrors.Is(err, probeErr) {
+			t.Fatalf("abortCh got %v, want %v", err, probeErr)
+		}
+	case <-time.After(2 * time.Second):
+		close(terminating)
+		t.Fatalf("worker did not abort after consecutive checkErrs")
+	}
+
+	wg.Wait()
+	if chain.bestHeightCalls < 3 {
+		t.Fatalf("GetBestBlockHeight calls = %d, want at least 3", chain.bestHeightCalls)
 	}
 }

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"syscall"
 	"testing"
+	"time"
 
 	jujuErrors "github.com/juju/errors"
 	"github.com/trezor/blockbook/bchain"
@@ -117,5 +118,157 @@ func TestIsRetryableGetBlockError(t *testing.T) {
 				t.Fatalf("isRetryableGetBlockError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+type getBlockChainTestChain struct {
+	bchain.BlockChain
+	bestHeight    uint32
+	hashes        map[uint32]string
+	blocks        map[uint32]*bchain.Block
+	blockErrors   map[uint32][]error
+	getBlockCalls map[uint32]int
+}
+
+func (c *getBlockChainTestChain) GetBestBlockHeight() (uint32, error) {
+	return c.bestHeight, nil
+}
+
+func (c *getBlockChainTestChain) GetBlockHash(height uint32) (string, error) {
+	if hash, ok := c.hashes[height]; ok {
+		return hash, nil
+	}
+	return "", bchain.ErrBlockNotFound
+}
+
+func (c *getBlockChainTestChain) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	c.getBlockCalls[height]++
+	if errs := c.blockErrors[height]; len(errs) > 0 {
+		err := errs[0]
+		c.blockErrors[height] = errs[1:]
+		return nil, err
+	}
+	if block := c.blocks[height]; block != nil {
+		copy := *block
+		return &copy, nil
+	}
+	return nil, bchain.ErrBlockNotFound
+}
+
+func newGetBlockChainTestWorker(chain *getBlockChainTestChain, startHash string, startHeight uint32) *SyncWorker {
+	return &SyncWorker{
+		chain:       chain,
+		startHash:   startHash,
+		startHeight: startHeight,
+		missingBlockRetry: MissingBlockRetryConfig{
+			TipRecheckThreshold: 2,
+			RetryDelay:          time.Millisecond,
+		},
+	}
+}
+
+func runGetBlockChain(w *SyncWorker) []blockResult {
+	out := make(chan blockResult)
+	done := make(chan struct{})
+	go w.getBlockChain(out, done)
+	var results []blockResult
+	for res := range out {
+		results = append(results, res)
+	}
+	return results
+}
+
+func TestGetBlockChainRetriesSequentialTipBlock(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight: 1,
+		hashes:     map[uint32]string{1: "h1"},
+		blocks: map[uint32]*bchain.Block{
+			1: {BlockHeader: bchain.BlockHeader{Hash: "h1", Height: 1}},
+		},
+		blockErrors: map[uint32][]error{
+			1: {bchain.ErrBlockNotFound, bchain.ErrBlockNotFound},
+		},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(chain, "h1", 1)
+
+	results := runGetBlockChain(w)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].err != nil {
+		t.Fatalf("unexpected error: %v", results[0].err)
+	}
+	if results[0].block == nil || results[0].block.Hash != "h1" {
+		t.Fatalf("unexpected block: %+v", results[0].block)
+	}
+	if calls := chain.getBlockCalls[1]; calls != 3 {
+		t.Fatalf("GetBlock height 1 calls = %d, want 3", calls)
+	}
+}
+
+func TestGetBlockChainStopsAboveBestHeight(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight:    0,
+		hashes:        map[uint32]string{},
+		blocks:        map[uint32]*bchain.Block{},
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(chain, "", 1)
+
+	results := runGetBlockChain(w)
+	if len(results) != 0 {
+		t.Fatalf("got %d results, want 0: %+v", len(results), results)
+	}
+	if calls := chain.getBlockCalls[1]; calls != 1 {
+		t.Fatalf("GetBlock height 1 calls = %d, want 1", calls)
+	}
+}
+
+func TestGetBlockChainMissingBlockChangedHashResyncs(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight:    1,
+		hashes:        map[uint32]string{1: "real-hash"},
+		blocks:        map[uint32]*bchain.Block{},
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(chain, "fake-hash", 1)
+
+	results := runGetBlockChain(w)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if !stdErrors.Is(results[0].err, errResync) {
+		t.Fatalf("error = %v, want errResync", results[0].err)
+	}
+	if calls := chain.getBlockCalls[1]; calls != 2 {
+		t.Fatalf("GetBlock height 1 calls = %d, want 2", calls)
+	}
+}
+
+func TestGetBlockChainNonRetryableErrorReturns(t *testing.T) {
+	boom := stdErrors.New("boom")
+	chain := &getBlockChainTestChain{
+		bestHeight: 1,
+		hashes:     map[uint32]string{1: "h1"},
+		blocks:     map[uint32]*bchain.Block{},
+		blockErrors: map[uint32][]error{
+			1: {boom},
+		},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(chain, "h1", 1)
+
+	results := runGetBlockChain(w)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if !stdErrors.Is(results[0].err, boom) {
+		t.Fatalf("error = %v, want %v", results[0].err, boom)
+	}
+	if calls := chain.getBlockCalls[1]; calls != 1 {
+		t.Fatalf("GetBlock height 1 calls = %d, want 1", calls)
 	}
 }

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -22,16 +22,16 @@ import (
 var (
 	testMetricsOnce sync.Once
 	testMetrics     *common.Metrics
+	testMetricsErr  error
 )
 
 func getTestMetrics(t *testing.T) *common.Metrics {
 	testMetricsOnce.Do(func() {
-		m, err := common.GetMetrics("test")
-		if err != nil {
-			t.Fatalf("GetMetrics: %v", err)
-		}
-		testMetrics = m
+		testMetrics, testMetricsErr = common.GetMetrics("test")
 	})
+	if testMetricsErr != nil {
+		t.Fatalf("GetMetrics: %v", testMetricsErr)
+	}
 	return testMetrics
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,5 @@
 * [RocksDB](/docs/rocksdb.md) – Description of RocksDB structures used by Blockbook
 * [API](/docs/api.md) – Description of Blockbook API
 * [API (Tron specifics)](/docs/api-tron.md) – Tron-specific behavior and data extensions for API V2
+* [Sync](/docs/sync.md) – Sync-loop architecture and the `missingBlockRetry` troubleshooting knobs
 * [Testing](/docs/testing.md) – Description of tests used during Blockbook development

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,111 @@
+# Sync
+
+The sync engine connects blocks from the backend RPC into the local RocksDB index. It is driven by external block notifications (EVM `newHeads`, BTC ZMQ) and an internal periodic tick. This page documents the loop and the knobs that govern how it recovers from transient backend trouble.
+
+## Sync loop
+
+```
+   ┌────────────────────┐         ┌────────────────────────────┐
+   │ EVM newHeads       │         │ resyncIndexPeriodMs timer  │
+   │ BTC ZMQ block      │         │ (default 15 min)           │
+   └─────────┬──────────┘         └──────────────┬─────────────┘
+             │                                   │
+             ▼                                   │
+   ┌────────────────────────────┐                │
+   │ pushSynchronizationHandler │                │
+   │ (non-blocking send)        │                │
+   └─────────────┬──────────────┘                │
+                 │                               │
+                 ▼                               │
+        ┌────────────────────────────┐           │
+        │ chanSyncIndex (buffer 1)   │◄──────────┘
+        └─────────────┬──────────────┘
+                      │
+                      ▼
+        ┌────────────────────────────┐
+        │ TickAndDebounce            │
+        └─────────────┬──────────────┘
+                      │
+                      ▼
+        ┌────────────────────────────┐
+        │ syncIndexLoop              │ ── 1 extra retry after 2.5 s on err
+        └─────────────┬──────────────┘
+                      │
+                      ▼
+        ┌────────────────────────────┐
+        │ ResyncIndex                │
+        └─────────────┬──────────────┘
+                      │
+        ┌─────────────┼──────────────┬─────────────────────────┐
+        ▼             ▼              ▼                         ▼
+    errSynced     handleFork    connectBlocks         ParallelConnectBlocks
+    (no work)     (local fork)  (sequential tail)     (initial / EVM gap,
+                  DisconnectBlocks   │                N × getBlockWorker)
+                  then recurse       │                          │
+                                     ▼                          │
+                          ┌──────────────────────┐              │
+                          │ getBlockChain        │              │
+                          └──────────┬───────────┘              │
+                                     │                          │
+                                     └─────────────┬────────────┘
+                                                   │
+                                                   ▼
+   ┌───────────────────────────────────────────────────────────────────┐
+   │ per-block retry loop                                              │
+   │                                                                   │
+   │   GetBlock(hash, height)                                          │
+   │     ├─ OK                ─► emit blockResult ─► db.ConnectBlock   │
+   │     ├─ non-retryable err ─► propagate (outer loop decides)        │
+   │     └─ retryable err                                              │
+   │          │                                                        │
+   │          ▼                                                        │
+   │     onRetryableMiss                                               │
+   │     retries++                                                     │
+   │       ├─ retries ≥ threshold                                      │
+   │       │     shouldRestartSyncOnMissingBlock                       │
+   │       │       ├─ restart=true   ─► errResync                      │
+   │       │       │                    IndexReorgEvents{type=resync}  │
+   │       │       └─ probe err × 3  ─► abortCh                        │
+   │       │  (worker path only)        IndexSyncYields{probe_failed}  │
+   │       └─ time.Since(loopStart) ≥ MaxStallDuration                 │
+   │             ─► errResync                                          │
+   │                IndexSyncYields{reason=deadline}                   │
+   │                                                                   │
+   │   sleep RetryDelay  (shutdown-interruptible)                      │
+   │   loop                                                            │
+   └───────────────────────────────────────────────────────────────────┘
+```
+
+`errResync` and `errFork` cause `resyncIndex` to be re-entered (handling the new chain state); any other error propagates up and `syncIndexLoop` retries once before waiting for the next trigger.
+
+## Troubleshooting
+
+The retry policy is exposed per chain under `additional_params.missingBlockRetry` in `configs/coins/*.json`. Each field is optional; missing or `<= 0` values fall back to the built-in defaults below.
+
+| Knob                  | Current default | Where it bites                                                                  | Semantic                                                              |
+| --------------------- | --------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `RetryDelay`          | 1 s             | `getBlockWorker` (parallel) directly; `getBlockChain` clamps to ≤ 250 ms regardless | Sleep between successive `GetBlock` attempts for the same missing block |
+| `RecheckThreshold`    | 10              | `getBlockWorker` mid-queue                                                      | Retries before calling `shouldRestartSyncOnMissingBlock`              |
+| `TipRecheckThreshold` | 3               | both loops, at the tail                                                         | Retries before chain-state probe, when we're near the tip             |
+| `MaxStallDuration`    | 60 s            | both loops                                                                      | Wall-clock cap before yielding `errResync`                            |
+
+Example override (JSON keys are camelCase with the `Ms` suffix for durations):
+
+```json
+"additional_params": {
+    "missingBlockRetry": {
+        "retryDelayMs": 1000,
+        "recheckThreshold": 10,
+        "tipRecheckThreshold": 3,
+        "maxStallMs": 60000
+    }
+}
+```
+
+When an override is applied, blockbook logs one `sync: missingBlockRetry override applied: …` line at startup so you can confirm the effective values.
+
+Related Prometheus counters for observing the budget at runtime:
+
+- `blockbook_index_block_not_found_retries` — every transient `ErrBlockNotFound` observed during sync.
+- `blockbook_index_sync_yields{reason="deadline"|"probe_failed"}` — wall-clock cap fired vs chain-state probe failed three times.
+- `blockbook_index_reorg_events{type="fork"|"resync"|"disconnect"}` — real reorg signals (not stall yields).

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -4,76 +4,78 @@ The sync engine connects blocks from the backend RPC into the local RocksDB inde
 
 ## Sync loop
 
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"lineColor": "#6b7280", "primaryTextColor": "#111827"}}}%%
+flowchart TD
+    trigger["Notifications or periodic tick"]
+    debounce["TickAndDebounce"]
+    loop["syncIndexLoop<br/>retry once after 2.5 s on error"]
+    resync["ResyncIndex / resyncIndex"]
+    done["syncNotNeeded<br/>(no work)"]
+    fork["fork detected<br/>handleFork + DisconnectBlocks"]
+    mode{"connect mode"}
+    bulk["BulkConnectBlocks<br/>(large initial range)"]
+    parallel["ParallelConnectBlocks"]
+    sequential["connectBlocks + getBlockChain"]
+    fetch["per-block fetch/retry<br/>(see below)"]
+    connected["blocks connected"]
+    recover["errResync / errFork<br/>restart resyncIndex"]
+    failed["terminal error<br/>returns to syncIndexLoop"]
+
+    trigger --> debounce --> loop --> resync
+    resync --> done
+    resync --> fork --> resync
+    resync --> mode
+    mode -- "initial sync" --> bulk
+    mode -- "EVM gap" --> parallel
+    mode -- "tail" --> sequential
+    bulk --> fetch
+    parallel --> fetch
+    sequential --> fetch
+    fetch -- OK --> connected
+    fetch -- "chain changed" --> recover --> resync
+    fetch -- "terminal error" --> failed --> loop
+
+    classDef normal fill:#e7f0ff,stroke:#4078c0,color:#10243e;
+    classDef error fill:#ffecec,stroke:#c03535,color:#3b0a0a;
+
+    class trigger,debounce,loop,resync,done,fork,mode,bulk,parallel,sequential,fetch,connected,recover normal;
+    class failed error;
 ```
-   ┌────────────────────┐         ┌────────────────────────────┐
-   │ EVM newHeads       │         │ resyncIndexPeriodMs timer  │
-   │ BTC ZMQ block      │         │ (default 15 min)           │
-   └─────────┬──────────┘         └──────────────┬─────────────┘
-             │                                   │
-             ▼                                   │
-   ┌────────────────────────────┐                │
-   │ pushSynchronizationHandler │                │
-   │ (non-blocking send)        │                │
-   └─────────────┬──────────────┘                │
-                 │                               │
-                 ▼                               │
-        ┌────────────────────────────┐           │
-        │ chanSyncIndex (buffer 1)   │◄──────────┘
-        └─────────────┬──────────────┘
-                      │
-                      ▼
-        ┌────────────────────────────┐
-        │ TickAndDebounce            │
-        └─────────────┬──────────────┘
-                      │
-                      ▼
-        ┌────────────────────────────┐
-        │ syncIndexLoop              │ ── 1 extra retry after 2.5 s on err
-        └─────────────┬──────────────┘
-                      │
-                      ▼
-        ┌────────────────────────────┐
-        │ ResyncIndex                │
-        └─────────────┬──────────────┘
-                      │
-        ┌─────────────┼──────────────┬─────────────────────────┐
-        ▼             ▼              ▼                         ▼
-    errSynced     handleFork    connectBlocks         ParallelConnectBlocks
-    (no work)     (local fork)  (sequential tail)     (initial / EVM gap,
-                  DisconnectBlocks   │                N × getBlockWorker)
-                  then recurse       │                          │
-                                     ▼                          │
-                          ┌──────────────────────┐              │
-                          │ getBlockChain        │              │
-                          └──────────┬───────────┘              │
-                                     │                          │
-                                     └─────────────┬────────────┘
-                                                   │
-                                                   ▼
-   ┌───────────────────────────────────────────────────────────────────┐
-   │ per-block retry loop                                              │
-   │                                                                   │
-   │   GetBlock(hash, height)                                          │
-   │     ├─ OK                ─► emit blockResult ─► db.ConnectBlock   │
-   │     ├─ non-retryable err ─► propagate (outer loop decides)        │
-   │     └─ retryable err                                              │
-   │          │                                                        │
-   │          ▼                                                        │
-   │     onRetryableMiss                                               │
-   │     retries++                                                     │
-   │       ├─ retries ≥ threshold                                      │
-   │       │     shouldRestartSyncOnMissingBlock                       │
-   │       │       ├─ restart=true   ─► errResync                      │
-   │       │       │                    IndexReorgEvents{type=resync}  │
-   │       │       └─ probe err × 3  ─► abortCh                        │
-   │       │  (worker path only)        IndexSyncYields{probe_failed}  │
-   │       └─ time.Since(loopStart) ≥ MaxStallDuration                 │
-   │             ─► errResync                                          │
-   │                IndexSyncYields{reason=deadline}                   │
-   │                                                                   │
-   │   sleep RetryDelay  (shutdown-interruptible)                      │
-   │   loop                                                            │
-   └───────────────────────────────────────────────────────────────────┘
+
+The per-block retry loop is shared by `getBlockChain` and `getBlockWorker`. Probe errors are path-specific: `getBlockChain` propagates immediately, while workers retry until three consecutive probe failures.
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"actorBkg": "#e7f0ff", "actorBorder": "#4078c0", "actorTextColor": "#10243e", "activationBkgColor": "#e8f7ed", "activationBorderColor": "#2e8b57", "signalColor": "#6b7280", "signalTextColor": "#111827", "labelBoxBkgColor": "#fff6d7", "labelBoxBorderColor": "#b58400", "loopTextColor": "#312300", "noteBkgColor": "#f1ecff", "noteBorderColor": "#7a55c2"}}}%%
+sequenceDiagram
+    participant Fetch as getBlockChain/getBlockWorker
+    participant RPC as backend RPC
+    participant Probe as chain-state probe
+    participant DB as RocksDB
+
+    Fetch->>RPC: GetBlock(hash, height)
+    alt OK
+        RPC-->>Fetch: block
+        Fetch->>DB: ConnectBlock
+    else non-retryable error
+        Fetch-->>Fetch: propagate, except worker mid-queue retries
+    else retryable error
+        Fetch-->>Fetch: onRetryableMiss and increment retries
+        opt threshold reached
+            Fetch->>Probe: shouldRestartSyncOnMissingBlock
+            alt restart=true
+                Probe-->>Fetch: errResync
+            else restart=false
+                Probe-->>Fetch: keep retrying
+            else probe error
+                Probe-->>Fetch: getBlockChain propagates, worker after 3 failures
+            end
+        end
+        opt MaxStallDuration exceeded
+            Fetch-->>Fetch: errResync
+        end
+        Fetch-->>Fetch: sleep RetryDelay, then retry GetBlock
+    end
 ```
 
 `errResync` and `errFork` cause `resyncIndex` to be re-entered (handling the new chain state); any other error propagates up and `syncIndexLoop` retries once before waiting for the next trigger.


### PR DESCRIPTION
Less complex solution to this problem https://github.com/trezor/blockbook/pull/1491

Alternative solution : https://github.com/trezor/blockbook/issues/1515

### Problem
QuickNode can route Ethereum-compatible WebSocket `newHeads` notifications and follow-up HTTP JSON-RPC calls to different backend nodes.
When the subscription observes a new tip before the HTTP-routed node has the block, `eth_getBlockByNumber` or `eth_getBlockByHash` can transiently return `null`.

In the short-tail sequential sync path, `ErrBlockNotFound` currently escapes to the outer `syncIndexLoop` retry.
That waits 2.5 seconds and reruns the whole `ResyncIndex` entry path, slowing chain-tip indexing even though the failed RPC call itself is cheap.

### Proposition
Retry transient missing-tip block fetches inside the sequential `getBlockChain` loop before unwinding to `ResyncIndex`.

Keep the change narrow:
- no Ethereum RPC API changes
- no transport or routing changes
- no database format changes
- no changes to parallel or bulk sync behavior

### Implementation
Update `db/sync.go` in `getBlockChain` only.

Behavior:
- `ErrBlockNotFound` with requested height above backend best height remains normal end-of-chain.
- Retryable errors for a height at or below backend best height retry the same `GetBlock(hash, height)` locally.
- Retry classification reuses `isRetryableGetBlockError`.
- Retry threshold reuses `MissingBlockRetry.TipRecheckThreshold`.
- Retry delay is fast bounded: `min(MissingBlockRetry.RetryDelay, 250ms)`.
- After the threshold, recheck chain state with `shouldRestartSyncOnMissingBlock`.
- If the block hash/height no longer matches chain state, return `errResync` so existing reorg/resync handling runs.

Preserve existing reorg handling:
- local-best fork detection before `connectBlocks`
- in-stream `prevHash` versus `block.Prev` fork detection
- parallel and bulk missing-block retry behavior

### Tests
Add focused unit coverage for sequential sync:
- retries a block when backend best height says the block should exist
- stops normally when requested height is above backend best height
- returns through the existing resync path when a missing block's hash changes
- returns non-retryable `GetBlock` errors immediately

Run:
```sh
contrib/tests/run-unit-tests.sh ./db -run 'TestIsRetryableGetBlockError|TestGetBlockChain'
```

### Marginal change
I was originally told by quicknode support to extend trace_timeout to like 20s and I blindly did it however I think when the rpc call does not return in 10 seconds, there is probably something wrong with it or the network and it would just needlessly slow down syncing.

There are blocks for which the `debug_traceBlockByHash` might take a looong time and we don't want timeout on that, however we also don't want be hanging too long in case of some network partitions, etc.

# New metrics

All metrics carry the existing `coin` ConstLabel.

#### `blockbook_tip_age_seconds`
- **Type:** gauge.
- **Meaning:** seconds since `BackendInfo.Blocks` was last observed to advance.
- **Emitted for:** every chain (UTXO and EVM).
- **Notes:** updated whenever `SetBackendInfo` is called (every `ResyncIndex` cycle, ~2.5 s, plus the `storeInternalStateLoop` app-info tick). Seeded to "now" on the first observation so it never reads as "since the unix epoch."

#### `blockbook_average_block_time_seconds`
- **Type:** gauge.
- **Meaning:** configured nominal block cadence for the chain, in seconds.
- **Emitted with a nonzero value for:**
  - all EVM chains (required config, validated at startup),
  - bitcoin, bcash, litecoin, dogecoin, zcash (mainnet only — added in this change).
- **Emitted as `0` for:** every other UTXO chain (testnets, signet, regtest, altcoins without `averageBlockTimeMs` in `configs/coins/*.json`). Filter `> 0` when dividing.
- **Notes:** this is the *configured* protocol target (e.g. 12 s for Ethereum, 600 s for Bitcoin), not a measured rate. The measured rate is exposed separately as `blockbook_avg_block_period` (the existing gauge derived from the last 100 indexed blocks).

#### `blockbook_index_block_not_found_retries`
- **Type:** counter, no labels.
- **Meaning:** every `ErrBlockNotFound` response from the backend during sync, **excluding** legitimate end-of-chain (those are filtered out via the existing `height > bestHeight` early return in `getBlockChain`).
- **Incremented in:** `getBlockChain` and `getBlockWorker` retry loops.
- **What it tells you:** load-balanced RPC routing skew (e.g. QuickNode), backend-vs-indexer race conditions, or generally "the backend keeps telling us a block we expect doesn't exist."

#### `blockbook_index_reorg_events{type="..."}`
- **Type:** counter, single label `type`.
- **Label values:**
  - `fork` — mid-stream `prevHash` mismatch detected by `getBlockChain` (one block's `prev` doesn't match the previously fetched block's `hash`).
  - `resync` — `shouldRestartSyncOnMissingBlock` returned true, causing `errResync` to be dispatched (the block hash we asked for no longer exists at that height on the backend). **Reorg-only:** stall-related yields are tracked separately as `blockbook_index_sync_yields`, see below.
  - `disconnect` — local-best fork detected in `resyncIndex` before sync, causing `DisconnectBlocks` to roll back DB state. Manual CLI rollback via `--rollback` is intentionally NOT counted here (different code path).
- **Notes:** a single chain reorg can increment multiple types (e.g., `fork` then `disconnect` on the next cycle). The breakdown shows which detection path fires, not unique reorg events.

#### `blockbook_index_sync_yields{reason="..."}`
- **Type:** counter, single label `reason`.
- **Label values:**
  - `deadline` — `MaxStallDuration` (default 60 s) elapsed inside `getBlockChain` or `getBlockWorker` while retrying a missing block. The backend kept replying (often with `ErrBlockNotFound`) but never produced the requested block, so sync yielded to the outer resync machinery via `errResync`. The QuickNode 404-storm signal.
  - `probe_failed` — `getBlockWorker` saw three consecutive `shouldRestartSyncOnMissingBlock` failures (`GetBestBlockHeight` / `GetBlockHash` couldn't answer either). Stronger signal than `deadline`: the backend is unreachable for *any* call, not just specific block bodies.
- **Notes:** both reasons are *recovery* events, not reorg events. A spike here typically means a provider incident; correlate with `blockbook_index_block_not_found_retries` for `deadline` and with `blockbook_index_resync_errors{error="failure"}` for `probe_failed`. Previously these escalations were folded into `blockbook_index_reorg_events{type="resync"}`, which inflated the apparent reorg rate during backend incidents; that labelling has been corrected so `type="resync"` is now pure reorg signal.

### Suggested PromQL

```promql
# Backend flakiness rate (your QuickNode signal). Persistent > 0 = backend keeps lying about block existence.
rate(blockbook_index_block_not_found_retries[5m])

# How often is sync escalating to resync because of backend trouble (vs real chain events)?
sum by (reason) (rate(blockbook_index_sync_yields[5m]))

# Real DB rollbacks per hour — operationally interesting reorg signal.
increase(blockbook_index_reorg_events{type="disconnect"}[1h])

# Which reorg detection path is firing.
sum by (type) (rate(blockbook_index_reorg_events[5m]))

# Tip staleness normalized by chain cadence — "how many expected block intervals behind."
# Works uniformly across chains that emit a nonzero average_block_time_seconds.
blockbook_tip_age_seconds / blockbook_average_block_time_seconds > 0

# Indexer lag vs backend (chain-agnostic).
blockbook_backend_best_height - blockbook_best_height
```

### Suggested alerts

- **Backend stalled / lagging the network:** `blockbook_tip_age_seconds / blockbook_average_block_time_seconds > 5` for 5 m — backend hasn't advanced in ~5 expected blocks. Works across all chains with a configured cadence. For chains with `average_block_time_seconds == 0` (most UTXO testnets), fall back to raw `blockbook_tip_age_seconds > 1800` or skip.
- **Indexer falling behind a healthy backend:** `(blockbook_backend_best_height - blockbook_best_height) > 100` for 10 m.
- **Backend flakiness incident:** `rate(blockbook_index_block_not_found_retries[5m]) > 1` for 10 m — backend returning not-found for blocks that should exist at >1 per second sustained.
- **Sync stuck escalating to resync:** `rate(blockbook_index_sync_yields{reason="deadline"}[10m]) > 0` for 15 m — sync repeatedly hit `MaxStallDuration` and yielded; backend is producing the tip very slowly or not at all on this RPC node.
- **Backend unreachable:** `rate(blockbook_index_sync_yields{reason="probe_failed"}[5m]) > 0` for 5 m — chain-state probes are failing too. Page on-call.
- **Deep reorg activity:** `increase(blockbook_index_reorg_events{type="disconnect"}[1h]) > 3` — more than three real rollbacks per hour indicates either chain instability or upstream backend rollbacks (consensus issue, snapshot restore, etc.).

### Recommended dashboard panels

1. **Sync status (single-stat / table per coin):** `blockbook_tip_age_seconds`, `blockbook_average_block_time_seconds`, `blockbook_backend_best_height`, `blockbook_best_height`, and their difference. Gives the three-state distinction (synced / indexer-behind / backend-stale) at a glance.
2. **Backend hiccup rate (time series):** `rate(blockbook_index_block_not_found_retries[5m])`. Should be ~0 in steady state; spikes correlate with provider incidents.
3. **Reorg activity (stacked time series by `type`):** `rate(blockbook_index_reorg_events[5m])`. Each chain has a characteristic baseline; deviations are interesting. With the labelling cleanup, `type="resync"` is now pure reorg signal — stall yields show up in panel 5 instead.
4. **Normalized tip lag (time series):** `blockbook_tip_age_seconds / blockbook_average_block_time_seconds` filtered to coins where the denominator is nonzero — uniform y-axis across chains regardless of cadence.
5. **Sync recovery events (stacked time series by `reason`):** `rate(blockbook_index_sync_yields[5m])`. Should be ~0 in steady state; `deadline` spikes during 404 storms, `probe_failed` spikes during full-provider outages.

### What did NOT change

- `blockbook_index_resync_errors{error="failure"}` still emits the same way at the same call sites, so any existing dashboards/alerts keep working. The new counters are *additive*. If you want to retire the `error="failure"` panel, the new metrics cover its useful signals more precisely.
