### PR TITLE
Limit fiat timestamp requests

### DIFF
--- a/api/fiat_rates_api.go
+++ b/api/fiat_rates_api.go
@@ -10,6 +10,9 @@ import (
 	"github.com/trezor/blockbook/common"
 )
 
+// MaxFiatRatesTimestamps limits batch fiat-rate lookups to bounded request work.
+const MaxFiatRatesTimestamps = 1000
+
 // removeEmpty removes empty strings from a slice.
 func removeEmpty(stringSlice []string) []string {
 	ret := make([]string, 0, len(stringSlice))
@@ -127,6 +130,9 @@ func makeErrorRates(currencies []string) map[string]float32 {
 func (w *Worker) GetFiatRatesForTimestamps(timestamps []int64, currencies []string, token string) (*FiatTickers, error) {
 	if len(timestamps) == 0 {
 		return nil, NewAPIError("No timestamps provided", true)
+	}
+	if len(timestamps) > MaxFiatRatesTimestamps {
+		return nil, NewAPIError(fmt.Sprintf("too many timestamps, max %d", MaxFiatRatesTimestamps), true)
 	}
 	vsCurrency := ""
 	currencies = removeEmpty(currencies)

--- a/api/fiat_rates_api_test.go
+++ b/api/fiat_rates_api_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -188,6 +189,17 @@ func TestGetFiatRatesForTimestamps_EmptyInput(t *testing.T) {
 	apiErr := requireAPIError(t, err, true)
 	if apiErr.Text != "No timestamps provided" {
 		t.Fatalf("unexpected error text: got %q", apiErr.Text)
+	}
+}
+
+func TestGetFiatRatesForTimestamps_LimitsInput(t *testing.T) {
+	w := &Worker{}
+	timestamps := make([]int64, MaxFiatRatesTimestamps+1)
+	_, err := w.GetFiatRatesForTimestamps(timestamps, []string{"usd"}, "")
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("too many timestamps, max %d", MaxFiatRatesTimestamps)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
 	}
 }
 

--- a/server/public.go
+++ b/server/public.go
@@ -1700,6 +1700,9 @@ func (s *PublicServer) apiTickers(r *http.Request, apiVersion int) (interface{},
 }
 
 func countCommaSeparatedValues(s string, limit int) int {
+	if s == "" {
+		return 0
+	}
 	count := 1
 	for i := 0; i < len(s); i++ {
 		if s[i] == ',' {

--- a/server/public.go
+++ b/server/public.go
@@ -1699,6 +1699,19 @@ func (s *PublicServer) apiTickers(r *http.Request, apiVersion int) (interface{},
 	return result, nil
 }
 
+func countCommaSeparatedValues(s string, limit int) int {
+	count := 1
+	for i := 0; i < len(s); i++ {
+		if s[i] == ',' {
+			count++
+			if count > limit {
+				return count
+			}
+		}
+	}
+	return count
+}
+
 // apiMultiTickers returns FiatRates ticker prices for the specified comma separated list of timestamps.
 func (s *PublicServer) apiMultiTickers(r *http.Request, apiVersion int) (interface{}, error) {
 	var result []api.FiatTicker
@@ -1713,6 +1726,9 @@ func (s *PublicServer) apiMultiTickers(r *http.Request, apiVersion int) (interfa
 	if timestampString := r.URL.Query().Get("timestamp"); timestampString != "" {
 		// Get tickers for specified timestamp
 		s.metrics.ExplorerViews.With(common.Labels{"action": "api-multi-tickers-date"}).Inc()
+		if countCommaSeparatedValues(timestampString, api.MaxFiatRatesTimestamps) > api.MaxFiatRatesTimestamps {
+			return nil, api.NewAPIError(fmt.Sprintf("too many timestamps, max %d", api.MaxFiatRatesTimestamps), true)
+		}
 		timestamps := strings.Split(timestampString, ",")
 		t := make([]int64, len(timestamps))
 		for i := range timestamps {

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -2692,3 +2692,24 @@ func Test_validateIntValue_gapClamp(t *testing.T) {
 		})
 	}
 }
+
+func Test_countCommaSeparatedValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		limit int
+		want  int
+	}{
+		{"empty string", "", api.MaxFiatRatesTimestamps, 0},
+		{"single value", "1", api.MaxFiatRatesTimestamps, 1},
+		{"stops after limit exceeded", "1,2,3", 2, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countCommaSeparatedValues(tt.value, tt.limit); got != tt.want {
+				t.Errorf("countCommaSeparatedValues(%q, %d) = %d, want %d", tt.value, tt.limit, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/linxGnu/grocksdb"
 	"github.com/martinboehm/btcutil/chaincfg"
+	"github.com/trezor/blockbook/api"
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/bchain/coins/btc"
 	"github.com/trezor/blockbook/common"
@@ -773,6 +774,15 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			contentType: "application/json; charset=utf-8",
 			body: []string{
 				`{"error":"Parameter 'timestamp' does not contain a valid Unix timestamp."}`,
+			},
+		},
+		{
+			name:        "apiMultiFiatRates timestamp limit",
+			r:           newGetRequest(ts.URL + "/api/v2/multi-tickers?timestamp=" + strings.Repeat("1,", api.MaxFiatRatesTimestamps) + "1&currency=usd"),
+			status:      http.StatusBadRequest,
+			contentType: "application/json; charset=utf-8",
+			body: []string{
+				`{"error":"too many timestamps, max ` + strconv.Itoa(api.MaxFiatRatesTimestamps) + `"}`,
 			},
 		},
 		{
@@ -1702,6 +1712,17 @@ var websocketTestsBitcoinType = []websocketTest{
 			},
 		},
 		want: `{"id":"44","data":{"error":{"message":"not supported"}}}`,
+	},
+	{
+		name: "websocket getFiatRatesForTimestamps timestamp limit",
+		req: websocketReq{
+			Method: "getFiatRatesForTimestamps",
+			Params: map[string]interface{}{
+				"currencies": []string{"usd"},
+				"timestamps": make([]int64, api.MaxFiatRatesTimestamps+1),
+			},
+		},
+		want: `{"id":"45","data":{"error":{"message":"too many timestamps, max ` + strconv.Itoa(api.MaxFiatRatesTimestamps) + `"}}}`,
 	},
 }
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -33,6 +33,7 @@ const defaultTimeout = 60 * time.Second
 const unknownMethodLabel = "unknown"
 const maxWebsocketMessageBytes int64 = 4 * 1024 * 1024
 const maxWebsocketPendingRequests = 48
+const maxWebsocketActiveRequests = 2048
 const maxWebsocketConnectionAttemptsPerIP = 64
 const maxWebsocketConnectionsPerIP = 128
 const maxWebsocketEstimateFeeBlocks = 32
@@ -109,6 +110,7 @@ type WebsocketServer struct {
 	shutdownMu     sync.Mutex
 	shuttingDown   bool
 	activeChannels map[*websocketChannel]struct{}
+	activeRequests int
 	requestWg      sync.WaitGroup
 }
 
@@ -522,17 +524,26 @@ func (s *WebsocketServer) unregisterChannel(c *websocketChannel) {
 // that get true must invoke workDone exactly once when the goroutine they
 // spawn returns. Used to gate goroutines that touch the DB/chain/api so that
 // Shutdown can wait for them to drain before RocksDB is closed.
-func (s *WebsocketServer) trackWork() bool {
+func (s *WebsocketServer) trackWork() (bool, string) {
 	s.shutdownMu.Lock()
 	defer s.shutdownMu.Unlock()
 	if s.shuttingDown {
-		return false
+		return false, "server_shutdown"
 	}
+	if s.activeRequests >= maxWebsocketActiveRequests {
+		return false, "work_limit"
+	}
+	s.activeRequests++
 	s.requestWg.Add(1)
-	return true
+	return true, ""
 }
 
 func (s *WebsocketServer) workDone() {
+	s.shutdownMu.Lock()
+	if s.activeRequests > 0 {
+		s.activeRequests--
+	}
+	s.shutdownMu.Unlock()
 	s.requestWg.Done()
 }
 
@@ -665,9 +676,9 @@ func (s *WebsocketServer) inputLoop(c *websocketChannel) {
 				s.closeChannel(c, "pending_requests_limit")
 				return
 			}
-			if !s.trackWork() {
+			if ok, reason := s.trackWork(); !ok {
 				c.releaseRequestSlot()
-				s.closeChannel(c, "server_shutdown")
+				s.closeChannel(c, reason)
 				return
 			}
 			go func(req WsReq) {
@@ -1641,7 +1652,7 @@ func (s *WebsocketServer) publishNewBlockTxsByAddr(block *bchain.Block) {
 		observeNewBlockTxDuration(s.metrics, "match", matchStart)
 		if len(subscribed) > 0 {
 			incNewBlockTxMetric(s.metrics, "matched", "success", 1)
-			if !s.trackWork() {
+			if ok, _ := s.trackWork(); !ok {
 				return
 			}
 			// Convert and publish asynchronously so heavy tx conversion does not
@@ -1679,7 +1690,7 @@ func (s *WebsocketServer) OnNewBlock(block *bchain.Block) {
 	go s.onNewBlockAsync(block.Hash, block.Height)
 	if s.newBlockTxsSubscriptionCount > 0 {
 		// Skip per-tx address matching when nobody opted into newBlockTxs.
-		if s.trackWork() {
+		if ok, _ := s.trackWork(); ok {
 			go func() {
 				defer s.workDone()
 				s.publishNewBlockTxsByAddr(block)
@@ -1824,7 +1835,7 @@ func (s *WebsocketServer) onNewTxAsync(tx *bchain.MempoolTx, subscribed map[stri
 func (s *WebsocketServer) OnNewTx(tx *bchain.MempoolTx) {
 	subscribed := s.getNewTxSubscriptions(tx.Vin, tx.Vout, tx.TokenTransfers, nil, false)
 	if len(s.newTransactionSubscriptions) > 0 || len(subscribed) > 0 {
-		if s.trackWork() {
+		if ok, _ := s.trackWork(); ok {
 			go func() {
 				defer s.workDone()
 				s.onNewTxAsync(tx, subscribed)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -678,6 +678,15 @@ func (s *WebsocketServer) inputLoop(c *websocketChannel) {
 			}
 			if ok, reason := s.trackWork(); !ok {
 				c.releaseRequestSlot()
+				if reason == "work_limit" {
+					e := resultError{}
+					e.Error.Message = reason
+					c.DataOut(&WsRes{
+						ID:   req.ID,
+						Data: e,
+					})
+					continue
+				}
 				s.closeChannel(c, reason)
 				return
 			}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -810,8 +810,8 @@ func newShutdownTestServer() *WebsocketServer {
 
 func TestWebsocketShutdownWaitsForInFlightWork(t *testing.T) {
 	s := newShutdownTestServer()
-	if !s.trackWork() {
-		t.Fatal("trackWork() returned false before shutdown")
+	if ok, reason := s.trackWork(); !ok {
+		t.Fatalf("trackWork() returned false before shutdown, reason %q", reason)
 	}
 
 	finished := make(chan struct{})
@@ -841,8 +841,8 @@ func TestWebsocketShutdownWaitsForInFlightWork(t *testing.T) {
 
 func TestWebsocketShutdownTimesOutOnStuckWork(t *testing.T) {
 	s := newShutdownTestServer()
-	if !s.trackWork() {
-		t.Fatal("trackWork() returned false before shutdown")
+	if ok, reason := s.trackWork(); !ok {
+		t.Fatalf("trackWork() returned false before shutdown, reason %q", reason)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
@@ -875,12 +875,29 @@ func TestWebsocketShutdownRefusesNewWork(t *testing.T) {
 	if err := s.Shutdown(ctx); err != nil {
 		t.Fatalf("Shutdown() = %v, want nil", err)
 	}
-	if s.trackWork() {
-		t.Fatal("trackWork() returned true after shutdown")
+	if ok, reason := s.trackWork(); ok || reason != "server_shutdown" {
+		t.Fatalf("trackWork() = %v, %q after shutdown, want false, server_shutdown", ok, reason)
 	}
 	dummy := &websocketChannel{}
 	if s.registerChannel(dummy) {
 		t.Fatal("registerChannel() returned true after shutdown")
+	}
+}
+
+func TestWebsocketTrackWorkAppliesGlobalLimit(t *testing.T) {
+	s := newShutdownTestServer()
+	s.activeRequests = maxWebsocketActiveRequests
+	if ok, reason := s.trackWork(); ok || reason != "work_limit" {
+		t.Fatalf("trackWork() = %v, %q at global limit, want false, work_limit", ok, reason)
+	}
+
+	s.activeRequests = 0
+	if ok, reason := s.trackWork(); !ok || reason != "" {
+		t.Fatalf("trackWork() = %v, %q below global limit, want true, empty reason", ok, reason)
+	}
+	s.workDone()
+	if s.activeRequests != 0 {
+		t.Fatalf("activeRequests = %d after workDone, want 0", s.activeRequests)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a shared 1000-timestamp maximum for fiat-rate timestamp lookups.
- Count REST timestamp values before splitting the query parameter.
- Add a global WebSocket active request limit alongside the per-connection pending request limit.

## Why
This keeps fiat-rate batch lookups and WebSocket work bounded under large caller-provided input while preserving existing small batch behavior.

## Validation
- contrib/tests/run-unit-tests.sh -run 'Test(GetFiatRatesForTimestamps_LimitsInput|WebsocketTrackWorkAppliesGlobalLimit)$'
- contrib/tests/run-unit-tests.sh -run 'Test_PublicServer_BitcoinType$'
- contrib/tests/run-unit-tests.sh