### PR TITLE
fix(cache): accumulate address-hotness hits across blocks

### DIFF
--- a/db/address_hotness.go
+++ b/db/address_hotness.go
@@ -84,7 +84,11 @@ func (h *addressHotness) BeginBlock() {
 	// delays a promotion and never affects correctness (lookups fall back to a
 	// linear scan when the index is not used). The LRU survives across blocks.
 	if len(h.hits) > h.maxPendingHits {
-		clear(h.hits)
+		// Reinitialize rather than clear(): Go's clear() does not shrink a map's
+		// underlying bucket allocation, so a single oversized block would leave the
+		// allocation at its high-water mark. Pre-size to maxPendingHits, the
+		// steady-state ceiling, so the oversized buckets can be released.
+		h.hits = make(map[addressHotnessKey]uint16, h.maxPendingHits)
 	}
 	// Reset per-block stats counters (metrics report per-block deltas).
 	h.blockEligibleLookups = 0

--- a/db/address_hotness.go
+++ b/db/address_hotness.go
@@ -32,9 +32,14 @@ type addressHotness struct {
 	minHits      int
 	lru          *hotAddressLRU
 	onEvict      func(addressHotnessKey)
-	// hits tracks per-block lookup counts so we can decide when an address is hot.
-	// It is cleared at BeginBlock to avoid unbounded growth.
+	// hits tracks lookup counts so we can decide when an address is hot. Counts
+	// accumulate across blocks so an address that recurs over several blocks (not
+	// only within one busy block) can become hot; the map is reset in BeginBlock
+	// once it grows past maxPendingHits to keep memory bounded.
 	hits map[addressHotnessKey]uint16
+	// maxPendingHits bounds the hits map (set to the LRU size, the natural ceiling
+	// for promotion candidates).
+	maxPendingHits int
 	// block stats (reset after reporting) to keep logging cheap.
 	// blockEligibleLookups counts lookups with contractCount >= minContracts (i.e., eligible for hotness).
 	blockEligibleLookups uint64
@@ -51,11 +56,11 @@ func newAddressHotness(minContracts, lruSize, minHits int) *addressHotness {
 		return nil
 	}
 	return &addressHotness{
-		minContracts: minContracts,
-		minHits:      minHits,
-		lru:          newHotAddressLRU(lruSize),
-		// Pre-size the per-block hit map to avoid reallocs on busy blocks.
-		hits: make(map[addressHotnessKey]uint16),
+		minContracts:   minContracts,
+		minHits:        minHits,
+		lru:            newHotAddressLRU(lruSize),
+		maxPendingHits: lruSize,
+		hits:           make(map[addressHotnessKey]uint16),
 	}
 }
 
@@ -72,9 +77,16 @@ func (h *addressHotness) BeginBlock() {
 	if h == nil {
 		return
 	}
-	// Reset per-block hit counts; LRU survives across blocks.
-	clear(h.hits)
-	// Reset per-block stats counters.
+	// Hit counts accumulate across blocks so addresses looked up repeatedly over
+	// several blocks (not only within one busy block) can become hot — this lets
+	// the index help lower-throughput chains, not just very busy ones. Reset only
+	// when the candidate map grows past its bound; dropping pending counts merely
+	// delays a promotion and never affects correctness (lookups fall back to a
+	// linear scan when the index is not used). The LRU survives across blocks.
+	if len(h.hits) > h.maxPendingHits {
+		clear(h.hits)
+	}
+	// Reset per-block stats counters (metrics report per-block deltas).
 	h.blockEligibleLookups = 0
 	h.blockLRUHits = 0
 	h.blockPromotions = 0

--- a/db/address_hotness_test.go
+++ b/db/address_hotness_test.go
@@ -122,7 +122,7 @@ func Test_addressHotness_LRUEvictionHook(t *testing.T) {
 }
 
 func Test_addressHotness_Specs(t *testing.T) {
-	t.Run("it should reset per-block hits", func(t *testing.T) {
+	t.Run("it should accumulate hits across blocks", func(t *testing.T) {
 		hot := newAddressHotness(1, 2, 2)
 		if hot == nil {
 			t.Fatal("expected hotness tracker to be initialized")
@@ -133,8 +133,30 @@ func Test_addressHotness_Specs(t *testing.T) {
 			t.Fatal("expected first hit to stay cold")
 		}
 		hot.BeginBlock()
-		if hot.ShouldUseIndex(key, 1) {
-			t.Fatal("expected hit count to reset between blocks")
+		if !hot.ShouldUseIndex(key, 1) {
+			t.Fatal("expected hit counts to accumulate across blocks and promote")
+		}
+	})
+
+	t.Run("it should reset pending hits once the candidate map exceeds its bound", func(t *testing.T) {
+		// lruSize (and thus maxPendingHits) is 1 here.
+		hot := newAddressHotness(1, 1, 2)
+		if hot == nil {
+			t.Fatal("expected hotness tracker to be initialized")
+		}
+		a := makeHotKey(30)
+		b := makeHotKey(31)
+		hot.BeginBlock()
+		if hot.ShouldUseIndex(a, 1) {
+			t.Fatal("expected first hit on A to stay cold")
+		}
+		if hot.ShouldUseIndex(b, 1) {
+			t.Fatal("expected first hit on B to stay cold")
+		}
+		// hits now holds 2 pending entries > maxPendingHits (1), so BeginBlock clears it.
+		hot.BeginBlock()
+		if hot.ShouldUseIndex(a, 1) {
+			t.Fatal("expected A's pending hit to be cleared once the bound was exceeded")
 		}
 	})
 


### PR DESCRIPTION
## What

Make the address-hotness `hits` counter accumulate **across blocks** instead of resetting every block. The candidate map is now reset only when it grows past `maxPendingHits` (= LRU size), keeping memory bounded.

## Why

Promotion into the contract-index LRU previously required `min_hits` lookups of the same fat address **within a single block**. That only happens reliably on very high-throughput chains (e.g. BSC), so the index — and the sync speedup it was built for — effectively never kicked in elsewhere. A fat address recurring 1–2×/block reset to zero every block and never promoted.

Accumulating across blocks lets those addresses become hot on lower-throughput chains too. BSC only improves (it promotes faster as well).

## Safety

- **Correctness-neutral by construction:** `ShouldUseIndex` only toggles the index-vs-linear-scan path in `findContractIndex`; both return identical results. Promotion timing cannot affect data.
- **Memory bounded:** pending map capped at `lruSize`; promoted addresses are still capped by the existing LRU ceiling (~1 MB total at the 20k default).
- **No new config knob** — deliberately self-contained to avoid the config-propagation surface.

## Tests

Updated/added spec tests for cross-block accumulation and the size-bounded reset; all hotness + ethereum-type rocksdb tests pass, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)