### PR TITLE
xpub(fix): XSS in xpub explorer descriptor handling

### DIFF
--- a/bchain/coins/btc/bitcoinlikeparser.go
+++ b/bchain/coins/btc/bitcoinlikeparser.go
@@ -442,7 +442,7 @@ var (
 
 func init() {
 	var err error
-	xpubDesriptorRegex, err = regexp.Compile(`^(?P<type>(sh\(wpkh|wpkh|pk|pkh|wpkh|wsh|tr))\((\[\w+/(?P<bip>\d+)['h]/\d+['h]?/\d+['h]?\])?(?P<xpub>\w+)(/(({(?P<changelist1>\d+(,\d+)*)})|(<(?P<changelist2>\d+(;\d+)*)>)|(?P<change>\d+))/\*)?\)+`)
+	xpubDesriptorRegex, err = regexp.Compile(`^(?P<type>(sh\(wpkh|wpkh|pk|pkh|wpkh|wsh|tr))\((\[\w+/(?P<bip>\d+)['h]/\d+['h]?/\d+['h]?\])?(?P<xpub>\w+)(/(({(?P<changelist1>\d+(,\d+)*)})|(<(?P<changelist2>\d+(;\d+)*)>)|(?P<change>\d+))/\*)?\)+(#[a-z0-9]{8})?$`)
 	if err != nil {
 		panic(errors.Annotate(err, "Invalid bitcoinparser xpubDesriptorRegex"))
 	}

--- a/bchain/coins/btc/bitcoinparser_test.go
+++ b/bchain/coins/btc/bitcoinparser_test.go
@@ -1001,6 +1001,12 @@ func TestParseXpubDescriptors(t *testing.T) {
 			},
 		},
 		{
+			name:    "wpkh(xpub) error - trailing JS suffix",
+			xpub:    `wpkh(xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ)"});alert(1);//`,
+			parser:  btcMainParser,
+			wantErr: true,
+		},
+		{
 			name:    "xxx(xpub) error - unknown output script",
 			xpub:    "xxx(xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ)",
 			parser:  btcMainParser,

--- a/server/html_templates_test.go
+++ b/server/html_templates_test.go
@@ -442,3 +442,22 @@ func Test_tokenDetailTemplateEscapesScriptEndTagInJSContext(t *testing.T) {
 		t.Fatalf("escaped script-end-tag payload not found in output: %s", body)
 	}
 }
+
+func Test_jsStrEscapesQRCodeTextInJSContext(t *testing.T) {
+	tmpl := template.Must(template.New("qrcode").Funcs(template.FuncMap{
+		"jsStr": jsStr,
+	}).Parse(`<script>new QRCode(document.getElementById("qrcode"), { text: {{jsStr .}}, width: 120, height: 120 });</script>`))
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, `wpkh(xpub)"});alert(1);//`); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	body := rendered.String()
+
+	if strings.Contains(body, `text: "wpkh(xpub)"});alert(1);//"`) {
+		t.Fatalf("found unescaped QR code text breakout payload in output: %s", body)
+	}
+	if !strings.Contains(body, `text: "wpkh(xpub)\"});alert(1);//"`) {
+		t.Fatalf("escaped QR code text literal not found in output: %s", body)
+	}
+}

--- a/server/public.go
+++ b/server/public.go
@@ -922,6 +922,8 @@ func tokenCount(tokens []api.Token, t bchain.TokenStandardName) int {
 	return count
 }
 
+// jsStr renders s as a complete, quoted JS string literal for use in a JS expression context (e.g. inside <script>).
+// json.Marshal also escapes <, >, & so the result is safe to embed in <script>; it never errors for a string input.
 func jsStr(s string) template.JS {
 	b, _ := json.Marshal(s)
 	return template.JS(b)

--- a/server/public.go
+++ b/server/public.go
@@ -922,8 +922,9 @@ func tokenCount(tokens []api.Token, t bchain.TokenStandardName) int {
 	return count
 }
 
-func jsStr(s string) template.JSStr {
-	return template.JSStr(s)
+func jsStr(s string) template.JS {
+	b, _ := json.Marshal(s)
+	return template.JS(b)
 }
 
 func (s *PublicServer) explorerTx(w http.ResponseWriter, r *http.Request) (tpl, *TemplateData, error) {


### PR DESCRIPTION
Blockbook accepts xpub descriptors on the /xpub/ explorer route. The Bitcoin descriptor parser matches only a valid prefix because xpubDesriptorRegex is anchored with ^ but has no terminal $, and ParseXpub uses FindStringSubmatch. The parser validates the extracted xpub, but descriptor.XpubDescriptor and the API response keep the original user-supplied string. The xpub template then renders that string through template.JSStr inside the QR-code JavaScript expression.