### PR TITLE
Extend E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,4 +231,15 @@ jobs:
         env:
           BB_BUILD_ENV: dev
           OPENAPI_COINS: ${{ needs.prepare_deploy.outputs.test_coins_csv }}
+          OPENAPI_JUNIT_PATH: ${{ github.workspace }}/tests/openapi/reports/junit.xml
         run: contrib/tests/run-openapi-tests.sh
+
+      # Upload even on failure: the runner writes the report before exiting non-zero, and a failed
+      # run is exactly when the per-test breakdown (which coin/test failed or skipped) is most useful.
+      - name: Upload OpenAPI e2e report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-e2e-report
+          path: tests/openapi/reports/
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,23 @@ test: .bin-image
 test-integration: .bin-image
 	docker run -t --rm -e PACKAGER=$(PACKAGER) -e BB_BUILD_ENV=$(BB_BUILD_ENV) -e GITCOMMIT=$(GITCOMMIT) $(BB_RPC_ENV) -v "$(CURDIR):/src" --network="host" $(BIN_IMAGE) make test-integration ARGS="$(ARGS)"
 
+# `make test-e2e [coin] [url]` — e.g. `make test-e2e bitcoin https://btc.trezor.io`.
+# Extra goals after test-e2e are consumed as positional args (coin, base URL)
+# and turned into OPENAPI_COINS / BB_DEV_API_URL_HTTP_<coin> for the test runner.
+ifeq (test-e2e,$(firstword $(MAKECMDGOALS)))
+  E2E_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifneq ($(E2E_ARGS),)
+    # no-op catch-all so make does not try to build the positional args as targets
+%:
+	@:
+  endif
+endif
+
 test-e2e:
 	@if [ ! -x tests/openapi/node_modules/.bin/redocly ]; then npm ci --prefix tests/openapi --prefer-offline --no-audit --no-fund; fi
+	@coin="$(word 1,$(E2E_ARGS))"; url="$(word 2,$(E2E_ARGS))"; \
+	if [ -n "$$coin" ]; then export OPENAPI_COINS="$$coin"; fi; \
+	if [ -n "$$url" ]; then export "BB_DEV_API_URL_HTTP_$$(printf %s "$$coin" | tr - _)=$$url"; fi; \
 	contrib/tests/run-openapi-tests.sh
 
 test-connectivity: .bin-image

--- a/tests/openapi/src/config.ts
+++ b/tests/openapi/src/config.ts
@@ -128,6 +128,17 @@ export function loadCoinConfig(coin: string) {
   return JSON.parse(raw) as CoinConfig;
 }
 
