### PR TITLE
fix(sync): prevent sync stalls on load-balanced EVM RPC skew

### DIFF
--- a/db/sync.go
+++ b/db/sync.go
@@ -119,6 +119,14 @@ func NewSyncWorkerWithConfig(db *RocksDB, chain bchain.BlockChain, syncWorkers, 
 	if cfg != nil {
 		effectiveCfg = *cfg
 	}
+	// MaxStallDuration is the load-bearing liveness cap (see its doc): the retry
+	// loops disable the cap when it's <= 0, which would let a chain-shortening
+	// reorg spin forever. Enforce the invariant structurally here so every caller
+	// (including tests passing a partial cfg) gets a safe value, not just the
+	// ApplyMissingBlockRetryOverride path.
+	if effectiveCfg.MissingBlockRetry.MaxStallDuration <= 0 {
+		effectiveCfg.MissingBlockRetry.MaxStallDuration = DefaultMissingBlockRetryConfig().MaxStallDuration
+	}
 	return &SyncWorker{
 		db:                db,
 		chain:             chain,

--- a/db/sync.go
+++ b/db/sync.go
@@ -43,10 +43,11 @@ type MissingBlockRetryConfig struct {
 	TipRecheckThreshold int
 	// RetryDelay keeps retry pressure low while still reacting quickly to transient backend gaps.
 	RetryDelay time.Duration
-	// MaxStallDuration caps the wall-clock time a single block fetch may spend
-	// in the retry loop before yielding control to the outer resync machinery.
-	// Without this cap, a backend that keeps returning ErrBlockNotFound while
-	// shouldRestartSyncOnMissingBlock keeps reporting "no reorg" loops forever.
+	// MaxStallDuration caps the wall-clock time a single block fetch may spend in
+	// the retry loop before yielding errResync. Liveness invariant: since lagging
+	// probes report "no reorg" and known hashes get retried, a genuinely-behind
+	// backend or chain-shortening reorg relies on this cap. Must stay > 0
+	// (ApplyMissingBlockRetryOverride enforces it).
 	MaxStallDuration time.Duration
 }
 
@@ -255,44 +256,44 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 			return err
 		}
 		if remoteBestHeight < w.startHeight {
-			glog.Error("resync: error - remote best height ", remoteBestHeight, " less than sync start height ", w.startHeight)
-			return errors.New("resync: remote best height error")
-		}
-		if initialSync {
-			if remoteBestHeight-w.startHeight > uint32(w.syncChunk) {
-				glog.Infof("resync: bulk sync of blocks %d-%d, using %d workers", w.startHeight, remoteBestHeight, w.syncWorkers)
-				// Bulk sync can encounter a disappearing block hash during reorgs.
-				// When that happens, it returns errResync to trigger a full restart.
-				err = w.BulkConnectBlocks(w.startHeight, remoteBestHeight)
-				if err != nil {
-					if stdErrors.Is(err, errResync) {
-						// block hash changed during parallel sync, restart the full resync
-						return w.resyncIndex(onNewBlock, initialSync)
+			glog.Warning("resync: observed remote best height ", remoteBestHeight, " less than sync start height ", w.startHeight, ", falling back to sequential sync")
+		} else {
+			if initialSync {
+				if remoteBestHeight-w.startHeight > uint32(w.syncChunk) {
+					glog.Infof("resync: bulk sync of blocks %d-%d, using %d workers", w.startHeight, remoteBestHeight, w.syncWorkers)
+					// Bulk sync can encounter a disappearing block hash during reorgs.
+					// When that happens, it returns errResync to trigger a full restart.
+					err = w.BulkConnectBlocks(w.startHeight, remoteBestHeight)
+					if err != nil {
+						if stdErrors.Is(err, errResync) {
+							// block hash changed during parallel sync, restart the full resync
+							return w.resyncIndex(onNewBlock, initialSync)
+						}
+						return err
 					}
-					return err
+					// after parallel load finish the sync using standard way,
+					// new blocks may have been created in the meantime
+					return w.resyncIndex(onNewBlock, initialSync)
 				}
-				// after parallel load finish the sync using standard way,
-				// new blocks may have been created in the meantime
-				return w.resyncIndex(onNewBlock, initialSync)
 			}
-		}
-		if w.chain.GetChainParser().GetChainType() == bchain.ChainEthereumType {
-			syncWorkers := uint32(4)
-			if remoteBestHeight-w.startHeight >= syncWorkers {
-				glog.Infof("resync: parallel sync of blocks %d-%d, using %d workers", w.startHeight, remoteBestHeight, syncWorkers)
-				// Parallel sync also returns errResync when a requested hash no longer
-				// exists at its height; restart to realign with the canonical chain.
-				err = w.ParallelConnectBlocks(onNewBlock, w.startHeight, remoteBestHeight, syncWorkers)
-				if err != nil {
-					if stdErrors.Is(err, errResync) {
-						// block hash changed during parallel sync, restart the full resync
-						return w.resyncIndex(onNewBlock, initialSync)
+			if w.chain.GetChainParser().GetChainType() == bchain.ChainEthereumType {
+				syncWorkers := uint32(4)
+				if remoteBestHeight-w.startHeight >= syncWorkers {
+					glog.Infof("resync: parallel sync of blocks %d-%d, using %d workers", w.startHeight, remoteBestHeight, syncWorkers)
+					// Parallel sync also returns errResync when a requested hash no longer
+					// exists at its height; restart to realign with the canonical chain.
+					err = w.ParallelConnectBlocks(onNewBlock, w.startHeight, remoteBestHeight, syncWorkers)
+					if err != nil {
+						if stdErrors.Is(err, errResync) {
+							// block hash changed during parallel sync, restart the full resync
+							return w.resyncIndex(onNewBlock, initialSync)
+						}
+						return err
 					}
-					return err
+					// after parallel load finish the sync using standard way,
+					// new blocks may have been created in the meantime
+					return w.resyncIndex(onNewBlock, initialSync)
 				}
-				// after parallel load finish the sync using standard way,
-				// new blocks may have been created in the meantime
-				return w.resyncIndex(onNewBlock, initialSync)
 			}
 		}
 	}
@@ -400,21 +401,37 @@ type hashHeight struct {
 	height uint32
 }
 
+// sendHashHeight queues hh but stays abort-aware: if a full hch made this a blocking
+// send, the coordinator could never read abortCh and sync would wedge. On abort hh is
+// intentionally dropped since the round is being torn down anyway.
+func (w *SyncWorker) sendHashHeight(hch chan<- hashHeight, abortCh <-chan error, hh hashHeight) error {
+	select {
+	case hch <- hh:
+		return nil
+	case abortErr := <-abortCh:
+		return abortErr
+	case <-w.chanOsSignal:
+		return ErrOperationInterrupted
+	}
+}
+
 func (w *SyncWorker) shouldRestartSyncOnMissingBlock(height uint32, expectedHash string) (bool, error) {
-	// When a block hash disappears at a given height, it usually indicates a
-	// reorg/rollback. Confirm by checking the current tip and block hash.
+	// When a block hash disappears at a given height, it can indicate a
+	// reorg/rollback, but on load-balanced EVM RPCs a single lagging backend can
+	// also report an older tip. Only restart immediately when another probe can
+	// prove the height exists with a different hash; otherwise let the retry
+	// loop or wall-clock cap yield control to the outer resync.
 	bestHeight, err := w.chain.GetBestBlockHeight()
 	if err != nil {
 		return false, err
 	}
 	if bestHeight < height {
-		// The tip moved below the requested height, so this block is no longer valid.
-		return true, nil
+		return false, nil
 	}
 	currentHash, err := w.chain.GetBlockHash(height)
 	if err != nil {
 		if stdErrors.Is(err, bchain.ErrBlockNotFound) {
-			return true, nil
+			return false, nil
 		}
 		return false, err
 	}
@@ -574,7 +591,17 @@ ConnectLoop:
 				time.Sleep(time.Millisecond * 500)
 				continue
 			}
-			hch <- hashHeight{hash, h}
+			if err = w.sendHashHeight(hch, abortCh, hashHeight{hash, h}); err != nil {
+				if stdErrors.Is(err, errResync) {
+					glog.Warning("sync: parallel connect aborted while queueing block hash, restarting sync")
+				} else if stdErrors.Is(err, ErrOperationInterrupted) {
+					glog.Info("connectBlocksParallel interrupted at height ", h)
+				} else {
+					glog.Error("sync: parallel connect aborted while queueing block hash, worker error ", err)
+				}
+				close(terminating)
+				break ConnectLoop
+			}
 			h++
 		}
 	}
@@ -791,7 +818,7 @@ ConnectLoop:
 			close(terminating)
 			break ConnectLoop
 		case <-w.chanOsSignal:
-			glog.Info("connectBlocksParallel interrupted at height ", h)
+			glog.Info("BulkConnectBlocks interrupted at height ", h)
 			err = ErrOperationInterrupted
 			// signal all workers to terminate their loops (error loops are interrupted below)
 			close(terminating)
@@ -804,7 +831,17 @@ ConnectLoop:
 				time.Sleep(time.Millisecond * 500)
 				continue
 			}
-			hch <- hashHeight{hash, h}
+			if err = w.sendHashHeight(hch, abortCh, hashHeight{hash, h}); err != nil {
+				if stdErrors.Is(err, errResync) {
+					glog.Warning("sync: bulk connect aborted while queueing block hash, restarting sync")
+				} else if stdErrors.Is(err, ErrOperationInterrupted) {
+					glog.Info("BulkConnectBlocks interrupted at height ", h)
+				} else {
+					glog.Error("sync: bulk connect aborted while queueing block hash, worker error ", err)
+				}
+				close(terminating)
+				break ConnectLoop
+			}
 			if h > 0 && h%1000 == 0 {
 				w.metrics.BlockbookBestHeight.Set(float64(h))
 				glog.Info("connecting block ", h, " ", hash, ", elapsed ", time.Since(start), " ", w.db.GetAndResetConnectBlockStats())
@@ -891,7 +928,10 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 					return
 				}
 				if height > bestHeight {
-					return
+					if hash == "" {
+						return
+					}
+					glog.Warningf("getBlockChain: block %d %s is above observed backend height %d; retrying because the block hash was already observed", height, hash, bestHeight)
 				}
 			}
 			if gotNotFound {

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -142,14 +143,14 @@ func TestIsRetryableGetBlockError(t *testing.T) {
 
 type getBlockChainTestChain struct {
 	bchain.BlockChain
-	bestHeight       uint32
-	bestHeightErr    error
-	bestHeightCalls  int
-	hashes           map[uint32]string
-	blocks           map[uint32]*bchain.Block
-	blockErrors      map[uint32][]error
-	getBlockCalls    map[uint32]int
-	getBlockHashErr  error
+	bestHeight      uint32
+	bestHeightErr   error
+	bestHeightCalls int
+	hashes          map[uint32]string
+	blocks          map[uint32]*bchain.Block
+	blockErrors     map[uint32][]error
+	getBlockCalls   map[uint32]int
+	getBlockHashErr error
 }
 
 func (c *getBlockChainTestChain) GetBestBlockHeight() (uint32, error) {
@@ -256,6 +257,35 @@ func TestGetBlockChainStopsAboveBestHeight(t *testing.T) {
 	}
 }
 
+func TestGetBlockChainRetriesKnownHashAboveObservedBestHeight(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight: 0,
+		hashes:     map[uint32]string{1: "h1"},
+		blocks: map[uint32]*bchain.Block{
+			1: {BlockHeader: bchain.BlockHeader{Hash: "h1", Height: 1}},
+		},
+		blockErrors: map[uint32][]error{
+			1: {bchain.ErrBlockNotFound},
+		},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(t, chain, "h1", 1)
+
+	results := runGetBlockChain(w)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].err != nil {
+		t.Fatalf("unexpected error: %v", results[0].err)
+	}
+	if results[0].block == nil || results[0].block.Hash != "h1" {
+		t.Fatalf("unexpected block: %+v", results[0].block)
+	}
+	if calls := chain.getBlockCalls[1]; calls != 2 {
+		t.Fatalf("GetBlock height 1 calls = %d, want 2", calls)
+	}
+}
+
 func TestGetBlockChainMissingBlockChangedHashResyncs(t *testing.T) {
 	chain := &getBlockChainTestChain{
 		bestHeight:    1,
@@ -275,6 +305,38 @@ func TestGetBlockChainMissingBlockChangedHashResyncs(t *testing.T) {
 	}
 	if calls := chain.getBlockCalls[1]; calls != 2 {
 		t.Fatalf("GetBlock height 1 calls = %d, want 2", calls)
+	}
+}
+
+func TestShouldRestartSyncOnMissingBlockIgnoresLaggingBestHeight(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight: 9,
+		hashes:     map[uint32]string{},
+	}
+	w := newGetBlockChainTestWorker(t, chain, "h10", 10)
+
+	restart, err := w.shouldRestartSyncOnMissingBlock(10, "h10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if restart {
+		t.Fatal("restart = true, want false for a single lagging best-height probe")
+	}
+}
+
+func TestShouldRestartSyncOnMissingBlockIgnoresMissingHashProbe(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight: 10,
+		hashes:     map[uint32]string{},
+	}
+	w := newGetBlockChainTestWorker(t, chain, "h10", 10)
+
+	restart, err := w.shouldRestartSyncOnMissingBlock(10, "h10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if restart {
+		t.Fatal("restart = true, want false for a single missing hash probe")
 	}
 }
 
@@ -402,5 +464,43 @@ func TestGetBlockWorkerCheckErrAbortsAfterStreak(t *testing.T) {
 	wg.Wait()
 	if chain.bestHeightCalls < 3 {
 		t.Fatalf("GetBestBlockHeight calls = %d, want at least 3", chain.bestHeightCalls)
+	}
+}
+
+func TestParallelConnectBlocksReturnsWorkerAbortWhenHashQueueFull(t *testing.T) {
+	hashes := make(map[uint32]string)
+	for h := uint32(1); h <= 10; h++ {
+		hashes[h] = "h" + strconv.Itoa(int(h))
+	}
+	chain := &getBlockChainTestChain{
+		bestHeight:    10,
+		hashes:        hashes,
+		blocks:        map[uint32]*bchain.Block{},
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := &SyncWorker{
+		chain: chain,
+		missingBlockRetry: MissingBlockRetryConfig{
+			RecheckThreshold:    1,
+			TipRecheckThreshold: 1,
+			RetryDelay:          time.Millisecond,
+			MaxStallDuration:    30 * time.Millisecond,
+		},
+		metrics: getTestMetrics(t),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.ParallelConnectBlocks(nil, 1, 10, 1)
+	}()
+
+	select {
+	case err := <-done:
+		if !stdErrors.Is(err, errResync) {
+			t.Fatalf("ParallelConnectBlocks error = %v, want errResync", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ParallelConnectBlocks did not return after worker abort")
 	}
 }

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -504,3 +504,43 @@ func TestParallelConnectBlocksReturnsWorkerAbortWhenHashQueueFull(t *testing.T) 
 		t.Fatal("ParallelConnectBlocks did not return after worker abort")
 	}
 }
+
+// MaxStallDuration is the load-bearing liveness cap: the retry loops disable the
+// cap when it is <= 0, so construction must clamp it to a safe default regardless
+// of which caller (or partial test cfg) supplied the config.
+func TestNewSyncWorkerClampsMaxStallDuration(t *testing.T) {
+	def := DefaultMissingBlockRetryConfig().MaxStallDuration
+	cases := []struct {
+		name string
+		cfg  *SyncWorkerConfig
+		want time.Duration
+	}{
+		{name: "nil cfg keeps default", cfg: nil, want: def},
+		{
+			name: "zero stall clamped to default",
+			cfg:  &SyncWorkerConfig{MissingBlockRetry: MissingBlockRetryConfig{MaxStallDuration: 0}},
+			want: def,
+		},
+		{
+			name: "negative stall clamped to default",
+			cfg:  &SyncWorkerConfig{MissingBlockRetry: MissingBlockRetryConfig{MaxStallDuration: -time.Second}},
+			want: def,
+		},
+		{
+			name: "explicit positive stall preserved",
+			cfg:  &SyncWorkerConfig{MissingBlockRetry: MissingBlockRetryConfig{MaxStallDuration: 5 * time.Second}},
+			want: 5 * time.Second,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := NewSyncWorkerWithConfig(nil, nil, 1, 0, 0, false, nil, getTestMetrics(t), nil, tc.cfg)
+			if err != nil {
+				t.Fatalf("NewSyncWorkerWithConfig: %v", err)
+			}
+			if got := w.missingBlockRetry.MaxStallDuration; got != tc.want {
+				t.Fatalf("MaxStallDuration = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/sync/sync.go
+++ b/tests/sync/sync.go
@@ -170,6 +170,9 @@ var testSyncWorkerConfig = &db.SyncWorkerConfig{
 		RecheckThreshold:    3,
 		TipRecheckThreshold: 2,
 		RetryDelay:          50 * time.Millisecond,
+		// Keep the liveness cap exercised but short so a stall yields quickly
+		// instead of waiting on the 60s production default.
+		MaxStallDuration: 5 * time.Second,
 	},
 }
 


### PR DESCRIPTION
## Summary
- Make EVM sync tolerate load-balanced backend tip skew when a later best-height probe is behind an already observed block hash.
- Prevent parallel and bulk sync from wedging while queueing block hashes after workers have already reported an abort/resync condition.
- Preserve real reorg handling by restarting only when a chain-state probe proves the same height has a different hash.

## Reasoning
Polygon can hit a QuickNode load-balanced RPC pool where consecutive calls land on nodes with different heights. Blockbook may first observe the next block hash at height `N`, then ask for best height and get `N-1` from a lagging backend. The previous code treated that single lagging response as a hard `remote best height error`, which made tip syncing retry instead of progressing.

```
sync.go:258] resync: error - remote best height 87570258 less than sync start height 87570259
blockbook.go:586] syncIndexLoop /go/src/github.com/trezor/blockbook/db/sync.go:259: resync: remote best height error, will retry...
```

**There was also a separate internal stall path: the parallel/bulk coordinator used a blocking `hch <- hashHeight{...}` send. If all workers were stuck retrying `block not found`, the hash queue could fill. At that point the coordinator no longer selected on `abortCh`, so a worker could report `errResync` or another terminal error and Blockbook would not observe it. That matches the symptom where sync appears stuck internally after height inconsistency without `debug_traceBlockByHash` errors.**

## Solution
- If `GetBestBlockHeight()` returns below `startHeight`, log a warning and fall back to sequential sync for that round instead of returning a hard error.
- Make queued hash sends abort-aware via `sendHashHeight`, so `ParallelConnectBlocks` and `BulkConnectBlocks` can return worker aborts even when the hash queue is full.
- Adjust missing-block rechecks for load-balanced EVM RPCs: a lagging best-height probe or a missing hash probe no longer proves a reorg by itself. Sync restarts immediately only when a probe can serve the height with a different hash.
- In sequential tip sync, continue retrying a missing block above an observed backend height when Blockbook already has a concrete hash for that block.

## Proofs
- `TestParallelConnectBlocksReturnsWorkerAbortWhenHashQueueFull` reproduces the queue-full/coordinator-stopped-reading-abort case and asserts the sync returns `errResync` instead of hanging.
- `TestGetBlockChainRetriesKnownHashAboveObservedBestHeight` covers the load-balanced tip skew case where the block hash is known but a later best-height probe is behind.
- `TestShouldRestartSyncOnMissingBlockIgnoresLaggingBestHeight` and `TestShouldRestartSyncOnMissingBlockIgnoresMissingHashProbe` cover the QuickNode-style lagging probe behavior.
- Existing changed-hash behavior is kept by `TestGetBlockChainMissingBlockChangedHashResyncs`.

## Tests
- `contrib/tests/run-unit-tests.sh -count=1`
- `contrib/tests/run-integration-tests.sh -run 'TestIntegration/.*/connectivity' -count=1`\n- `contrib/tests/run-integration-tests.sh -run 'TestIntegration/polygon=main/rpc/GetBlock' -count=1`