+// Golomb block-filter settings for a coin, read from its config (the source of truth for the
+// instance's BlockFilterScripts/BlockGolombFilterP). scriptType is "" when block filters are
+// not configured, which callers use to skip the ws filter tests.
+export function blockFilterConfig(coin: string) {
+  const params = loadCoinConfig(coin).blockbook?.block_chain?.additional_params ?? {};
+  return {
+    scriptType: (params.block_filter_scripts ?? "").trim(),
+    golombP: params.block_golomb_filter_p ?? 0,
+  };
+}
+
 function firstNonEmptyEnv(keys: string[]) {
   for (const key of keys) {
     const value = process.env[key]?.trim();

--- a/tests/openapi/src/config.ts
+++ b/tests/openapi/src/config.ts
@@ -28,6 +28,14 @@ export function fiatMaxAgeSeconds() {
   return DEFAULT_FIAT_MAX_AGE_SECONDS;
 }
 
+// allowOutOfSync lets dev runs proceed against a node still catching up to its backend. Off by
+// default so CI fails loudly on a stale tip (which makes every recent-block sample unreliable).
+// Set OPENAPI_ALLOW_OUT_OF_SYNC=1 to downgrade the inSync assertion in TestContext.getStatus.
+export function allowOutOfSync() {
+  const raw = process.env.OPENAPI_ALLOW_OUT_OF_SYNC?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
 export function resolveSelectedCoins(config: TestConfig) {
   const raw = process.env.OPENAPI_COINS?.trim();
   const requested = raw

--- a/tests/openapi/src/config.ts
+++ b/tests/openapi/src/config.ts
@@ -12,6 +12,22 @@ export function loadTestsConfig() {
   return JSON.parse(fs.readFileSync(path.join(repoRoot, "tests", "tests.json"), "utf8")) as TestConfig;
 }
 
+// Maximum age (seconds) a current fiat ticker may have before it is considered stale.
+// Coins refresh rates every 60s (BTC) … 900s (ETH); 2h gives margin against a transient
+// CoinGecko skip while still flagging a feed stalled for hours.
+export const DEFAULT_FIAT_MAX_AGE_SECONDS = 7200; // 2h
+
+export function fiatMaxAgeSeconds() {
+  const raw = process.env.BB_FIAT_MAX_AGE_SECONDS?.trim();
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_FIAT_MAX_AGE_SECONDS;
+}
+
 export function resolveSelectedCoins(config: TestConfig) {
   const raw = process.env.OPENAPI_COINS?.trim();
   const requested = raw

--- a/tests/openapi/src/context.ts
+++ b/tests/openapi/src/context.ts
@@ -305,7 +305,7 @@ export class TestContext {
     }
 
     this.sampleFiatResolved = true;
-    const path = "/api/v2/tickers/?currency=usd";
+    const path = "/api/v2/tickers/";
     const result = await this.client.getMaybe("/api/v2/tickers/", path);
     if (isFiatDataUnavailable(result.status, result.body)) {
       throw new SkipTest("fiat ticker data currently unavailable");

--- a/tests/openapi/src/context.ts
+++ b/tests/openapi/src/context.ts
@@ -2,7 +2,7 @@ import WebSocket from "ws";
 
 import { OpenApiFetchClient } from "./client.js";
 import { OpenApiContract, preview } from "./openapi.js";
-import { resolveHTTPBase, resolveWSURL } from "./config.js";
+import { allowOutOfSync, resolveHTTPBase, resolveWSURL } from "./config.js";
 import { SkipTest } from "./errors.js";
 import { addressPage, addressPageSize, blockPageSize, sampleBlockPageSize, sampleBlockProbeMax, sciNotationTxLimit, sciNotationWindow, scientificNotationPattern, txSearchWindow, wsDialTimeoutMs, wsMessageTimeoutMs } from "./constants.js";
 import {
@@ -85,6 +85,14 @@ export class TestContext {
     }
     if (!positiveNumber(envelope.blockbook.bestHeight)) {
       throw new Error(`invalid status bestHeight: ${String(envelope.blockbook.bestHeight)}`);
+    }
+    // A node that has not caught up to its backend serves a stale tip, so every recent-block sample
+    // (tx/address/block) the suite derives would be unreliable. Fail loudly unless a dev run opts out.
+    if (!envelope.blockbook.inSync && !allowOutOfSync()) {
+      throw new Error(
+        `blockbook is not in sync (inSync=${String(envelope.blockbook.inSync)}, bestHeight=${envelope.blockbook.bestHeight}); ` +
+          `set OPENAPI_ALLOW_OUT_OF_SYNC=1 to run anyway`,
+      );
     }
 
     this.status = envelope.blockbook;

--- a/tests/openapi/src/report.ts
+++ b/tests/openapi/src/report.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type TestStatus = "ok" | "skip" | "fail";
+
+export interface TestResult {
+  coin: string;
+  name: string;
+  group: string;
+  status: TestStatus;
+  durationMs: number;
+  message?: string;
+}
+
+export interface CoinSummary {
+  coin: string;
+  ok: number;
+  skip: number;
+  fail: number;
+  results: TestResult[];
+}
+
+export function summarize(coin: string, results: TestResult[]): CoinSummary {
+  return {
+    coin,
+    ok: results.filter((r) => r.status === "ok").length,
+    skip: results.filter((r) => r.status === "skip").length,
+    fail: results.filter((r) => r.status === "fail").length,
+    results,
+  };
+}
+
+// writeReports emits a JUnit XML report when OPENAPI_JUNIT_PATH points at a file path, so CI test
+// reporters can enforce results (distinguish skips from passes, annotate PRs) instead of scraping
+// stdout. Opt-in; console output is unaffected.
+export function writeReports(summaries: CoinSummary[]): string[] {
+  const written: string[] = [];
+  const junitPath = process.env.OPENAPI_JUNIT_PATH?.trim();
+  if (junitPath) {
+    writeFile(junitPath, toJUnitXML(summaries));
+    written.push(junitPath);
+  }
+  return written;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+export function toJUnitXML(summaries: CoinSummary[]): string {
+  const totalTests = summaries.reduce((n, s) => n + s.results.length, 0);
+  const totalFail = summaries.reduce((n, s) => n + s.fail, 0);
+  const totalSkip = summaries.reduce((n, s) => n + s.skip, 0);
+  const totalTime = seconds(summaries.reduce((n, s) => n + s.results.reduce((m, r) => m + r.durationMs, 0), 0));
+
+  const lines: string[] = [];
+  lines.push(`<?xml version="1.0" encoding="UTF-8"?>`);
+  lines.push(`<testsuites name="blockbook-openapi-e2e" tests="${totalTests}" failures="${totalFail}" skipped="${totalSkip}" time="${totalTime}">`);
+  for (const summary of summaries) {
+    const suiteTime = seconds(summary.results.reduce((m, r) => m + r.durationMs, 0));
+    lines.push(`  <testsuite name="${attr(summary.coin)}" tests="${summary.results.length}" failures="${summary.fail}" skipped="${summary.skip}" time="${suiteTime}">`);
+    for (const result of summary.results) {
+      const open = `    <testcase name="${attr(result.name)}" classname="${attr(`${summary.coin}.${result.group}`)}" time="${seconds(result.durationMs)}">`;
+      if (result.status === "ok") {
+        lines.push(`${open.slice(0, -1)}/>`);
+      } else if (result.status === "skip") {
+        lines.push(open);
+        lines.push(`      <skipped message="${attr(result.message ?? "")}"/>`);
+        lines.push(`    </testcase>`);
+      } else {
+        lines.push(open);
+        lines.push(`      <failure message="${attr(result.message ?? "")}">${text(result.message ?? "")}</failure>`);
+        lines.push(`    </testcase>`);
+      }
+    }
+    lines.push(`  </testsuite>`);
+  }
+  lines.push(`</testsuites>`);
+  return `${lines.join("\n")}\n`;
+}
+
+function seconds(ms: number): string {
+  return (ms / 1000).toFixed(3);
+}
+
+// Escape the five XML entity characters for attribute context (quotes included).
+function attr(value: string): string {
+  return sanitize(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Escape for element-text context (quotes are legal in text).
+function text(value: string): string {
+  return sanitize(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Replace control chars that are illegal in XML 1.0, keeping tab (0x09), newline (0x0a) and
+// carriage return (0x0d), so an arbitrary error message can never produce an invalid document.
+function sanitize(value: string): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d ? " " : ch;
+  }
+  return out;
+}

--- a/tests/openapi/src/runner.ts
+++ b/tests/openapi/src/runner.ts
@@ -5,6 +5,7 @@ import { Agent, setGlobalDispatcher } from "undici";
 import { loadTestsConfig, repoRoot, resolveSelectedCoins } from "./config.js";
 import { errorMessage, SkipTest } from "./errors.js";
 import { OpenApiContract } from "./openapi.js";
+import { CoinSummary, summarize, TestResult, writeReports } from "./report.js";
 import { testRegistry } from "./registry.js";
 import { TestContext } from "./context.js";
 
@@ -22,11 +23,39 @@ export async function runOpenApiE2E() {
     return;
   }
 
-  const failures: string[] = [];
+  const summaries: CoinSummary[] = [];
   for (const coin of selectedCoins) {
-    await runCoin(coin, contract, failures);
+    summaries.push(await runCoin(coin, contract));
   }
 
+  // Per-coin and aggregate summary so a run that is green-but-empty (everything skipped) is
+  // visible at a glance, not hidden behind a zero-failure exit.
+  console.log("\nOpenAPI e2e summary:");
+  for (const summary of summaries) {
+    console.log(`  ${summary.coin}: ${summary.ok} ok, ${summary.skip} skip, ${summary.fail} fail`);
+  }
+  const totals = summaries.reduce(
+    (acc, s) => ({ ok: acc.ok + s.ok, skip: acc.skip + s.skip, fail: acc.fail + s.fail }),
+    { ok: 0, skip: 0, fail: 0 },
+  );
+  console.log(`  total: ${totals.ok} ok, ${totals.skip} skip, ${totals.fail} fail`);
+
+  // Machine-readable artifact for CI (opt-in via OPENAPI_JUNIT_PATH). A requested-but-unwritable
+  // report is itself a failure, so CI never silently loses results.
+  try {
+    for (const reportPath of writeReports(summaries)) {
+      console.log(`  report written: ${reportPath}`);
+    }
+  } catch (error) {
+    console.error(`OpenAPI e2e: failed to write report: ${errorMessage(error)}`);
+    process.exit(1);
+  }
+
+  const failures = summaries.flatMap((summary) =>
+    summary.results
+      .filter((result) => result.status === "fail")
+      .map((result) => `${result.coin}/${result.name}: ${result.message ?? "failed"}`),
+  );
   if (failures.length > 0) {
     console.error(`\nOpenAPI e2e failed with ${failures.length} failure(s):`);
     for (const failure of failures) {
@@ -35,26 +64,39 @@ export async function runOpenApiE2E() {
     process.exit(1);
   }
 
-  console.log(`\nOpenAPI e2e passed for ${selectedCoins.length} coin(s): ${selectedCoins.join(", ")}`);
+  console.log(`\nOpenAPI e2e passed for ${summaries.length} coin(s): ${selectedCoins.join(", ")}`);
 }
 
-async function runCoin(coin: string, contract: OpenApiContract, failures: string[]) {
+async function runCoin(coin: string, contract: OpenApiContract): Promise<CoinSummary> {
   const testsConfig = loadTestsConfig();
   const apiTests = testsConfig[coin]?.api ?? [];
+  const results: TestResult[] = [];
   if (apiTests.length === 0) {
     console.log(`OpenAPI e2e ${coin}: no api tests configured, skipping.`);
-    return;
+    return summarize(coin, results);
   }
 
   const ctx = await TestContext.create(coin, contract);
   console.log(`\nOpenAPI e2e ${coin}: ${apiTests.length} tests`);
-  await ctx.getStatus();
+
+  // Status preflight: if the node is unreachable or not in sync, every sample-derived test would
+  // fail or skip downstream for the same root cause. Surface it once as a single coin-level failure
+  // instead of N confusing ones, and stop here (the 0-ok guard would fire anyway).
+  try {
+    await ctx.getStatus();
+  } catch (error) {
+    const message = errorMessage(error);
+    console.error(`  fail (status preflight): ${message}`);
+    results.push({ coin, name: "StatusPreflight", group: "preflight", status: "fail", durationMs: 0, message });
+    return summarize(coin, results);
+  }
 
   for (const testName of apiTests) {
     const def = testRegistry[testName];
     if (!def) {
-      failures.push(`${coin}/${testName}: test is listed in tests/tests.json but not implemented`);
-      console.error(`  fail ${testName}: test is listed in tests/tests.json but not implemented`);
+      const message = "test is listed in tests/tests.json but not implemented";
+      console.error(`  fail ${testName}: ${message}`);
+      results.push({ coin, name: testName, group: "unknown", status: "fail", durationMs: 0, message });
       continue;
     }
 
@@ -64,15 +106,32 @@ async function runCoin(coin: string, contract: OpenApiContract, failures: string
         await ctx.requireCapability(def.capability, def.group, testName);
       }
       await def.run(ctx);
-      console.log(`  ok   ${testName} (${Date.now() - started}ms)`);
+      const durationMs = Date.now() - started;
+      console.log(`  ok   ${testName} (${durationMs}ms)`);
+      results.push({ coin, name: testName, group: def.group, status: "ok", durationMs });
     } catch (error) {
+      const durationMs = Date.now() - started;
       if (error instanceof SkipTest) {
         console.log(`  skip ${testName}: ${error.message}`);
+        results.push({ coin, name: testName, group: def.group, status: "skip", durationMs, message: error.message });
         continue;
       }
       const message = errorMessage(error);
-      failures.push(`${coin}/${testName}: ${message}`);
       console.error(`  fail ${testName}: ${message}`);
+      results.push({ coin, name: testName, group: def.group, status: "fail", durationMs, message });
     }
   }
+
+  // Silent-green guard: a coin that ran tests but passed none (all skipped, none failed) is not a
+  // pass — it usually means the recent-block window had no usable sample or a capability probe
+  // turned everything off. Flag it as a failure so CI does not report green on zero coverage.
+  const summary = summarize(coin, results);
+  if (summary.ok === 0 && summary.fail === 0 && results.length > 0) {
+    const message = `coin ${coin} had 0 passing tests (${summary.skip} skipped) — likely not in sync or the recent-block window yielded no usable sample data`;
+    console.error(`  fail (coin health): ${message}`);
+    results.push({ coin, name: "CoinHealth", group: "health", status: "fail", durationMs: 0, message });
+    return summarize(coin, results);
+  }
+
+  return summary;
 }

--- a/tests/openapi/src/support.ts
+++ b/tests/openapi/src/support.ts
@@ -217,8 +217,9 @@ export function assertFiatTickerFresh(payload: FiatTickerResponse, context: stri
   if (ageSeconds > maxAgeSeconds) {
     throw new Error(`${context} ticker is stale: ts=${payload.ts} is ${ageSeconds}s old (max ${maxAgeSeconds}s)`);
   }
-  // tolerate small clock skew; flag only an egregiously future timestamp
-  if (ageSeconds < -maxAgeSeconds) {
+  // tolerate small clock skew (5 minutes); flag only an egregiously future timestamp
+  const maxFutureSkewSeconds = Math.min(maxAgeSeconds, 300);
+  if (ageSeconds < -maxFutureSkewSeconds) {
     throw new Error(`${context} ticker timestamp is in the future: ts=${payload.ts} (now=${nowSeconds})`);
   }
 }

--- a/tests/openapi/src/support.ts
+++ b/tests/openapi/src/support.ts
@@ -199,9 +199,27 @@ export function assertFiatTickerPayload(payload: FiatTickerResponse, context: st
   }
   for (const [currency, rate] of Object.entries(payload.rates)) {
     assertNonEmptyString(currency, `${context}.rates.currency`);
-    if (rate === 0) {
-      throw new Error(`${context} returned zero rate for currency ${currency}`);
+    if (!(rate > 0)) {
+      throw new Error(`${context} returned non-positive rate ${rate} for currency ${currency}`);
     }
+  }
+}
+
+// assertFiatTickerFresh fails when the current ticker's timestamp is older than maxAgeSeconds,
+// flagging a stalled fiat-rates feed. Only meaningful for the live current ticker (no timestamp
+// query param) — do not apply to historical/multi-tickers queries.
+export function assertFiatTickerFresh(payload: FiatTickerResponse, context: string, maxAgeSeconds: number) {
+  if (!positiveNumber(payload.ts)) {
+    throw new Error(`${context} invalid timestamp: ${String(payload.ts)}`);
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const ageSeconds = nowSeconds - payload.ts; // ts is Unix seconds (api/types.go FiatTicker.ts)
+  if (ageSeconds > maxAgeSeconds) {
+    throw new Error(`${context} ticker is stale: ts=${payload.ts} is ${ageSeconds}s old (max ${maxAgeSeconds}s)`);
+  }
+  // tolerate small clock skew; flag only an egregiously future timestamp
+  if (ageSeconds < -maxAgeSeconds) {
+    throw new Error(`${context} ticker timestamp is in the future: ts=${payload.ts} (now=${nowSeconds})`);
   }
 }
 

--- a/tests/openapi/src/support.ts
+++ b/tests/openapi/src/support.ts
@@ -223,6 +223,23 @@ export function assertFiatTickerFresh(payload: FiatTickerResponse, context: stri
   }
 }
 
+// assertFiatTickerEquals asserts two tickers are identical (same timestamp and rate map).
+// Use only for immutable historical data (e.g. HTTP↔WS parity at a fixed timestamp), never
+// for current rates which can change between calls.
+export function assertFiatTickerEquals(got: FiatTickerResponse, want: FiatTickerResponse, context: string) {
+  if (got.ts !== want.ts) {
+    throw new Error(`${context} ts mismatch: got ${got.ts ?? 0}, want ${want.ts ?? 0}`);
+  }
+  const gotRates = got.rates ?? {};
+  const wantRates = want.rates ?? {};
+  assertStringSlicesEqual(Object.keys(gotRates).sort(), Object.keys(wantRates).sort(), `${context}.rates keys`);
+  for (const [currency, rate] of Object.entries(wantRates)) {
+    if (gotRates[currency] !== rate) {
+      throw new Error(`${context} rate mismatch for ${currency}: got ${gotRates[currency]}, want ${rate}`);
+    }
+  }
+}
+
 export function assertPageMeta(page: unknown, itemsOnPage: unknown, totalPages: unknown, totalItems: unknown, context: string) {
   const p = numberValue(page);
   const items = numberValue(itemsOnPage);

--- a/tests/openapi/src/support.ts
+++ b/tests/openapi/src/support.ts
@@ -332,6 +332,25 @@ export function assertUTXOListNonNegativeConfirmations(utxos: UtxoResponse[], co
   });
 }
 
+// assertGolombParams validates the shared P/M/zeroedKey header returned by the Golomb block-filter
+// surfaces — the HTTP /api/v2/block-filters endpoint and the ws getBlockFilter/getBlockFiltersBatch/
+// getMempoolFilters methods. P is cross-checked against the coin's configured block_golomb_filter_p
+// when known (golombP > 0).
+export function assertGolombParams(res: { P?: number; M?: number; zeroedKey?: boolean }, golombP: number, context: string) {
+  if (!Number.isInteger(res.P) || (res.P ?? 0) <= 0) {
+    throw new Error(`${context} invalid P: ${String(res.P)}`);
+  }
+  if (golombP > 0 && res.P !== golombP) {
+    throw new Error(`${context} P mismatch: got ${res.P}, want ${golombP}`);
+  }
+  if (!Number.isInteger(res.M) || (res.M ?? 0) <= 0) {
+    throw new Error(`${context} invalid M: ${String(res.M)}`);
+  }
+  if (typeof res.zeroedKey !== "boolean") {
+    throw new Error(`${context} invalid zeroedKey: ${String(res.zeroedKey)}`);
+  }
+}
+
 export function txIDsFromTransactions(txs: TxResponse[], context: string) {
   return txs.map((tx, index) => {
     assertNonEmptyString(tx.txid, `${context}.transactions[${index}].txid`);

--- a/tests/openapi/src/tests/common.ts
+++ b/tests/openapi/src/tests/common.ts
@@ -199,6 +199,50 @@ async function testGetAddressTxsScientificNotation(ctx: TestContext) {
   assertAddressTxsPayload(addr, found.address, found.txid, "GetAddressTxsScientificNotation", 1000);
 }
 
+// HTTP twin of the ws getBalanceHistory test: GET /api/v2/balancehistory/{descriptor}. Bounds the
+// window to the sample tx's block time (± a day) so the server scans only a small range instead of
+// the address's entire history (which can exceed timeouts on busy chains).
+async function testGetBalanceHistory(ctx: TestContext) {
+  const address = await ctx.sampleAddressOrSkip();
+  const txid = await ctx.sampleTxIDOrSkip();
+  const tx = await ctx.getTransactionByID(txid, false);
+
+  const blockTime = tx?.blockTime;
+  if (!positiveNumber(blockTime)) {
+    throw new SkipTest(`sample tx ${txid} has no block time to bound balance history`);
+  }
+  const from = blockTime - 1;
+  const to = blockTime + 24 * 3600; // clamps to best height; window is bounded by recent blocks
+
+  const result = await ctx.client.getMaybe(
+    "/api/v2/balancehistory/{descriptor}",
+    `/api/v2/balancehistory/${encodePathSegment(address)}?from=${from}&to=${to}`,
+  );
+  if (result.status !== 200 || result.data === undefined) {
+    // EVM rejects balance history for contract addresses ("...for a contract not allowed"); skip
+    // those, mirroring the ws getBalanceHistory test.
+    if (result.body.toLowerCase().includes("not allowed")) {
+      throw new SkipTest(`balance history not allowed for ${address} (contract)`);
+    }
+    throw new Error(`GET /api/v2/balancehistory returned HTTP ${result.status}: ${preview(result.body)}`);
+  }
+
+  const history = result.data;
+  if (!Array.isArray(history)) {
+    throw new Error("GetBalanceHistory response is not an array");
+  }
+  // An empty history is valid (address with no activity in range); the 200 body is already
+  // schema-validated against BalanceHistory[] by the client, so just assert the entry invariants.
+  history.forEach((entry, i) => {
+    if (!positiveNumber(entry.time)) {
+      throw new Error(`GetBalanceHistory[${i}] invalid time: ${String(entry.time)}`);
+    }
+    if (!Number.isInteger(entry.txs) || entry.txs < 0) {
+      throw new Error(`GetBalanceHistory[${i}] invalid txs: ${String(entry.txs)}`);
+    }
+  });
+}
+
 export async function getFiatJSONOrSkip<P extends GetOperationPath>(
   ctx: TestContext,
   operationPath: P,
@@ -225,6 +269,7 @@ export const commonTests: Record<string, TestFunction> = {
   GetAddressTxids: testGetAddressTxids,
   GetAddressTxs: testGetAddressTxs,
   GetAddressTxsScientificNotation: testGetAddressTxsScientificNotation,
+  GetBalanceHistory: testGetBalanceHistory,
   GetCurrentFiatRates: testGetCurrentFiatRates,
   GetTickersList: testGetTickersList,
   GetMultiTickers: testGetMultiTickers,

--- a/tests/openapi/src/tests/common.ts
+++ b/tests/openapi/src/tests/common.ts
@@ -199,7 +199,7 @@ async function testGetAddressTxsScientificNotation(ctx: TestContext) {
   assertAddressTxsPayload(addr, found.address, found.txid, "GetAddressTxsScientificNotation", 1000);
 }
 
-async function getFiatJSONOrSkip<P extends GetOperationPath>(
+export async function getFiatJSONOrSkip<P extends GetOperationPath>(
   ctx: TestContext,
   operationPath: P,
   actualPath: string,

--- a/tests/openapi/src/tests/common.ts
+++ b/tests/openapi/src/tests/common.ts
@@ -7,6 +7,7 @@ import {
   assertAddressTxsPayload,
   assertBasicAccountInfoPayload,
   assertEqualString,
+  assertFiatTickerFresh,
   assertFiatTickerPayload,
   assertNonEmptyString,
   buildAddressDetailsPath,
@@ -16,6 +17,7 @@ import {
   isObject,
   positiveNumber,
 } from "../support.js";
+import { fiatMaxAgeSeconds } from "../config.js";
 
 import type { TestContext } from "../context.js";
 
@@ -109,15 +111,11 @@ async function testGetAddress(ctx: TestContext) {
 }
 
 async function testGetCurrentFiatRates(ctx: TestContext) {
+  // sampleFiatTickerOrSkip fetches the unfiltered /api/v2/tickers/, so this verifies the
+  // full currency map (e.g. cny, eur, usd): non-empty, every rate > 0, and timestamp fresh.
   const ticker = await ctx.sampleFiatTickerOrSkip();
   assertFiatTickerPayload(ticker, "GetCurrentFiatRates");
-  const usd = ticker.rates?.usd;
-  if (usd === undefined) {
-    throw new Error("GetCurrentFiatRates missing requested usd rate");
-  }
-  if (usd === 0) {
-    throw new Error("GetCurrentFiatRates usd rate must not be zero");
-  }
+  assertFiatTickerFresh(ticker, "GetCurrentFiatRates", fiatMaxAgeSeconds());
 }
 
 async function testGetTickersList(ctx: TestContext) {

--- a/tests/openapi/src/tests/utxo.ts
+++ b/tests/openapi/src/tests/utxo.ts
@@ -1,5 +1,6 @@
+import { blockFilterConfig } from "../config.js";
 import { SkipTest } from "../errors.js";
-import { assertUTXOList, encodePathSegment, stringValue } from "../support.js";
+import { assertGolombParams, assertUTXOList, encodePathSegment, stringValue } from "../support.js";
 
 import type { TestContext } from "../context.js";
 import type { UtxoResponse } from "../types.js";
@@ -113,7 +114,62 @@ function isUnconfirmedUtxo(utxo: UtxoResponse) {
   return (utxo.confirmations ?? 0) <= 0 || (utxo.height ?? 0) <= 0;
 }
 
+// HTTP twin of the ws getBlockFilter* tests: /api/v2/block-filters returns the same Golomb
+// P/M/zeroedKey header plus a {height: {blockHash, filter}} map. Gated on the coin's configured
+// block_filter_scripts (skips when filters are not enabled) and on the utxo capability.
+async function testGetBlockFilters(ctx: TestContext) {
+  const { scriptType, golombP } = blockFilterConfig(ctx.coin);
+  if (!scriptType) {
+    throw new SkipTest(`${ctx.coin} has no block_filter_scripts configured`);
+  }
+
+  // lastN=5 anchors the window to the last 5 blocks from the tip, so the server scans only a
+  // handful of blocks and the result is guaranteed non-empty.
+  const lastN = 5;
+  const res = await ctx.client.getJson(
+    "/api/v2/block-filters/",
+    `/api/v2/block-filters/?scriptType=${encodeURIComponent(scriptType)}&lastN=${lastN}`,
+  );
+  assertGolombParams(res, golombP, "GetBlockFilters");
+
+  const filters = res.blockFilters ?? {};
+  const heights = Object.keys(filters);
+  if (heights.length === 0 || heights.length > lastN) {
+    throw new Error(`GetBlockFilters expected 1..${lastN} entries, got ${heights.length}`);
+  }
+  for (const [height, entry] of Object.entries(filters)) {
+    if (!/^[0-9]+$/.test(height)) {
+      throw new Error(`GetBlockFilters invalid height key: ${height}`);
+    }
+    if (typeof entry.blockHash !== "string" || !/^[0-9a-f]+$/i.test(entry.blockHash)) {
+      throw new Error(`GetBlockFilters[${height}] invalid blockHash: ${String(entry.blockHash)}`);
+    }
+    // filter hex can be empty for a block with no matching scripts; require hex chars when present.
+    if (typeof entry.filter !== "string" || !/^[0-9a-f]*$/i.test(entry.filter)) {
+      throw new Error(`GetBlockFilters[${height}] invalid filter hex: ${String(entry.filter)}`);
+    }
+  }
+}
+
+// Negative twin: an unknown scriptType must be rejected (public.go apiBlockFilters returns a 400
+// API error "Invalid scriptType ..."), never silently served.
+async function testGetBlockFiltersInvalidScriptType(ctx: TestContext) {
+  const { scriptType } = blockFilterConfig(ctx.coin);
+  if (!scriptType) {
+    throw new SkipTest(`${ctx.coin} has no block_filter_scripts configured`);
+  }
+  const result = await ctx.client.getMaybe(
+    "/api/v2/block-filters/",
+    `/api/v2/block-filters/?scriptType=bogus_${scriptType}&lastN=1`,
+  );
+  if (result.status === 200) {
+    throw new Error("GetBlockFiltersInvalidScriptType: server accepted an invalid scriptType (expected non-200)");
+  }
+}
+
 export const utxoOnlyTests: Record<string, TestFunction> = {
   GetUtxo: testGetUtxo,
   GetUtxoConfirmedFilter: testGetUtxoConfirmedFilter,
+  GetBlockFilters: testGetBlockFilters,
+  GetBlockFiltersInvalidScriptType: testGetBlockFiltersInvalidScriptType,
 };

--- a/tests/openapi/src/tests/websocket.ts
+++ b/tests/openapi/src/tests/websocket.ts
@@ -1,9 +1,10 @@
-import { addressPage, addressPageSize, evmHistoryPage, evmHistoryPageSize } from "../constants.js";
-import { fiatMaxAgeSeconds } from "../config.js";
+import { addressPage, addressPageSize, blockPageSize, evmHistoryPage, evmHistoryPageSize } from "../constants.js";
+import { blockFilterConfig, fiatMaxAgeSeconds } from "../config.js";
 import { SkipTest } from "../errors.js";
 import {
   assertAddressTxidsPayload,
   assertBasicAccountInfoPayload,
+  assertBigIntString,
   assertComparableAccountPages,
   assertEqualString,
   assertEVMTokenBalancesHaveHoldingsFields,
@@ -26,7 +27,7 @@ import { assertContractInfoFixturesFetched, assertErc4626FixturesInAccountInfo }
 import { getFiatJSONOrSkip } from "./common.js";
 
 import type { TestContext } from "../context.js";
-import type { AddressResponse, AvailableVsCurrenciesResponse, ContractInfoResponse, FiatTickerResponse, FiatTickersResponse, TxResponse, UtxoResponse, WsBlockHashResponse } from "../types.js";
+import type { AddressResponse, AvailableVsCurrenciesResponse, BalanceHistoryResponse, BlockResponse, ContractInfoResponse, FiatTickerResponse, FiatTickersResponse, TxResponse, UtxoResponse, WsBlockHashResponse } from "../types.js";
 
 type TestFunction = (ctx: TestContext) => Promise<void>;
 
@@ -295,6 +296,227 @@ async function testWsGetFiatRatesTickersList(ctx: TestContext) {
   );
 }
 
+// Re-raise a ws error as a SkipTest when its message matches a known "unsupported on this
+// chain/config" condition (e.g. ExtendedIndex off, balance history for a contract); otherwise
+// rethrow so genuine failures still surface. Returns `never` so callers can rely on it throwing.
+function skipWsUnsupportedOrRethrow(error: unknown, needles: string[], reason: string): never {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  if (needles.some((needle) => message.includes(needle))) {
+    throw new SkipTest(reason);
+  }
+  throw error;
+}
+
+async function testWsGetBlock(ctx: TestContext) {
+  const sample = await ctx.getSampleIndexedBlock();
+  if (!sample) {
+    const status = await ctx.getStatus();
+    throw new Error(`missing indexed block hash in recent height window near ${status.bestHeight ?? 0}`);
+  }
+
+  let block: BlockResponse;
+  try {
+    block = await ctx.wsCall<BlockResponse>(
+      "getBlock",
+      { id: sample.hash, page: 1, pageSize: blockPageSize },
+      "#/components/schemas/Block",
+    );
+  } catch (error) {
+    // ws getBlock is gated on ExtendedIndex flag; skip on instances where it is not enabled.
+    skipWsUnsupportedOrRethrow(error, ["not supported"], "ws getBlock requires ExtendedIndex (not enabled)");
+  }
+
+  assertEqualString(block.hash, sample.hash, "WsGetBlock hash");
+  if (block.height !== sample.height) {
+    throw new Error(`WsGetBlock height mismatch: got ${block.height}, want ${sample.height}`);
+  }
+  if (!Array.isArray(block.txs)) {
+    throw new Error("WsGetBlock response missing txs field");
+  }
+}
+
+async function testWsGetBalanceHistory(ctx: TestContext) {
+  const address = await ctx.sampleAddressOrSkip();
+  const txid = await ctx.sampleTxIDOrSkip();
+  const tx = await ctx.getTransactionByID(txid, false);
+
+  // An unbounded query (from=0,to=0) aggregates the address's ENTIRE history, which can exceed
+  // the ws timeout on busy chains (e.g. tron). The sample address comes from this recent tx
+  // (within txSearchWindow=12 blocks of the tip), so bound the window to that block onward:
+  // the server scans only ~a dozen blocks and the result still contains the sampled tx.
+  const blockTime = tx?.blockTime;
+  if (!positiveNumber(blockTime)) {
+    throw new SkipTest(`sample tx ${txid} has no block time to bound balance history`);
+  }
+  const from = blockTime - 1;
+  const to = blockTime + 24 * 3600; // clamps to best height; window is bounded by recent blocks
+
+  let history: BalanceHistoryResponse[];
+  try {
+    history = await ctx.wsCall<BalanceHistoryResponse[]>("getBalanceHistory", { descriptor: address, from, to });
+  } catch (error) {
+    // EVM rejects balance history for contract addresses; skip when the sample is a contract.
+    skipWsUnsupportedOrRethrow(error, ["not allowed"], `ws getBalanceHistory not allowed for ${address} (contract)`);
+  }
+
+  if (!Array.isArray(history)) {
+    throw new Error("WsGetBalanceHistory response is not an array");
+  }
+  // An empty history is valid (address with no activity in range); validate any entries present.
+  history.forEach((entry, i) => {
+    ctx.contract.validateSchemaRef("#/components/schemas/BalanceHistory", `WsGetBalanceHistory[${i}]`, entry);
+    if (!positiveNumber(entry.time)) {
+      throw new Error(`WsGetBalanceHistory[${i}] invalid time: ${String(entry.time)}`);
+    }
+    if (!Number.isInteger(entry.txs) || entry.txs < 0) {
+      throw new Error(`WsGetBalanceHistory[${i}] invalid txs: ${String(entry.txs)}`);
+    }
+  });
+}
+
+async function testWsGetTransactionSpecific(ctx: TestContext) {
+  const txid = await ctx.sampleTxIDOrSkip();
+  // Response is chain-specific free-form JSON (no schema ref to validate against).
+  const specific = await ctx.wsCall<Record<string, unknown>>("getTransactionSpecific", { txid });
+  if (!isObject(specific) || Object.keys(specific).length === 0) {
+    throw new Error(`WsGetTransactionSpecific empty response for ${txid}`);
+  }
+  const rawTxid = specific.txid;
+  if (typeof rawTxid === "string" && rawTxid.trim() !== "" && rawTxid.toLowerCase() !== txid.toLowerCase()) {
+    throw new Error(`WsGetTransactionSpecific txid mismatch: got ${rawTxid}, want ${txid}`);
+  }
+}
+
+async function testWsLongTermFeeRate(ctx: TestContext) {
+  // UTXO-only method; gated to UTXO coins via the ws-utxo capability group.
+  // No response schema exists in openapi.yaml, so validate structurally.
+  const res = await ctx.wsCall<{ feePerUnit?: string; blocks?: number }>("longTermFeeRate", {});
+  assertBigIntString(res.feePerUnit, "WsLongTermFeeRate.feePerUnit");
+  if (!Number.isInteger(res.blocks) || (res.blocks ?? -1) < 0) {
+    throw new Error(`WsLongTermFeeRate invalid blocks: ${String(res.blocks)}`);
+  }
+}
+
+// The Golomb-filter responses (getBlockFilter/getBlockFiltersBatch/getMempoolFilters) are
+// anonymous server structs with no openapi schema, so validate the shared P/M/zeroedKey header
+// structurally. P is cross-checked against the coin's configured block_golomb_filter_p.
+function assertGolombParams(res: { P?: number; M?: number; zeroedKey?: boolean }, golombP: number, context: string) {
+  if (!Number.isInteger(res.P) || (res.P ?? 0) <= 0) {
+    throw new Error(`${context} invalid P: ${String(res.P)}`);
+  }
+  if (golombP > 0 && res.P !== golombP) {
+    throw new Error(`${context} P mismatch: got ${res.P}, want ${golombP}`);
+  }
+  if (!Number.isInteger(res.M) || (res.M ?? 0) <= 0) {
+    throw new Error(`${context} invalid M: ${String(res.M)}`);
+  }
+  if (typeof res.zeroedKey !== "boolean") {
+    throw new Error(`${context} invalid zeroedKey: ${String(res.zeroedKey)}`);
+  }
+}
+
+type WsBlockFilterRes = { P?: number; M?: number; zeroedKey?: boolean; blockFilter?: string };
+type WsBlockFiltersBatchRes = { P?: number; M?: number; zeroedKey?: boolean; blockFiltersBatch?: string[] };
+type WsMempoolFiltersRes = { P?: number; M?: number; zeroedKey?: boolean; entries?: Record<string, string> };
+
+async function testWsGetBlockFilter(ctx: TestContext) {
+  const { scriptType, golombP } = blockFilterConfig(ctx.coin);
+  if (!scriptType) {
+    throw new SkipTest(`${ctx.coin} has no block_filter_scripts configured`);
+  }
+  const sample = await ctx.getSampleIndexedBlock();
+  if (!sample) {
+    const status = await ctx.getStatus();
+    throw new Error(`missing indexed block near ${status.bestHeight ?? 0}`);
+  }
+
+  let res: WsBlockFilterRes;
+  try {
+    res = await ctx.wsCall<WsBlockFilterRes>("getBlockFilter", { scriptType, blockHash: sample.hash });
+  } catch (error) {
+    skipWsUnsupportedOrRethrow(error, ["not supported", "unsupported script"], `ws getBlockFilter unsupported on ${ctx.coin}`);
+  }
+  assertGolombParams(res, golombP, "WsGetBlockFilter");
+  if (typeof res.blockFilter !== "string" || res.blockFilter.trim() === "" || !/^[0-9a-f]+$/i.test(res.blockFilter)) {
+    throw new Error(`WsGetBlockFilter blockFilter is not a non-empty hex string: ${String(res.blockFilter)}`);
+  }
+}
+
+async function testWsGetBlockFiltersBatch(ctx: TestContext) {
+  const { scriptType, golombP } = blockFilterConfig(ctx.coin);
+  if (!scriptType) {
+    throw new SkipTest(`${ctx.coin} has no block_filter_scripts configured`);
+  }
+  const status = await ctx.getStatus();
+  const best = status.bestHeight ?? 0;
+  const pageSize = 5;
+  // The batch returns filters forward from the anchor, so anchor a few blocks behind the tip
+  // to guarantee a non-empty result.
+  const anchorHeight = Math.max(1, best - (pageSize + 2));
+  const anchorHash = await ctx.getBlockHashForHeight(anchorHeight, false);
+  if (!anchorHash) {
+    throw new SkipTest(`no block hash for height ${anchorHeight}`);
+  }
+
+  let res: WsBlockFiltersBatchRes;
+  try {
+    res = await ctx.wsCall<WsBlockFiltersBatchRes>(
+      "getBlockFiltersBatch",
+      { scriptType, bestKnownBlockHash: anchorHash, pageSize },
+    );
+  } catch (error) {
+    skipWsUnsupportedOrRethrow(error, ["not supported", "unsupported script"], `ws getBlockFiltersBatch unsupported on ${ctx.coin}`);
+  }
+  assertGolombParams(res, golombP, "WsGetBlockFiltersBatch");
+  const batch = res.blockFiltersBatch;
+  if (!Array.isArray(batch) || batch.length === 0 || batch.length > pageSize) {
+    throw new Error(`WsGetBlockFiltersBatch expected 1..${pageSize} entries, got ${Array.isArray(batch) ? batch.length : "non-array"}`);
+  }
+  batch.forEach((entry, i) => {
+    // entry format: "<height>:<blockHash>:<filterHex>"
+    const parts = entry.split(":");
+    if (parts.length !== 3) {
+      throw new Error(`WsGetBlockFiltersBatch[${i}] malformed entry: ${entry}`);
+    }
+    const [heightStr, blockHash, filter] = parts;
+    if (!/^[0-9]+$/.test(heightStr)) {
+      throw new Error(`WsGetBlockFiltersBatch[${i}] invalid height: ${heightStr}`);
+    }
+    if (!/^[0-9a-f]+$/i.test(blockHash)) {
+      throw new Error(`WsGetBlockFiltersBatch[${i}] invalid blockHash: ${blockHash}`);
+    }
+    if (!/^[0-9a-f]*$/i.test(filter)) {
+      throw new Error(`WsGetBlockFiltersBatch[${i}] invalid filter hex: ${filter}`);
+    }
+  });
+}
+
+async function testWsGetMempoolFilters(ctx: TestContext) {
+  const { scriptType, golombP } = blockFilterConfig(ctx.coin);
+  if (!scriptType) {
+    throw new SkipTest(`${ctx.coin} has no block_filter_scripts configured`);
+  }
+
+  let res: WsMempoolFiltersRes;
+  try {
+    res = await ctx.wsCall<WsMempoolFiltersRes>("getMempoolFilters", { scriptType, fromTimestamp: 0 });
+  } catch (error) {
+    skipWsUnsupportedOrRethrow(error, ["not supported", "unsupported script"], `ws getMempoolFilters unsupported on ${ctx.coin}`);
+  }
+  assertGolombParams(res, golombP, "WsGetMempoolFilters");
+  const entries = res.entries;
+  if (entries === null || typeof entries !== "object" || Array.isArray(entries)) {
+    throw new Error(`WsGetMempoolFilters entries is not an object: ${String(entries)}`);
+  }
+  // entries may be empty (no matching mempool txs at call time); validate any present.
+  for (const [txid, filter] of Object.entries(entries)) {
+    assertNonEmptyString(txid, "WsGetMempoolFilters.entries.txid");
+    if (typeof filter !== "string" || !/^[0-9a-f]+$/i.test(filter)) {
+      throw new Error(`WsGetMempoolFilters entry ${txid} is not a hex filter: ${String(filter)}`);
+    }
+  }
+}
+
 export const wsOnlyTests: Record<string, TestFunction> = {
   WsGetInfo: testWsGetInfo,
   WsGetBlockHash: testWsGetBlockHash,
@@ -305,10 +527,17 @@ export const wsOnlyTests: Record<string, TestFunction> = {
   WsGetCurrentFiatRates: testWsGetCurrentFiatRates,
   WsGetFiatRatesForTimestamps: testWsGetFiatRatesForTimestamps,
   WsGetFiatRatesTickersList: testWsGetFiatRatesTickersList,
+  WsGetBlock: testWsGetBlock,
+  WsGetBalanceHistory: testWsGetBalanceHistory,
+  WsGetTransactionSpecific: testWsGetTransactionSpecific,
 };
 
 export const wsUTXOTests: Record<string, TestFunction> = {
   WsGetAccountUtxo: testWsGetAccountUtxo,
+  WsLongTermFeeRate: testWsLongTermFeeRate,
+  WsGetBlockFilter: testWsGetBlockFilter,
+  WsGetBlockFiltersBatch: testWsGetBlockFiltersBatch,
+  WsGetMempoolFilters: testWsGetMempoolFilters,
 };
 
 export const wsEVMTests: Record<string, TestFunction> = {

--- a/tests/openapi/src/tests/websocket.ts
+++ b/tests/openapi/src/tests/websocket.ts
@@ -1,4 +1,6 @@
 import { addressPage, addressPageSize, evmHistoryPage, evmHistoryPageSize } from "../constants.js";
+import { fiatMaxAgeSeconds } from "../config.js";
+import { SkipTest } from "../errors.js";
 import {
   assertAddressTxidsPayload,
   assertBasicAccountInfoPayload,
@@ -8,6 +10,9 @@ import {
   assertEVMBasicAddressPayload,
   assertEVMTokenBalancesPayload,
   assertEVMTokenListContractsMatch,
+  assertFiatTickerEquals,
+  assertFiatTickerFresh,
+  assertFiatTickerPayload,
   assertNonEmptyString,
   assertPageMetaAllowUnknownTotal,
   assertStringSlicesEqual,
@@ -18,9 +23,10 @@ import {
   txIDsFromTransactions,
 } from "../support.js";
 import { assertContractInfoFixturesFetched, assertErc4626FixturesInAccountInfo } from "./evm.js";
+import { getFiatJSONOrSkip } from "./common.js";
 
 import type { TestContext } from "../context.js";
-import type { AddressResponse, ContractInfoResponse, TxResponse, UtxoResponse, WsBlockHashResponse } from "../types.js";
+import type { AddressResponse, AvailableVsCurrenciesResponse, ContractInfoResponse, FiatTickerResponse, FiatTickersResponse, TxResponse, UtxoResponse, WsBlockHashResponse } from "../types.js";
 
 type TestFunction = (ctx: TestContext) => Promise<void>;
 
@@ -200,6 +206,95 @@ async function testWsGetContractInfoEVM(ctx: TestContext) {
   });
 }
 
+async function testWsGetCurrentFiatRates(ctx: TestContext) {
+  // ws getCurrentFiatRates mirrors HTTP /api/v2/tickers/ (current, unfiltered).
+  const ws = await ctx.wsCall<FiatTickerResponse>(
+    "getCurrentFiatRates",
+    {},
+    "#/components/schemas/FiatTicker",
+  );
+  assertFiatTickerPayload(ws, "WsGetCurrentFiatRates");
+  assertFiatTickerFresh(ws, "WsGetCurrentFiatRates", fiatMaxAgeSeconds());
+
+  // HTTP-WS parity: both call GetCurrentFiatRates on the same instance, so they expose the
+  // same currency set. Values/ts can differ if a refresh lands between the two calls, so
+  // compare the stable currency keys rather than the time-sensitive values.
+  const http = await ctx.sampleFiatTickerOrSkip();
+  assertStringSlicesEqual(
+    Object.keys(ws.rates ?? {}).sort(),
+    Object.keys(http.rates ?? {}).sort(),
+    "WsGetCurrentFiatRates parity currencies",
+  );
+}
+
+async function testWsGetFiatRatesForTimestamps(ctx: TestContext) {
+  const ticker = await ctx.sampleFiatTickerOrSkip();
+  const ts = ticker.ts;
+  if (!positiveNumber(ts)) {
+    throw new SkipTest("fiat sample timestamp unavailable");
+  }
+
+  // Pick a currency that exists at ts (currencies available now may not exist historically).
+  const list = await getFiatJSONOrSkip(ctx, "/api/v2/tickers-list/", `/api/v2/tickers-list/?timestamp=${ts}`);
+  const currency = list.available_currencies?.[0]?.trim().toLowerCase();
+  if (!currency) {
+    throw new SkipTest(`no available fiat currencies for timestamp ${ts}`);
+  }
+
+  const ws = await ctx.wsCall<FiatTickersResponse>(
+    "getFiatRatesForTimestamps",
+    { timestamps: [ts], currencies: [currency] },
+    "#/components/schemas/FiatTickers",
+  );
+  if (!Array.isArray(ws.tickers) || ws.tickers.length !== 1) {
+    throw new Error(`WsGetFiatRatesForTimestamps expected 1 ticker, got ${ws.tickers?.length ?? 0}`);
+  }
+  assertFiatTickerPayload(ws.tickers[0], "WsGetFiatRatesForTimestamps");
+
+  // HTTP-WS parity vs /api/v2/multi-tickers/ (immutable historical data → exact match).
+  const http = await getFiatJSONOrSkip(
+    ctx,
+    "/api/v2/multi-tickers/",
+    `/api/v2/multi-tickers/?timestamp=${ts}&currency=${encodeURIComponent(currency)}`,
+  );
+  if (http.length !== 1) {
+    throw new Error(`WsGetFiatRatesForTimestamps HTTP expected 1 ticker, got ${http.length}`);
+  }
+  assertFiatTickerEquals(ws.tickers[0], http[0], "WsGetFiatRatesForTimestamps parity");
+}
+
+async function testWsGetFiatRatesTickersList(ctx: TestContext) {
+  const ticker = await ctx.sampleFiatTickerOrSkip();
+  const ts = ticker.ts;
+  if (!positiveNumber(ts)) {
+    throw new SkipTest("fiat sample timestamp unavailable");
+  }
+
+  const ws = await ctx.wsCall<AvailableVsCurrenciesResponse>(
+    "getFiatRatesTickersList",
+    { timestamp: ts },
+    "#/components/schemas/AvailableVsCurrencies",
+  );
+  if (!positiveNumber(ws.ts)) {
+    throw new Error(`WsGetFiatRatesTickersList invalid timestamp: ${String(ws.ts)}`);
+  }
+  if (!Array.isArray(ws.available_currencies) || ws.available_currencies.length === 0) {
+    throw new Error("WsGetFiatRatesTickersList returned no currencies");
+  }
+  ws.available_currencies.forEach((currency) => assertNonEmptyString(currency, "WsGetFiatRatesTickersList.available_currencies"));
+
+  // HTTP-WS parity vs /api/v2/tickers-list/.
+  const http = await getFiatJSONOrSkip(ctx, "/api/v2/tickers-list/", `/api/v2/tickers-list/?timestamp=${ts}`);
+  if (ws.ts !== http.ts) {
+    throw new Error(`WsGetFiatRatesTickersList ts mismatch: ws=${ws.ts ?? 0} http=${http.ts ?? 0}`);
+  }
+  assertStringSlicesEqual(
+    [...ws.available_currencies].sort(),
+    [...(http.available_currencies ?? [])].sort(),
+    "WsGetFiatRatesTickersList parity currencies",
+  );
+}
+
 export const wsOnlyTests: Record<string, TestFunction> = {
   WsGetInfo: testWsGetInfo,
   WsGetBlockHash: testWsGetBlockHash,
@@ -207,6 +302,9 @@ export const wsOnlyTests: Record<string, TestFunction> = {
   WsGetAccountInfo: testWsGetAccountInfo,
   WsGetAccountInfoBasic: testWsGetAccountInfoBasic,
   WsPing: testWsPing,
+  WsGetCurrentFiatRates: testWsGetCurrentFiatRates,
+  WsGetFiatRatesForTimestamps: testWsGetFiatRatesForTimestamps,
+  WsGetFiatRatesTickersList: testWsGetFiatRatesTickersList,
 };
 
 export const wsUTXOTests: Record<string, TestFunction> = {

--- a/tests/openapi/src/tests/websocket.ts
+++ b/tests/openapi/src/tests/websocket.ts
@@ -424,8 +424,9 @@ async function testWsGetBlockFilter(ctx: TestContext) {
     skipWsUnsupportedOrRethrow(error, ["not supported", "unsupported script"], `ws getBlockFilter unsupported on ${ctx.coin}`);
   }
   assertGolombParams(res, golombP, "WsGetBlockFilter");
-  if (typeof res.blockFilter !== "string" || res.blockFilter.trim() === "" || !/^[0-9a-f]+$/i.test(res.blockFilter)) {
-    throw new Error(`WsGetBlockFilter blockFilter is not a non-empty hex string: ${String(res.blockFilter)}`);
+  // filter hex can be empty for a block with no matching scripts; require hex chars when present.
+  if (typeof res.blockFilter !== "string" || !/^[0-9a-f]*$/i.test(res.blockFilter)) {
+    throw new Error(`WsGetBlockFilter invalid filter hex: ${String(res.blockFilter)}`);
   }
 }
 

--- a/tests/openapi/src/tests/websocket.ts
+++ b/tests/openapi/src/tests/websocket.ts
@@ -14,6 +14,7 @@ import {
   assertFiatTickerEquals,
   assertFiatTickerFresh,
   assertFiatTickerPayload,
+  assertGolombParams,
   assertNonEmptyString,
   assertPageMetaAllowUnknownTotal,
   assertStringSlicesEqual,
@@ -399,22 +400,8 @@ async function testWsLongTermFeeRate(ctx: TestContext) {
 
 // The Golomb-filter responses (getBlockFilter/getBlockFiltersBatch/getMempoolFilters) are
 // anonymous server structs with no openapi schema, so validate the shared P/M/zeroedKey header
-// structurally. P is cross-checked against the coin's configured block_golomb_filter_p.
-function assertGolombParams(res: { P?: number; M?: number; zeroedKey?: boolean }, golombP: number, context: string) {
-  if (!Number.isInteger(res.P) || (res.P ?? 0) <= 0) {
-    throw new Error(`${context} invalid P: ${String(res.P)}`);
-  }
-  if (golombP > 0 && res.P !== golombP) {
-    throw new Error(`${context} P mismatch: got ${res.P}, want ${golombP}`);
-  }
-  if (!Number.isInteger(res.M) || (res.M ?? 0) <= 0) {
-    throw new Error(`${context} invalid M: ${String(res.M)}`);
-  }
-  if (typeof res.zeroedKey !== "boolean") {
-    throw new Error(`${context} invalid zeroedKey: ${String(res.zeroedKey)}`);
-  }
-}
-
+// structurally via the shared assertGolombParams helper (support.ts), which is also used by the
+// HTTP /api/v2/block-filters twin in utxo.ts.
 type WsBlockFilterRes = { P?: number; M?: number; zeroedKey?: boolean; blockFilter?: string };
 type WsBlockFiltersBatchRes = { P?: number; M?: number; zeroedKey?: boolean; blockFiltersBatch?: string[] };
 type WsMempoolFiltersRes = { P?: number; M?: number; zeroedKey?: boolean; entries?: Record<string, string> };

--- a/tests/openapi/src/types.ts
+++ b/tests/openapi/src/types.ts
@@ -8,6 +8,7 @@ export type TxResponse = GetResponse<"/api/v2/tx/{txid}">;
 export type AddressResponse = components["schemas"]["Address"];
 export type UtxoResponse = components["schemas"]["Utxo"];
 export type FiatTickerResponse = components["schemas"]["FiatTicker"];
+export type FiatTickersResponse = components["schemas"]["FiatTickers"];
 export type AvailableVsCurrenciesResponse = components["schemas"]["AvailableVsCurrencies"];
 export type ContractInfoResponse = components["schemas"]["ContractInfoResult"];
 export type TokenResponse = components["schemas"]["Token"];

--- a/tests/openapi/src/types.ts
+++ b/tests/openapi/src/types.ts
@@ -7,6 +7,7 @@ export type BlockResponse = GetResponse<"/api/v2/block/{blockId}">;
 export type TxResponse = GetResponse<"/api/v2/tx/{txid}">;
 export type AddressResponse = components["schemas"]["Address"];
 export type UtxoResponse = components["schemas"]["Utxo"];
+export type BalanceHistoryResponse = components["schemas"]["BalanceHistory"];
 export type FiatTickerResponse = components["schemas"]["FiatTicker"];
 export type FiatTickersResponse = components["schemas"]["FiatTickers"];
 export type AvailableVsCurrenciesResponse = components["schemas"]["AvailableVsCurrencies"];
@@ -34,6 +35,14 @@ export type CoinConfig = {
   };
   ports?: {
     blockbook_public?: number;
+  };
+  blockbook?: {
+    block_chain?: {
+      additional_params?: {
+        block_filter_scripts?: string;
+        block_golomb_filter_p?: number;
+      };
+    };
   };
 };
 

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -2,14 +2,14 @@
     "avalanche": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "bcash": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -30,8 +30,8 @@
     "bitcoin": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasic", "WsGetAccountUtxo", "WsPing", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific", "WsLongTermFeeRate", "WsGetBlockFilter", "WsGetBlockFiltersBatch", "WsGetMempoolFilters"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter",
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasic", "WsGetAccountUtxo", "WsPing", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific", "WsLongTermFeeRate", "WsGetBlockFilter", "WsGetBlockFiltersBatch", "WsGetMempoolFilters", "GetBlockFilters", "GetBlockFiltersInvalidScriptType"],
         "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                  "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -39,7 +39,7 @@
     "bitcoin_regtest": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-          "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+          "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
           "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -47,7 +47,7 @@
     "bitcoin_testnet": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                  "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -55,7 +55,7 @@
     "bitcoin_testnet4": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                  "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -78,7 +78,7 @@
     "bsc": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
@@ -124,7 +124,7 @@
     "dogecoin": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "MempoolSync"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks"]
     },
@@ -170,7 +170,7 @@
     "litecoin": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "EstimateSmartFee", "EstimateFee"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -196,7 +196,7 @@
     "zcash": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetAddressTxsScientificNotation", "GetUtxo", "GetUtxoConfirmedFilter"],
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetAddressTxsScientificNotation", "GetUtxo", "GetUtxoConfirmedFilter"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                 "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -288,49 +288,49 @@
     "arbitrum": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "base": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressProtocolsEVM", "GetAddressProtocolsOptInEVM", "GetContractInfoEVM", "GetContractInfoOptInEVM", "GetContractInfoNonVaultEVM", "Erc4626FeeInvariantEVM", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressProtocolsEVM", "GetAddressProtocolsOptInEVM", "GetContractInfoEVM", "GetContractInfoOptInEVM", "GetContractInfoNonVaultEVM", "Erc4626FeeInvariantEVM", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsGetAccountInfoProtocolsEVM", "WsGetContractInfoEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "ethereum": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressProtocolsEVM", "GetAddressProtocolsOptInEVM", "GetContractInfoEVM", "GetContractInfoOptInEVM", "GetContractInfoNonVaultEVM", "Erc4626FeeInvariantEVM", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressProtocolsEVM", "GetAddressProtocolsOptInEVM", "GetContractInfoEVM", "GetContractInfoOptInEVM", "GetContractInfoNonVaultEVM", "Erc4626FeeInvariantEVM", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsGetAccountInfoProtocolsEVM", "WsGetContractInfoEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader"]
     },
     "ethereum-classic": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader"]
     },
     "optimism": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "polygon": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "tron": {
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
-                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs",
+                "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs",
                 "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
                 "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader"]

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -3,7 +3,7 @@
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "bcash": {
@@ -31,7 +31,7 @@
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasic", "WsGetAccountUtxo", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasic", "WsGetAccountUtxo", "WsPing", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific", "WsLongTermFeeRate", "WsGetBlockFilter", "WsGetBlockFiltersBatch", "WsGetMempoolFilters"],
         "rpc":  ["GetBlock", "GetBlockHash", "GetTransaction", "GetTransactionForMempool", "MempoolSync",
                  "EstimateSmartFee", "EstimateFee", "GetBestBlockHash", "GetBestBlockHeight", "GetBlockHeader"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks", "HandleFork"]
@@ -79,7 +79,7 @@
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "cpuchain": {
@@ -289,42 +289,42 @@
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "base": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressProtocolsEVM", "GetAddressProtocolsOptInEVM", "GetContractInfoEVM", "GetContractInfoOptInEVM", "GetContractInfoNonVaultEVM", "Erc4626FeeInvariantEVM", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsGetAccountInfoProtocolsEVM", "WsGetContractInfoEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsGetAccountInfoProtocolsEVM", "WsGetContractInfoEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "ethereum": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressProtocolsEVM", "GetAddressProtocolsOptInEVM", "GetContractInfoEVM", "GetContractInfoOptInEVM", "GetContractInfoNonVaultEVM", "Erc4626FeeInvariantEVM", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsGetAccountInfoProtocolsEVM", "WsGetContractInfoEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsGetAccountInfoProtocolsEVM", "WsGetContractInfoEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader"]
     },
     "ethereum-classic": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader"]
     },
     "optimism": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "polygon": {
         "connectivity": ["http", "ws"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader", "EthCallBatch"]
     },
     "tron": {
@@ -332,7 +332,7 @@
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetAddressTxids", "GetAddressTxs",
                 "GetAddressBasicEVM", "GetAddressTokensEVM", "GetAddressTokenBalances", "GetAddressTxidsPaginationEVM", "GetAddressTxsPaginationEVM", "GetAddressContractFilterEVM", "GetTransactionEVMShape",
-                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing"],
+                "WsGetInfo", "WsGetBlockHash", "WsGetTransaction", "WsGetAccountInfo", "WsGetAccountInfoBasicEVM", "WsGetAccountInfoEVM", "WsGetAccountInfoTxidsConsistencyEVM", "WsGetAccountInfoTxsConsistencyEVM", "WsGetAccountInfoContractFilterEVM", "WsPing", "WsGetCurrentFiatRates", "WsGetFiatRatesForTimestamps", "WsGetFiatRatesTickersList", "WsGetBlock", "WsGetBalanceHistory", "WsGetTransactionSpecific"],
         "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "EstimateFee", "GetBlockHeader"]
     }
 }


### PR DESCRIPTION
## Test report
- added machine-readable e2e test report (jUnit XML) to see the test results directly in the Github CI
- `make e2e-test` accepts crypto and blockbook url as parameters for local debugging purposes

## Fiat rates
- Check that the current tickers are fresh (no older than 2 hours)
- All rates in the response should be >0 (-1 indicates an error)
- Tests both REST and websocket endpoint
## Other added tests
- websocket tests - getblock, balancehistory, tx-specific