### PR TITLE
fix(fiat-rates): make CoinGecko fetching resilient to 429

### DIFF
--- a/blockbook.go
+++ b/blockbook.go
@@ -763,8 +763,21 @@ func computeFeeStats(stopCompute chan os.Signal, blockFrom, blockTo int, db *db.
 	return err
 }
 
+// runStartupSelfHealing runs blocking, at-startup self-healing tasks once RocksDB is
+// initialized. It blocks until done so the rest of startup proceeds against a consistent DB.
+// Future self-healing tasks can be added here; today it reconciles missing historical fiat
+// rates before the periodic downloader loops start.
+func runStartupSelfHealing() {
+	if fiatRates != nil && fiatRates.Enabled {
+		fiatRates.ReconcileHistoricalRatesAtStartup()
+	}
+}
+
 func initDownloaders(db *db.RocksDB, chain bchain.BlockChain, config *common.Config) {
 	if fiatRates.Enabled {
+		// Block on startup self-healing before the periodic loops begin, so historical gaps
+		// are repaired via the CDN without contending with the Free-tier tip loop.
+		runStartupSelfHealing()
 		go fiatRates.RunDownloader()
 	}
 

--- a/blockbook.go
+++ b/blockbook.go
@@ -769,7 +769,9 @@ func computeFeeStats(stopCompute chan os.Signal, blockFrom, blockTo int, db *db.
 // rates before the periodic downloader loops start.
 func runStartupSelfHealing() {
 	if fiatRates != nil && fiatRates.Enabled {
-		fiatRates.ReconcileHistoricalRatesAtStartup()
+		// chanOsSignal is closed on shutdown, so a SIGTERM during a long reconciliation
+		// aborts it promptly instead of blocking startup-shutdown until the backfill ends.
+		fiatRates.ReconcileHistoricalRatesAtStartup(chanOsSignal)
 	}
 }
 

--- a/common/metrics.go
+++ b/common/metrics.go
@@ -80,6 +80,9 @@ type Metrics struct {
 	CoingeckoRequests                 *prometheus.CounterVec   `metric:"coingecko_requests"`
 	CoingeckoRangeRequests            *prometheus.CounterVec   `metric:"coingecko_range_requests"`
 	FiatRatesUpdateDuration           *prometheus.HistogramVec `metric:"fiat_rates_update_duration_seconds"`
+	FiatRatesFetchedUnits             *prometheus.CounterVec   `metric:"fiat_rates_fetched_units_total"`
+	FiatRatesFetchedTokens            *prometheus.CounterVec   `metric:"fiat_rates_fetched_tokens_total"`
+	FiatRatesUnable                   *prometheus.CounterVec   `metric:"fiat_rates_unable_total"`
 	AlternativeFeeProviderRequests    *prometheus.CounterVec   `metric:"alternative_fee_provider_requests"`
 	EthSyncRpcErrors                  *prometheus.CounterVec   `metric:"eth_sync_rpc_errors"`
 }

--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -585,7 +585,7 @@ panels:
         legend: '{{coin}} - {{instance}} tokens repaired/h'
   fiatrates.unable:
     title: Unable to fetch (by reason)
-    description: Fiat-rate series that could not be fetched, split by phase and reason. gap_too_large flags series stale beyond the reconcile guard (probable bug); fetch_failed/provider_banned are transport failures; no_base_ticker is a token day lacking a base-currency ticker.
+    description: Fiat-rate series that could not be fetched, split by phase and reason. gap_too_large flags series stale beyond the reconcile guard (probable bug); fetch_failed/provider_banned are transport failures; no_base_ticker is a token day lacking a base-currency ticker; budget_exhausted means the startup reconcile wall-clock budget elapsed before completion (remaining series retried next startup).
     queries:
       by_reason:
         promql: sum(increase({{name:fiat_rates_unable_total}}{job="blockbook", coin="$coin"}[1h])) by (phase, reason)

--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -554,3 +554,39 @@ panels:
       p95:
         promql: histogram_quantile(0.95, sum(increase({{name:fiat_rates_update_duration_seconds}}_bucket{job="blockbook", coin="$coin"}[1h])) by (coin, stage, status, le))
         legend: '{{coin}} - {{stage}} - {{status}}'
+  row.fiat_rates:
+    title: Fiat Rates
+  fiatrates.tip_fetches:
+    title: Chain tip fetches (<=1 day, Free tier)
+    description: Daily fiat-rate points fetched for the chain tip (gap of one day), the only historical range still served from the rate-limited CoinGecko Free tier. Steady-state activity here is normal; sustained zero across a day means the tip update is failing.
+    queries:
+      units:
+        promql: sum(rate({{name:fiat_rates_fetched_units_total}}{job="blockbook", coin="$coin", phase="tip"}[$__rate_interval])) by (coin, instance) * 60
+        legend: '{{coin}} - {{instance}} tip points/min'
+  fiatrates.backfill_fetches:
+    title: Backfill fetches (>1 day, via CDN)
+    description: Higher-volume historical ranges routed to the Trezor CDN — multi-day downtime catch-up (backfill) and full-history population (bootstrap). units are daily points; tokens are token series. These should stay off the Free tier.
+    queries:
+      units:
+        promql: sum(rate({{name:fiat_rates_fetched_units_total}}{job="blockbook", coin="$coin", phase=~"backfill|bootstrap"}[$__rate_interval])) by (phase) * 60
+        legend: '{{coin}} - {{phase}} points/min'
+      tokens:
+        promql: sum(rate({{name:fiat_rates_fetched_tokens_total}}{job="blockbook", coin="$coin", phase=~"backfill|bootstrap"}[$__rate_interval])) by (phase) * 60
+        legend: '{{coin}} - {{phase}} tokens/min'
+  fiatrates.reconcile:
+    title: Startup reconciliation (self-healing)
+    description: Daily points and token series repaired by the blocking at-startup self-healing pass via the CDN. Bursts at process start are expected; recurring large bursts on every restart suggest persistent holes the provider cannot fill.
+    queries:
+      units:
+        promql: sum(increase({{name:fiat_rates_fetched_units_total}}{job="blockbook", coin="$coin", phase="reconcile"}[1h])) by (coin, instance)
+        legend: '{{coin}} - {{instance}} points repaired/h'
+      tokens:
+        promql: sum(increase({{name:fiat_rates_fetched_tokens_total}}{job="blockbook", coin="$coin", phase="reconcile"}[1h])) by (coin, instance)
+        legend: '{{coin}} - {{instance}} tokens repaired/h'
+  fiatrates.unable:
+    title: Unable to fetch (by reason)
+    description: Fiat-rate series that could not be fetched, split by phase and reason. gap_too_large flags series stale beyond the reconcile guard (probable bug); fetch_failed/provider_banned are transport failures; no_base_ticker is a token day lacking a base-currency ticker.
+    queries:
+      by_reason:
+        promql: sum(increase({{name:fiat_rates_unable_total}}{job="blockbook", coin="$coin"}[1h])) by (phase, reason)
+        legend: '{{coin}} - {{phase}} - {{reason}}'

--- a/configs/grafana/template.json
+++ b/configs/grafana/template.json
@@ -4452,6 +4452,265 @@
       ],
       "type": "timeseries",
       "x-panel-key": "general.fiat_update_duration_p95"
+    },
+    {
+      "collapsed": false,
+      "id": 321,
+      "panels": [],
+      "type": "row",
+      "x-panel-key": "row.fiat_rates"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 322,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "units"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "fiatrates.tip_fetches"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 323,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "units"
+        },
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "B",
+          "x-query-key": "tokens"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "fiatrates.backfill_fetches"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 324,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "units"
+        },
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "B",
+          "x-query-key": "tokens"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "fiatrates.reconcile"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 325,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "by_reason"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "fiatrates.unable"
     }
   ],
   "preload": false,

--- a/configs/metrics.yaml
+++ b/configs/metrics.yaml
@@ -298,6 +298,21 @@ metrics:
     help: Time spent in fiat-rate downloader stages such as current, hourly, historical and token ticker updates
     labels: [stage, status]
     buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300]
+  fiat_rates_fetched_units_total:
+    name: blockbook_fiat_rates_fetched_units_total
+    type: counter_vec
+    help: Daily fiat-rate time-units fetched and persisted, split by fetch phase (tip, backfill, bootstrap, reconcile)
+    labels: [phase]
+  fiat_rates_fetched_tokens_total:
+    name: blockbook_fiat_rates_fetched_tokens_total
+    type: counter_vec
+    help: Token fiat-rate series fetched and persisted, split by fetch phase (backfill, bootstrap, reconcile)
+    labels: [phase]
+  fiat_rates_unable_total:
+    name: blockbook_fiat_rates_unable_total
+    type: counter_vec
+    help: Fiat-rate series that could not be fetched, split by phase and reason (gap_too_large, fetch_failed, provider_banned, no_base_ticker)
+    labels: [phase, reason]
   alternative_fee_provider_requests:
     name: blockbook_alternative_fee_provider_requests
     type: counter_vec

--- a/configs/metrics.yaml
+++ b/configs/metrics.yaml
@@ -311,7 +311,7 @@ metrics:
   fiat_rates_unable_total:
     name: blockbook_fiat_rates_unable_total
     type: counter_vec
-    help: Fiat-rate series that could not be fetched, split by phase and reason (gap_too_large, fetch_failed, provider_banned, no_base_ticker)
+    help: Fiat-rate series that could not be fetched, split by phase and reason (gap_too_large, fetch_failed, provider_banned, no_base_ticker, budget_exhausted)
     labels: [phase, reason]
   alternative_fee_provider_requests:
     name: blockbook_alternative_fee_provider_requests

--- a/db/fiat.go
+++ b/db/fiat.go
@@ -234,6 +234,27 @@ func (d *RocksDB) FiatRatesGetAllTickers(fn func(ticker *common.CurrencyRatesTic
 	return nil
 }
 
+// FiatRatesGetTickerTimestamps returns, in ascending order, the unix-second timestamps of all
+// stored fiat-rate tickers at or after `from`. It reads keys only (no value decoding), so it
+// stays cheap even over long history -- used by the startup reconciliation to detect which
+// whole days are missing without loading every (potentially large) record.
+func (d *RocksDB) FiatRatesGetTickerTimestamps(from time.Time) ([]int64, error) {
+	fromKey := []byte(from.UTC().Format(FiatRatesTimeFormat))
+	it := d.db.NewIteratorCF(d.ro, d.cfh[cfFiatRates])
+	defer it.Close()
+
+	var timestamps []int64
+	for it.Seek(fromKey); it.Valid(); it.Next() {
+		t, err := time.Parse(FiatRatesTimeFormat, string(it.Key().Data()))
+		if err != nil {
+			// defensively skip any key that is not a valid timestamp
+			continue
+		}
+		timestamps = append(timestamps, t.Unix())
+	}
+	return timestamps, nil
+}
+
 // FiatRatesFindLastTicker gets the last FiatRates record, of the base currency, vsCurrency or the token if specified
 func (d *RocksDB) FiatRatesFindLastTicker(vsCurrency string, token string) (*common.CurrencyRatesTicker, error) {
 	it := d.db.NewIteratorCF(d.ro, d.cfh[cfFiatRates])

--- a/db/sync.go
+++ b/db/sync.go
@@ -198,13 +198,16 @@ func (w *SyncWorker) ResyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 	switch err {
 	case nil:
 		d := time.Since(start)
-		glog.Info("resync: finished in ", d)
 		w.metrics.IndexResyncDuration.Observe(float64(d) / 1e6) // in milliseconds
 		w.metrics.IndexDBSize.Set(float64(w.db.DatabaseSizeOnDisk()))
-		bh, _, err := w.db.GetBestBlock()
+		bh, bhash, err := w.db.GetBestBlock()
 		if err == nil {
 			w.is.FinishedSync(bh)
 		}
+		// Single steady-state sync line: what we synced to and how long it took.
+		// The "is behind" trigger and the connectBlocks "synced at" line are
+		// intentionally not logged, as they fire every block on fast chains.
+		glog.Infof("resync: synced at %d %s in %s", bh, bhash, d)
 		w.metrics.BackendBestHeight.Set(float64(w.is.BackendInfo.Blocks))
 		w.metrics.BlockbookBestHeight.Set(float64(bh))
 		return err
@@ -248,7 +251,6 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 			glog.Info("resync: local is forked at height ", localBestHeight, ", local hash ", localBestHash, ", remote hash ", remoteHash)
 			return w.handleFork(localBestHeight, localBestHash, onNewBlock, initialSync)
 		}
-		glog.Info("resync: local at ", localBestHeight, " is behind")
 		w.startHeight = localBestHeight + 1
 	} else {
 		// database is empty, start genesis
@@ -413,10 +415,6 @@ ConnectLoop:
 				return err
 			}
 		}
-	}
-
-	if lastRes.block != nil {
-		glog.Infof("resync: synced at %d %s", lastRes.block.Height, lastRes.block.Hash)
 	}
 
 	return nil

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -243,13 +243,14 @@ func retryAfterFromError(err error) time.Duration {
 	if errors.As(err, &httpErr) {
 		return httpErr.retryAfter
 	}
+	glog.Errorf("No retryAfter header found in the headers: %s", err.Error())
 	return 0
 }
 
 func throttleBackoffDelay(attempt int, err error) time.Duration {
-	delay := coingeckoThrottleRetryBackoff[attempt]
-	if ra := retryAfterFromError(err); ra > delay {
-		delay = ra
+	delay := retryAfterFromError(err)
+	if delay <= 0 {
+		delay = coingeckoThrottleRetryBackoff[attempt]
 	}
 	if delay <= 0 {
 		return 0

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -295,6 +295,10 @@ func isCoingeckoThrottleError(err error) bool {
 		strings.Contains(lowerError, "throttled")
 }
 
+func isCoingeckoCloudflareBanError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "error code: 1015")
+}
+
 func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 	return errors.Is(err, errCoingeckoHistoricalTokenUpdateInProgress)
 }
@@ -388,6 +392,14 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority 
 				cg.metrics.CoingeckoRequests.With(common.Labels{"endpoint": endpoint, "status": "success"}).Inc()
 			}
 			return resp, err
+		}
+
+		if isCoingeckoCloudflareBanError(err) {
+			if cg.metrics != nil {
+				cg.metrics.CoingeckoRequests.With(common.Labels{"endpoint": endpoint, "status": "banned"}).Inc()
+			}
+			glog.Warningf("Coingecko makeReq %v Cloudflare rate-limit ban (1015), fast-failing: %v", url, err)
+			return nil, err
 		}
 		if !isCoingeckoThrottleError(err) {
 			if cg.metrics != nil {
@@ -781,6 +793,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	cg.cacheMu.Unlock()
 
 	hadFailures := false
+	var banErr error
 	for _, currency := range vs {
 		// get historical rates for each currency
 		var err error
@@ -789,10 +802,17 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 			// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 			// the rates will be updated next run
 			glog.Errorf("getHistoricalTicker %s-%s %v", cg.coin, currency, err)
+			if isCoingeckoCloudflareBanError(err) {
+				banErr = err
+				break
+			}
 		}
 	}
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
 		return err
+	}
+	if banErr != nil {
+		return banErr
 	}
 	if bootstrapInProgress && hadFailures {
 		return fmt.Errorf("coingecko historical bootstrap incomplete: one or more currency updates failed")
@@ -839,6 +859,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		cg.cacheMu.Unlock()
 		glog.Infof("Coingecko returned %d %s tokens ", len(platformIds), cg.coin)
 		count := 0
+		var banErr error
 		// get token historical rates
 		for tokenId, token := range platformIdsToTokens {
 			var err error
@@ -846,6 +867,10 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run
 				glog.Errorf("getHistoricalTicker %s-%s %v", tokenId, cg.platformVsCurrency, err)
+				if isCoingeckoCloudflareBanError(err) {
+					banErr = err
+					break
+				}
 			}
 			count++
 			if count%100 == 0 {
@@ -856,6 +881,12 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 				tickersToUpdate = make(map[uint]*common.CurrencyRatesTicker)
 				glog.Infof("Coingecko updated %d of %d token tickers", count, len(platformIds))
 			}
+		}
+		if banErr != nil {
+			if err := cg.storeTickers(tickersToUpdate); err != nil {
+				return err
+			}
+			return banErr
 		}
 	}
 

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -887,7 +887,7 @@ func (cg *Coingecko) getHistoricalTicker(ctx context.Context, tickersToUpdate ma
 	}
 	cg.observeFetchedUnits(phase, written)
 	if token != "" && written > 0 {
-		cg.observeFetchedToken(phase)
+		cg.observeFetchedToken(phase, 1)
 	}
 	cg.observeUnable(phase, fiatUnableNoBaseTicker, noBaseTicker)
 	return true, nil
@@ -899,9 +899,9 @@ func (cg *Coingecko) observeFetchedUnits(phase string, n int) {
 	}
 }
 
-func (cg *Coingecko) observeFetchedToken(phase string) {
-	if cg.metrics != nil {
-		cg.metrics.FiatRatesFetchedTokens.With(common.Labels{"phase": phase}).Inc()
+func (cg *Coingecko) observeFetchedToken(phase string, n int) {
+	if cg.metrics != nil && n > 0 {
+		cg.metrics.FiatRatesFetchedTokens.With(common.Labels{"phase": phase}).Add(float64(n))
 	}
 }
 
@@ -1154,10 +1154,19 @@ func (cg *Coingecko) missingDayWindow(windowDays int) (missing map[uint]struct{}
 // population) or when no CDN URL is configured.
 //
 // ctx bounds the whole pass: it carries both the shutdown signal and a wall-clock budget, so a
-// SIGTERM or a persistently throttling CDN aborts the pass promptly instead of stalling
-// startup. On abort, any days already fetched are persisted so the next startup resumes from
-// the remaining gap; a budget timeout is also recorded as fiat_rates_unable_total{reason=
-// "budget_exhausted"} so it is visible in monitoring.
+// SIGTERM or a persistently throttling CDN aborts the pass promptly instead of stalling startup.
+// Persistence is all-or-nothing per pass: results are written only after the loop has run to
+// completion over every target. On any early exit (abort, budget timeout, Cloudflare ban, or DB
+// error) the partially fetched days are discarded, not persisted, so a day is never marked
+// "present" while still missing the series the un-run targets would have filled (which the
+// whole-day key-only stage-1 scan could not later detect); the next startup re-reconciles the
+// gap. A budget timeout is recorded as fiat_rates_unable_total{reason="budget_exhausted"} so it
+// is visible in monitoring. (An isolated per-series fetch failure is skipped, not an early exit:
+// the pass still completes and persists, leaving that series' day a partial-day hole.)
+//
+// Scope: this repairs days that are wholly absent from the DB. A day that has a record but is
+// missing a particular vsCurrency or token (a partial-day hole) is treated as present and is not
+// repaired here; that is handled separately.
 func (cg *Coingecko) ReconcileHistoricalRates(ctx context.Context, windowDays int, maxGapDays int) (int, error) {
 	bootstrapInProgress, _, err := historicalBootstrapInProgress(cg.db)
 	if err != nil {
@@ -1248,17 +1257,27 @@ func (cg *Coingecko) ReconcileHistoricalRates(ctx context.Context, windowDays in
 		len(missingDays), windowDays, time.Unix(earliestMissing, 0).UTC().Format("2006-01-02"), fetchDays, len(targets))
 
 	// ---- Stage 2: fetch the missing-day range from the CDN and fill only those days ----
-	// targetDays ensures only the (few) missing-day records are touched and persisted, so the
-	// shared map holds at most len(missingDays) records regardless of how many series we scan.
+	// targetDays ensures only the (few) missing-day records are touched, so the shared map holds at
+	// most len(missingDays) records regardless of how many series we scan.
+	//
+	// All-or-nothing persistence: every target writes into the SAME per-day records (base coin x
+	// each vsCurrency first, then every token), so a day record is only as complete as it will ever
+	// be once ALL targets have run. We therefore persist the map only after a clean, complete pass.
+	// On any early exit -- a shutdown/budget abort, a Cloudflare ban, or a DB fill error -- the
+	// accumulated records are missing the series from the un-run targets (e.g. after a base-phase
+	// abort they hold base rates but no token rates). Because stage-1 detection is whole-day
+	// key-only, persisting such a record would mark the day "present" and it would never be
+	// reconciled again, silently dropping the un-run series for good. So on an early exit we discard
+	// the partial map and let the next startup re-reconcile the whole gap from scratch. (A future
+	// per-day completion checkpoint could let an aborted run resume without refetching.)
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
-	filled, failed, repairedTokens := 0, 0, 0
+	filled, failed, repairedTokens, noBaseTotal := 0, 0, 0, 0
 	var banErr, abortErr error
 	abortAt := 0
 	for i, c := range targets {
-		// Abort promptly on shutdown or budget timeout; persist what we already fetched (below)
-		// so the next startup resumes from the remaining gap rather than refetching from scratch.
-		// The check before the fetch catches cancellation between iterations; the one after
-		// catches cancellation during the in-flight fetch.
+		// Abort promptly on shutdown or budget timeout. The check before the fetch catches
+		// cancellation between iterations; the one after catches cancellation during the in-flight
+		// fetch. The accumulated map is discarded after the loop (see above).
 		if err := ctx.Err(); err != nil {
 			abortErr, abortAt = err, i
 			break
@@ -1272,7 +1291,7 @@ func (cg *Coingecko) ReconcileHistoricalRates(ctx context.Context, windowDays in
 			failed++
 			if isCoingeckoCloudflareBanError(err) {
 				cg.observeUnable(fiatPhaseReconcile, fiatUnableProviderBan, 1)
-				banErr = err
+				banErr, abortAt = err, i
 				glog.Errorf("FiatRates reconcile: Cloudflare ban fetching %s/%s, stopping: %v", c.coinId, c.vsCurrency, err)
 				break
 			}
@@ -1282,35 +1301,41 @@ func (cg *Coingecko) ReconcileHistoricalRates(ctx context.Context, windowDays in
 		}
 		written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, c.vsCurrency, c.token, true, missingDays)
 		if err != nil {
-			if storeErr := cg.storeTickers(tickersToUpdate); storeErr != nil {
-				return filled, storeErr
-			}
-			return filled, fmt.Errorf("reconcile: fill %s/%s: %w", c.coinId, c.vsCurrency, err)
+			// A DB fill error is an abnormal mid-pass exit: discard the partial map (do not persist)
+			// and surface the error so the next startup retries the whole gap.
+			return 0, fmt.Errorf("reconcile: fill %s/%s: %w", c.coinId, c.vsCurrency, err)
 		}
 		filled += written
-		cg.observeFetchedUnits(fiatPhaseReconcile, written)
+		noBaseTotal += noBaseTicker
 		if c.token != "" && written > 0 {
 			repairedTokens++
-			cg.observeFetchedToken(fiatPhaseReconcile)
 		}
-		cg.observeUnable(fiatPhaseReconcile, fiatUnableNoBaseTicker, noBaseTicker)
 	}
-	if err := cg.storeTickers(tickersToUpdate); err != nil {
-		return filled, err
-	}
+
+	// Early exit: discard the incomplete map (see the block comment above) so no day is wrongly
+	// marked present; nothing is persisted, so report 0 filled.
 	if abortErr != nil {
 		remaining := len(targets) - abortAt
-		// a budget timeout (vs. a clean shutdown) is a problem worth surfacing in monitoring:
-		// the window was too small or the CDN too slow to finish.
+		// A budget timeout (vs. a clean shutdown) is worth surfacing in monitoring: the window was
+		// too small or the CDN too slow to finish within the budget.
 		if errors.Is(abortErr, context.DeadlineExceeded) {
 			cg.observeUnable(fiatPhaseReconcile, fiatUnableBudgetExhausted, remaining)
 		}
-		glog.Warningf("FiatRates reconcile stage 2: aborted (%v), persisted %d point(s) (%d token series), %d fetch failures, %d series unprocessed; remaining gap will be reconciled on next startup", abortErr, filled, repairedTokens, failed, remaining)
-		return filled, nil
+		glog.Warningf("FiatRates reconcile stage 2: aborted (%v) after %d/%d series, %d fetch failures; discarding partial results, gap will be reconciled on next startup", abortErr, abortAt, len(targets), failed)
+		return 0, nil
 	}
-	glog.Infof("FiatRates reconcile stage 2: filled %d point(s) across %d series (%d token series), %d fetch failures", filled, len(targets), repairedTokens, failed)
 	if banErr != nil {
-		return filled, banErr
+		glog.Warningf("FiatRates reconcile stage 2: Cloudflare ban after %d/%d series, %d fetch failures; discarding partial results, gap will be reconciled on next startup", abortAt, len(targets), failed)
+		return 0, banErr
 	}
+
+	// Clean, complete pass: persist, then record what was actually fetched and persisted.
+	if err := cg.storeTickers(tickersToUpdate); err != nil {
+		return 0, err
+	}
+	cg.observeFetchedUnits(fiatPhaseReconcile, filled)
+	cg.observeFetchedToken(fiatPhaseReconcile, repairedTokens)
+	cg.observeUnable(fiatPhaseReconcile, fiatUnableNoBaseTicker, noBaseTotal)
+	glog.Infof("FiatRates reconcile stage 2: filled %d point(s) across %d series (%d token series), %d fetch failures", filled, len(targets), repairedTokens, failed)
 	return filled, nil
 }

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -37,12 +37,21 @@ const (
 	coingeckoAPIKeyEnvSuffix          = "_" + coingeckoAPIKeyEnv
 )
 
-var coingeckoThrottleRetryBackoff = []time.Duration{
-	1 * time.Minute,
-	2 * time.Minute,
-	4 * time.Minute,
-	8 * time.Minute,
-}
+// used when retry-after header is missing
+var coingeckoThrottleBackoff = time.Minute
+
+// how often a parked low-priority request re-checks the throttle gate
+// var (not const) so tests can shrink it to avoid real waits
+var coingeckoLowPriorityPollInterval = time.Second
+
+// reqPriority determines which requests reclaim request slots first while a
+// shared throttle window (429) is open.
+type reqPriority int
+
+const (
+	priorityHigh reqPriority = iota // current tickers + high-granularity fetches
+	priorityLow                     // historical (daily) ticker updates
+)
 
 var errCoingeckoHistoricalTokenUpdateInProgress = errors.New("coingecko historical token update already in progress")
 
@@ -78,6 +87,8 @@ type Coingecko struct {
 	minHttpRequestInterval time.Duration
 	reqMu                  sync.Mutex
 	lastRequestAt          time.Time
+	throttledUntil         time.Time // set on any 429; every request waits past it
+	highPriorityInFlight   int       // high-priority requests currently in flight, including their retries
 }
 
 // simpleSupportedVSCurrencies https://api.coingecko.com/api/v3/simple/supported_vs_currencies
@@ -247,10 +258,10 @@ func retryAfterFromError(err error) time.Duration {
 	return 0
 }
 
-func throttleBackoffDelay(attempt int, err error) time.Duration {
+func throttleBackoffDelay(err error) time.Duration {
 	delay := retryAfterFromError(err)
 	if delay <= 0 {
-		delay = coingeckoThrottleRetryBackoff[attempt]
+		delay = coingeckoThrottleBackoff
 	}
 	if delay <= 0 {
 		return 0
@@ -288,7 +299,9 @@ func isCoingeckoThrottleError(err error) bool {
 		return true
 	}
 	lowerError := strings.ToLower(err.Error())
-	return err.Error() == "error code: 1015" ||
+	// Cloudflare serves rate-limit blocks as a full HTML page that merely contains
+	// "error code: 1015", so match it as a substring rather than the whole body.
+	return strings.Contains(lowerError, "error code: 1015") ||
 		strings.Contains(lowerError, "exceeded the rate limit") ||
 		strings.Contains(lowerError, "throttled")
 }
@@ -302,30 +315,68 @@ func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 	return errors.Is(err, errCoingeckoHistoricalTokenUpdateInProgress)
 }
 
-// waitForRateLimit enforces minHttpRequestInterval spacing between requests
-func (cg *Coingecko) waitForRateLimit() {
-	if cg.minHttpRequestInterval <= 0 {
-		return
-	}
-	cg.reqMu.Lock()
-	slot := time.Now()
-	if !cg.lastRequestAt.IsZero() {
-		if next := cg.lastRequestAt.Add(cg.minHttpRequestInterval); next.After(slot) {
-			slot = next
+// waitForRequestSlot enforces minHttpRequestInterval spacing between requests and makes
+// every request wait out the shared throttle window opened by any 429. While the window
+// is open, low-priority requests additionally yield to in-flight high-priority ones so
+// current/high-granularity fetches reclaim request slots first.
+func (cg *Coingecko) waitForRequestSlot(priority reqPriority) {
+	for {
+		cg.reqMu.Lock()
+		now := time.Now()
+		if priority == priorityLow && cg.throttledUntil.After(now) && cg.highPriorityInFlight > 0 {
+			cg.reqMu.Unlock()
+			time.Sleep(coingeckoLowPriorityPollInterval)
+			continue
 		}
-	}
-	cg.lastRequestAt = slot
-	cg.reqMu.Unlock()
-	if d := time.Until(slot); d > 0 {
-		time.Sleep(d)
+		slot := now
+		if !cg.lastRequestAt.IsZero() {
+			if next := cg.lastRequestAt.Add(cg.minHttpRequestInterval); next.After(slot) {
+				slot = next
+			}
+		}
+		if cg.throttledUntil.After(slot) {
+			slot = cg.throttledUntil
+		}
+		cg.lastRequestAt = slot
+		cg.reqMu.Unlock()
+		if d := time.Until(slot); d > 0 {
+			time.Sleep(d)
+		}
+		// Another goroutine's 429 may have extended throttledUntil while we slept on an
+		// already-reserved slot; firing now would be a guaranteed 429, so re-enter the gate.
+		cg.reqMu.Lock()
+		stillThrottled := cg.throttledUntil.After(time.Now())
+		cg.reqMu.Unlock()
+		if !stillThrottled {
+			return
+		}
 	}
 }
 
-// makeReq HTTP request helper with bounded retries for throttling errors.
-func (cg *Coingecko) makeReq(url string, endpoint string, plan string) ([]byte, error) {
+// markThrottled opens (or extends) the shared throttle window for all requests.
+func (cg *Coingecko) markThrottled(delay time.Duration) {
+	cg.reqMu.Lock()
+	if until := time.Now().Add(delay); until.After(cg.throttledUntil) {
+		cg.throttledUntil = until // extend only, never shorten
+	}
+	cg.reqMu.Unlock()
+}
+
+// makeReq HTTP request helper with unbounded retries for throttling errors.
+func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority reqPriority) ([]byte, error) {
+	if priority == priorityHigh {
+		cg.reqMu.Lock()
+		cg.highPriorityInFlight++
+		cg.reqMu.Unlock()
+		defer func() {
+			cg.reqMu.Lock()
+			cg.highPriorityInFlight--
+			cg.reqMu.Unlock()
+		}()
+	}
 	for attempt := 0; ; attempt++ {
 		// glog.Infof("Coingecko makeReq %v", url)
-		cg.waitForRateLimit()
+		cg.waitForRequestSlot(priority)
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err
@@ -356,24 +407,21 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string) ([]byte, 
 		if cg.metrics != nil {
 			cg.metrics.CoingeckoRequests.With(common.Labels{"endpoint": endpoint, "status": "throttle"}).Inc()
 		}
-		if attempt >= len(coingeckoThrottleRetryBackoff) {
-			if cg.metrics != nil {
-				cg.metrics.CoingeckoRequests.With(common.Labels{"endpoint": endpoint, "status": "error"}).Inc()
-			}
-			glog.Warningf("Coingecko makeReq %v error %v, retries exhausted after %d retries", url, err, len(coingeckoThrottleRetryBackoff))
-			return nil, &coingeckoThrottleRetriesExhaustedError{
-				cause:   err,
-				retries: len(coingeckoThrottleRetryBackoff),
-			}
-		}
-		time.Sleep(throttleBackoffDelay(attempt, err))
+		// Retry throttled requests indefinitely (no attempt cap) so historical rate downloads
+		// always finish eventually, even when a provider-wide 429 persists for many hours.
+		// Retry-After is honored when present; otherwise a flat ~1-minute backoff (plus jitter).
+		// The delay opens a throttle window shared by all requests; the next
+		// waitForRequestSlot waits it out, so no local sleep is needed here.
+		delay := throttleBackoffDelay(err)
+		cg.markThrottled(delay)
+		glog.Warningf("Coingecko makeReq %v throttled on attempt %d, retrying in %v: %v", url, attempt+1, delay, err)
 	}
 }
 
 // SimpleSupportedVSCurrencies /simple/supported_vs_currencies
-func (cg *Coingecko) simpleSupportedVSCurrenciesAt(baseURL string) (simpleSupportedVSCurrencies, error) {
+func (cg *Coingecko) simpleSupportedVSCurrenciesAt(baseURL string, priority reqPriority) (simpleSupportedVSCurrencies, error) {
 	url := baseURL + "/simple/supported_vs_currencies"
-	resp, err := cg.makeReq(url, "supported_vs_currencies", cg.plan)
+	resp, err := cg.makeReq(url, "supported_vs_currencies", cg.plan, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +452,8 @@ func (cg *Coingecko) simplePrice(ids []string, vsCurrencies []string) (*map[stri
 	params.Add("vs_currencies", vsCurrenciesParam)
 
 	url := fmt.Sprintf("%s/simple/price?%s", cg.tipURL, params.Encode())
-	resp, err := cg.makeReq(url, "simple/price", cg.plan)
+	// only called from CurrentTickers, therefore always high priority
+	resp, err := cg.makeReq(url, "simple/price", cg.plan, priorityHigh)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +468,7 @@ func (cg *Coingecko) simplePrice(ids []string, vsCurrencies []string) (*map[stri
 }
 
 // CoinsList /coins/list
-func (cg *Coingecko) coinsListAt(baseURL string) (coinList, error) {
+func (cg *Coingecko) coinsListAt(baseURL string, priority reqPriority) (coinList, error) {
 	params := url.Values{}
 	platform := "false"
 	if cg.platformIdentifier != "" {
@@ -427,7 +476,7 @@ func (cg *Coingecko) coinsListAt(baseURL string) (coinList, error) {
 	}
 	params.Add("include_platform", platform)
 	url := fmt.Sprintf("%s/coins/list?%s", baseURL, params.Encode())
-	resp, err := cg.makeReq(url, "coins/list", cg.plan)
+	resp, err := cg.makeReq(url, "coins/list", cg.plan, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +490,7 @@ func (cg *Coingecko) coinsListAt(baseURL string) (coinList, error) {
 }
 
 // coinMarketChart /coins/{id}/market_chart?vs_currency={usd, eur, jpy, etc.}&days={1,14,30,max}
-func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency string, days string, daily bool) (*marketChartPrices, error) {
+func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency string, days string, daily bool, priority reqPriority) (*marketChartPrices, error) {
 	if len(id) == 0 || len(vs_currency) == 0 || len(days) == 0 {
 		return nil, fmt.Errorf("id, vs_currency, and days is required")
 	}
@@ -454,7 +503,7 @@ func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency st
 	params.Add("days", days)
 
 	url := fmt.Sprintf("%s/coins/%s/market_chart?%s", baseURL, id, params.Encode())
-	resp, err := cg.makeReq(url, "market_chart", cg.plan)
+	resp, err := cg.makeReq(url, "market_chart", cg.plan, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -472,11 +521,11 @@ var vsCurrencies []string
 var platformIds []string
 var platformIdsToTokens map[string]string
 
-func (cg *Coingecko) platformIdsAt(baseURL string) error {
+func (cg *Coingecko) platformIdsAt(baseURL string, priority reqPriority) error {
 	if cg.platformIdentifier == "" {
 		return nil
 	}
-	cl, err := cg.coinsListAt(baseURL)
+	cl, err := cg.coinsListAt(baseURL, priority)
 	if err != nil {
 		return err
 	}
@@ -499,7 +548,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 	var newTickers = common.CurrencyRatesTicker{}
 
 	if vsCurrencies == nil {
-		vs, err := cg.simpleSupportedVSCurrenciesAt(cg.tipURL)
+		vs, err := cg.simpleSupportedVSCurrenciesAt(cg.tipURL, priorityHigh)
 		if err != nil {
 			return nil, err
 		}
@@ -516,7 +565,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 
 	if cg.platformIdentifier != "" && cg.platformVsCurrency != "" {
 		if platformIdsToTokens == nil {
-			err = cg.platformIdsAt(cg.tipURL)
+			err = cg.platformIdsAt(cg.tipURL, priorityHigh)
 			if err != nil {
 				return nil, err
 			}
@@ -548,7 +597,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 }
 
 func (cg *Coingecko) getHighGranularityTickers(days string) (*[]common.CurrencyRatesTicker, error) {
-	mc, err := cg.coinMarketChartAt(cg.tipURL, cg.coin, highGranularityVsCurrency, days, false)
+	mc, err := cg.coinMarketChartAt(cg.tipURL, cg.coin, highGranularityVsCurrency, days, false, priorityHigh)
 	if err != nil {
 		return nil, err
 	}
@@ -641,7 +690,8 @@ func (cg *Coingecko) getHistoricalTicker(baseURL string, tickersToUpdate map[uin
 	if cg.metrics != nil {
 		cg.metrics.CoingeckoRangeRequests.With(common.Labels{"range": rangeKind}).Inc()
 	}
-	mc, err := cg.coinMarketChartAt(baseURL, coinId, vsCurrency, days, true)
+	// both callers update historical (daily) tickers, therefore always low priority
+	mc, err := cg.coinMarketChartAt(baseURL, coinId, vsCurrency, days, true, priorityLow)
 	if err != nil {
 		return false, err
 	}
@@ -724,7 +774,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	}
 
 	// reload vs_currencies
-	vs, err := cg.simpleSupportedVSCurrenciesAt(historicalSyncURL)
+	vs, err := cg.simpleSupportedVSCurrenciesAt(historicalSyncURL, priorityLow)
 	if err != nil {
 		return err
 	}
@@ -762,11 +812,18 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 
 // UpdateHistoricalTokenTickers gets historical tickers for the tokens
 func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
+	cg.reqMu.Lock()
 	if cg.updatingTokens {
+		cg.reqMu.Unlock()
 		return errCoingeckoHistoricalTokenUpdateInProgress
 	}
 	cg.updatingTokens = true
-	defer func() { cg.updatingTokens = false }()
+	cg.reqMu.Unlock()
+	defer func() {
+		cg.reqMu.Lock()
+		cg.updatingTokens = false
+		cg.reqMu.Unlock()
+	}()
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
 	var throttleErr error
 
@@ -785,7 +842,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		}
 
 		//  reload platform ids
-		if err := cg.platformIdsAt(historicalSyncURL); err != nil {
+		if err := cg.platformIdsAt(historicalSyncURL, priorityLow); err != nil {
 			return err
 		}
 		glog.Infof("Coingecko returned %d %s tokens ", len(platformIds), cg.coin)

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -57,29 +57,30 @@ var errCoingeckoHistoricalTokenUpdateInProgress = errors.New("coingecko historic
 
 // Coingecko is a structure that implements RatesDownloaderInterface
 type Coingecko struct {
-	tipURL                 string
-	bootstrapURL           string
-	apiKey                 string
-	coin                   string
-	platformIdentifier     string
-	platformVsCurrency     string
-	allowedVsCurrencies    map[string]struct{}
-	httpTimeout            time.Duration
-	timeFormat             string
-	httpClient             *http.Client
-	db                     *db.RocksDB
-	updatingTokens         bool
-	metrics                *common.Metrics
-	plan                   string
-	minHttpRequestInterval time.Duration
-	reqMu                  sync.Mutex
-	lastRequestAt          time.Time
-	throttledUntil         time.Time // set on any 429; every request waits past it
-	highPriorityInFlight   int       // high-priority requests currently in flight, including their retries
-	cacheMu                sync.Mutex
-	vsCurrencies           []string          // guarded by cacheMu
-	platformIds            []string          // guarded by cacheMu
-	platformIdsToTokens    map[string]string // guarded by cacheMu
+	tipURL                   string
+	bootstrapURL             string
+	apiKey                   string
+	coin                     string
+	platformIdentifier       string
+	platformVsCurrency       string
+	allowedVsCurrencies      map[string]struct{}
+	httpTimeout              time.Duration
+	timeFormat               string
+	httpClient               *http.Client
+	db                       *db.RocksDB
+	updatingTokens           bool
+	metrics                  *common.Metrics
+	plan                     string
+	minHttpRequestInterval   time.Duration // spacing between requests to the rate-limited CoinGecko API hosts (plan-based)
+	bootstrapRequestInterval time.Duration // spacing between requests to the bootstrap CDN, which has no CoinGecko rate limit
+	reqMu                    sync.Mutex
+	lastRequestAt            time.Time
+	throttledUntil           time.Time // set on any 429; every request waits past it
+	highPriorityInFlight     int       // high-priority requests currently in flight, including their retries
+	cacheMu                  sync.Mutex
+	vsCurrencies             []string          // guarded by cacheMu
+	platformIds              []string          // guarded by cacheMu
+	platformIdsToTokens      map[string]string // guarded by cacheMu
 }
 
 // simpleSupportedVSCurrencies https://api.coingecko.com/api/v3/simple/supported_vs_currencies
@@ -172,12 +173,20 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, coinShortcut string,
 	normalizedPlan := normalizeCoinGeckoPlan(plan)
 
 	minRequestInterval := time.Duration(0)
+	bootstrapRequestInterval := time.Duration(0)
 	if throttleDown {
 		if normalizedPlan == coingeckoPlanFree {
 			minRequestInterval = time.Minute / coingeckoKeylessRequestsPerMinute
 		} else {
 			minRequestInterval = DefaultThrottleDelayMs * time.Millisecond
 		}
+		// The bootstrap CDN (cdn.trezor.io) serves cached CoinGecko data and is not
+		// subject to CoinGecko's per-minute rate limit, so it keeps the light default
+		// spacing regardless of plan. Without this, the free-plan 6s spacing would
+		// stretch the initial bootstrap (tens of currencies + thousands of tokens)
+		// from minutes to hours and, because the bootstrap token pass runs
+		// synchronously on the downloader goroutine, starve current-ticker refreshes.
+		bootstrapRequestInterval = DefaultThrottleDelayMs * time.Millisecond
 	}
 	resolvedBootstrapURL := resolveCoinGeckoBootstrapURL(bootstrapURL)
 	tipURL := coingeckoFreeURL
@@ -199,10 +208,11 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, coinShortcut string,
 		httpClient: &http.Client{
 			Timeout: DefaultHTTPTimeout,
 		},
-		db:                     db,
-		minHttpRequestInterval: minRequestInterval,
-		metrics:                metrics,
-		plan:                   normalizedPlan,
+		db:                       db,
+		minHttpRequestInterval:   minRequestInterval,
+		bootstrapRequestInterval: bootstrapRequestInterval,
+		metrics:                  metrics,
+		plan:                     normalizedPlan,
 	}
 }
 
@@ -301,13 +311,30 @@ func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 	return errors.Is(err, errCoingeckoHistoricalTokenUpdateInProgress)
 }
 
-// waitForRequestSlot enforces minHttpRequestInterval spacing between requests and makes
-// every request wait out the shared throttle window opened by any 429. While the window
+// targetsBootstrapCDN reports whether url points at the bootstrap CDN, which serves
+// cached CoinGecko data and has no CoinGecko per-minute rate limit. Requests to it must
+// not inherit the plan-based pacing meant for the rate-limited CoinGecko API hosts.
+func (cg *Coingecko) targetsBootstrapCDN(url string) bool {
+	return cg.bootstrapURL != "" && strings.HasPrefix(url, cg.bootstrapURL)
+}
+
+// requestIntervalFor returns the minimum spacing to enforce before a request to url:
+// the light CDN spacing for bootstrap requests, the plan-based spacing otherwise.
+func (cg *Coingecko) requestIntervalFor(url string) time.Duration {
+	if cg.targetsBootstrapCDN(url) {
+		return cg.bootstrapRequestInterval
+	}
+	return cg.minHttpRequestInterval
+}
+
+// waitForRequestSlot enforces minInterval spacing between requests and makes every
+// request wait out the shared throttle window opened by any 429. While the window
 // is open, low-priority requests additionally yield to in-flight high-priority ones so
 // current/high-granularity fetches reclaim request slots first.
-// With minHttpRequestInterval == 0 (throttleDown disabled) all waiters fire as soon as
-// the window expires; acceptable, as at most a couple of goroutines share one instance.
-func (cg *Coingecko) waitForRequestSlot(priority reqPriority) {
+// With minInterval == 0 (throttleDown disabled, or a bootstrap request in tests) all
+// waiters fire as soon as the window expires; acceptable, as at most a couple of
+// goroutines share one instance.
+func (cg *Coingecko) waitForRequestSlot(priority reqPriority, minInterval time.Duration) {
 	for {
 		cg.reqMu.Lock()
 		now := time.Now()
@@ -318,7 +345,7 @@ func (cg *Coingecko) waitForRequestSlot(priority reqPriority) {
 		}
 		slot := now
 		if !cg.lastRequestAt.IsZero() {
-			if next := cg.lastRequestAt.Add(cg.minHttpRequestInterval); next.After(slot) {
+			if next := cg.lastRequestAt.Add(minInterval); next.After(slot) {
 				slot = next
 			}
 		}
@@ -362,9 +389,10 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority 
 			cg.reqMu.Unlock()
 		}()
 	}
+	minInterval := cg.requestIntervalFor(url)
 	for attempt := 0; ; attempt++ {
 		// glog.Infof("Coingecko makeReq %v", url)
-		cg.waitForRequestSlot(priority)
+		cg.waitForRequestSlot(priority, minInterval)
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -1,6 +1,7 @@
 package fiat
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,10 +53,11 @@ const (
 
 // Reason labels for fiat_rates_unable_total.
 const (
-	fiatUnableGapTooLarge  = "gap_too_large"   // series stale >= reconcile guard, probable bug
-	fiatUnableFetchFailed  = "fetch_failed"    // HTTP/parse error fetching the range
-	fiatUnableProviderBan  = "provider_banned" // Cloudflare 1015 IP ban
-	fiatUnableNoBaseTicker = "no_base_ticker"  // token day without an existing base-currency ticker
+	fiatUnableGapTooLarge     = "gap_too_large"    // series stale >= reconcile guard, probable bug
+	fiatUnableFetchFailed     = "fetch_failed"     // HTTP/parse error fetching the range
+	fiatUnableProviderBan     = "provider_banned"  // Cloudflare 1015 IP ban
+	fiatUnableNoBaseTicker    = "no_base_ticker"   // token day without an existing base-currency ticker
+	fiatUnableBudgetExhausted = "budget_exhausted" // reconcile wall-clock budget elapsed before completion
 )
 
 // used when retry-after header is missing
@@ -335,13 +337,21 @@ func (cg *Coingecko) requestIntervalFor(url string) time.Duration {
 	return cg.minHttpRequestInterval
 }
 
-func (cg *Coingecko) waitForRequestSlot(priority reqPriority, minInterval time.Duration) {
+// waitForRequestSlot blocks until this request may fire, honoring the shared throttle window
+// and the per-request minimum interval. ctx lets the wait be cut short on shutdown or when the
+// reconcile budget expires; on cancellation it returns early and makeReq observes ctx.Err().
+func (cg *Coingecko) waitForRequestSlot(ctx context.Context, priority reqPriority, minInterval time.Duration) {
 	for {
+		if ctx.Err() != nil {
+			return
+		}
 		cg.reqMu.Lock()
 		now := time.Now()
 		if priority == priorityLow && cg.throttledUntil.After(now) && cg.highPriorityInFlight > 0 {
 			cg.reqMu.Unlock()
-			time.Sleep(coingeckoLowPriorityPollInterval)
+			if !sleepCtx(ctx, coingeckoLowPriorityPollInterval) {
+				return
+			}
 			continue
 		}
 		slot := now
@@ -356,7 +366,9 @@ func (cg *Coingecko) waitForRequestSlot(priority reqPriority, minInterval time.D
 		cg.lastRequestAt = slot
 		cg.reqMu.Unlock()
 		if d := time.Until(slot); d > 0 {
-			time.Sleep(d)
+			if !sleepCtx(ctx, d) {
+				return
+			}
 		}
 		// Another goroutine's 429 may have extended throttledUntil while we slept on an
 		// already-reserved slot; firing now would be a guaranteed 429, so re-enter the gate.
@@ -369,6 +381,19 @@ func (cg *Coingecko) waitForRequestSlot(priority reqPriority, minInterval time.D
 	}
 }
 
+// sleepCtx sleeps for d unless ctx is cancelled first. It returns true if the full duration
+// elapsed, false if ctx was cancelled (so the caller can bail).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
 // markThrottled opens (or extends) the shared throttle window for all requests.
 func (cg *Coingecko) markThrottled(delay time.Duration) {
 	cg.reqMu.Lock()
@@ -378,8 +403,12 @@ func (cg *Coingecko) markThrottled(delay time.Duration) {
 	cg.reqMu.Unlock()
 }
 
-// makeReq HTTP request helper with unbounded retries for throttling errors.
-func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority reqPriority) ([]byte, error) {
+// makeReq HTTP request helper with unbounded retries for throttling errors. ctx bounds the
+// otherwise-unbounded retry loop: callers on the steady-state loops pass context.Background()
+// (retry forever, as before), while the startup reconcile pass passes a context carrying both
+// the shutdown signal and a wall-clock budget, so a persistently throttling endpoint can never
+// stall startup and a SIGTERM aborts mid-retry.
+func (cg *Coingecko) makeReq(ctx context.Context, url string, endpoint string, plan string, priority reqPriority) ([]byte, error) {
 	if priority == priorityHigh {
 		cg.reqMu.Lock()
 		cg.highPriorityInFlight++
@@ -393,8 +422,13 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority 
 	minInterval := cg.requestIntervalFor(url)
 	for attempt := 0; ; attempt++ {
 		// glog.Infof("Coingecko makeReq %v", url)
-		cg.waitForRequestSlot(priority, minInterval)
-		req, err := http.NewRequest("GET", url, nil)
+		// waitForRequestSlot returns immediately if ctx is already done, so a single check after
+		// it covers both an already-cancelled context and one cancelled while waiting.
+		cg.waitForRequestSlot(ctx, priority, minInterval)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -413,6 +447,14 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority 
 				cg.metrics.CoingeckoRequests.With(common.Labels{"endpoint": endpoint, "status": "success"}).Inc()
 			}
 			return resp, err
+		}
+
+		// A request cut short by our context (shutdown or the reconcile budget) is expected, not
+		// a provider failure: return quietly without an error log or the "error" status metric.
+		// A client-side HTTP timeout is a real failure and deliberately falls through below.
+		if ctx.Err() != nil {
+			glog.V(1).Infof("Coingecko makeReq %v aborted: %v", url, err)
+			return nil, err
 		}
 
 		if isCoingeckoCloudflareBanError(err) {
@@ -440,9 +482,9 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority 
 }
 
 // SimpleSupportedVSCurrencies /simple/supported_vs_currencies
-func (cg *Coingecko) simpleSupportedVSCurrenciesAt(baseURL string, priority reqPriority) (simpleSupportedVSCurrencies, error) {
+func (cg *Coingecko) simpleSupportedVSCurrenciesAt(ctx context.Context, baseURL string, priority reqPriority) (simpleSupportedVSCurrencies, error) {
 	url := baseURL + "/simple/supported_vs_currencies"
-	resp, err := cg.makeReq(url, "supported_vs_currencies", cg.plan, priority)
+	resp, err := cg.makeReq(ctx, url, "supported_vs_currencies", cg.plan, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +506,7 @@ func (cg *Coingecko) simpleSupportedVSCurrenciesAt(baseURL string, priority reqP
 }
 
 // SimplePrice /simple/price Multiple ID and Currency (ids, vs_currencies)
-func (cg *Coingecko) simplePrice(ids []string, vsCurrencies []string) (*map[string]map[string]float32, error) {
+func (cg *Coingecko) simplePrice(ctx context.Context, ids []string, vsCurrencies []string) (*map[string]map[string]float32, error) {
 	params := url.Values{}
 	idsParam := strings.Join(ids, ",")
 	vsCurrenciesParam := strings.Join(vsCurrencies, ",")
@@ -474,7 +516,7 @@ func (cg *Coingecko) simplePrice(ids []string, vsCurrencies []string) (*map[stri
 
 	url := fmt.Sprintf("%s/simple/price?%s", cg.tipURL, params.Encode())
 	// only called from CurrentTickers, therefore always high priority
-	resp, err := cg.makeReq(url, "simple/price", cg.plan, priorityHigh)
+	resp, err := cg.makeReq(ctx, url, "simple/price", cg.plan, priorityHigh)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +531,7 @@ func (cg *Coingecko) simplePrice(ids []string, vsCurrencies []string) (*map[stri
 }
 
 // CoinsList /coins/list
-func (cg *Coingecko) coinsListAt(baseURL string, priority reqPriority) (coinList, error) {
+func (cg *Coingecko) coinsListAt(ctx context.Context, baseURL string, priority reqPriority) (coinList, error) {
 	params := url.Values{}
 	platform := "false"
 	if cg.platformIdentifier != "" {
@@ -497,7 +539,7 @@ func (cg *Coingecko) coinsListAt(baseURL string, priority reqPriority) (coinList
 	}
 	params.Add("include_platform", platform)
 	url := fmt.Sprintf("%s/coins/list?%s", baseURL, params.Encode())
-	resp, err := cg.makeReq(url, "coins/list", cg.plan, priority)
+	resp, err := cg.makeReq(ctx, url, "coins/list", cg.plan, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +553,7 @@ func (cg *Coingecko) coinsListAt(baseURL string, priority reqPriority) (coinList
 }
 
 // coinMarketChart /coins/{id}/market_chart?vs_currency={usd, eur, jpy, etc.}&days={1,14,30,max}
-func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency string, days string, daily bool, priority reqPriority) (*marketChartPrices, error) {
+func (cg *Coingecko) coinMarketChartAt(ctx context.Context, baseURL string, id string, vs_currency string, days string, daily bool, priority reqPriority) (*marketChartPrices, error) {
 	if len(id) == 0 || len(vs_currency) == 0 || len(days) == 0 {
 		return nil, fmt.Errorf("id, vs_currency, and days is required")
 	}
@@ -524,7 +566,7 @@ func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency st
 	params.Add("days", days)
 
 	url := fmt.Sprintf("%s/coins/%s/market_chart?%s", baseURL, id, params.Encode())
-	resp, err := cg.makeReq(url, "market_chart", cg.plan, priority)
+	resp, err := cg.makeReq(ctx, url, "market_chart", cg.plan, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -538,11 +580,11 @@ func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency st
 	return &m, nil
 }
 
-func (cg *Coingecko) platformIdsAt(baseURL string, priority reqPriority) error {
+func (cg *Coingecko) platformIdsAt(ctx context.Context, baseURL string, priority reqPriority) error {
 	if cg.platformIdentifier == "" {
 		return nil
 	}
-	cl, err := cg.coinsListAt(baseURL, priority)
+	cl, err := cg.coinsListAt(ctx, baseURL, priority)
 	if err != nil {
 		return err
 	}
@@ -570,7 +612,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 	vsCurrencies := cg.vsCurrencies
 	cg.cacheMu.Unlock()
 	if vsCurrencies == nil {
-		vs, err := cg.simpleSupportedVSCurrenciesAt(cg.tipURL, priorityHigh)
+		vs, err := cg.simpleSupportedVSCurrenciesAt(context.Background(), cg.tipURL, priorityHigh)
 		if err != nil {
 			return nil, err
 		}
@@ -579,7 +621,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 		cg.vsCurrencies = vs
 		cg.cacheMu.Unlock()
 	}
-	prices, err := cg.simplePrice([]string{cg.coin}, vsCurrencies)
+	prices, err := cg.simplePrice(context.Background(), []string{cg.coin}, vsCurrencies)
 	if err != nil || prices == nil {
 		return nil, err
 	}
@@ -593,7 +635,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 		platformIds, platformIdsToTokens := cg.platformIds, cg.platformIdsToTokens
 		cg.cacheMu.Unlock()
 		if platformIdsToTokens == nil {
-			err = cg.platformIdsAt(cg.tipURL, priorityHigh)
+			err = cg.platformIdsAt(context.Background(), cg.tipURL, priorityHigh)
 			if err != nil {
 				return nil, err
 			}
@@ -608,7 +650,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 		for to := 0; to < len(platformIds); to++ {
 			requestLen += len(platformIds[to]) + 3 // 3 characters for the comma separator %2C
 			if requestLen > maxRequestLen || to+1 >= len(platformIds) {
-				tokenPrices, err := cg.simplePrice(platformIds[from:to+1], []string{cg.platformVsCurrency})
+				tokenPrices, err := cg.simplePrice(context.Background(), platformIds[from:to+1], []string{cg.platformVsCurrency})
 				if err != nil || tokenPrices == nil {
 					return nil, err
 				}
@@ -628,7 +670,7 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 }
 
 func (cg *Coingecko) getHighGranularityTickers(days string) (*[]common.CurrencyRatesTicker, error) {
-	mc, err := cg.coinMarketChartAt(cg.tipURL, cg.coin, highGranularityVsCurrency, days, false, priorityHigh)
+	mc, err := cg.coinMarketChartAt(context.Background(), cg.tipURL, cg.coin, highGranularityVsCurrency, days, false, priorityHigh)
 	if err != nil {
 		return nil, err
 	}
@@ -813,7 +855,7 @@ func (cg *Coingecko) fillFromMarketChart(tickersToUpdate map[uint]*common.Curren
 	return written, noBaseTicker, nil
 }
 
-func (cg *Coingecko) getHistoricalTicker(tickersToUpdate map[uint]*common.CurrencyRatesTicker, coinId string, vsCurrency string, token string, allowMax bool) (bool, error) {
+func (cg *Coingecko) getHistoricalTicker(ctx context.Context, tickersToUpdate map[uint]*common.CurrencyRatesTicker, coinId string, vsCurrency string, token string, allowMax bool) (bool, error) {
 	lastTicker, err := cg.db.FiatRatesFindLastTicker(vsCurrency, token)
 	if err != nil {
 		return false, err
@@ -829,7 +871,7 @@ func (cg *Coingecko) getHistoricalTicker(tickersToUpdate map[uint]*common.Curren
 	baseURL := cg.sourceURLForRange(rangeKind)
 	phase := phaseForRange(rangeKind)
 	// both callers update historical (daily) tickers, therefore always low priority
-	mc, err := cg.coinMarketChartAt(baseURL, coinId, vsCurrency, days, true, priorityLow)
+	mc, err := cg.coinMarketChartAt(ctx, baseURL, coinId, vsCurrency, days, true, priorityLow)
 	if err != nil {
 		return false, err
 	}
@@ -896,7 +938,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	}
 
 	// reload vs_currencies
-	vs, err := cg.simpleSupportedVSCurrenciesAt(metadataURL, priorityLow)
+	vs, err := cg.simpleSupportedVSCurrenciesAt(context.Background(), metadataURL, priorityLow)
 	if err != nil {
 		return err
 	}
@@ -909,7 +951,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	for _, currency := range vs {
 		// get historical rates for each currency
 		var err error
-		if _, err = cg.getHistoricalTicker(tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
+		if _, err = cg.getHistoricalTicker(context.Background(), tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
 			hadFailures = true
 			// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 			// the rates will be updated next run
@@ -963,7 +1005,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		}
 
 		//  reload platform ids
-		if err := cg.platformIdsAt(metadataURL, priorityLow); err != nil {
+		if err := cg.platformIdsAt(context.Background(), metadataURL, priorityLow); err != nil {
 			return err
 		}
 		cg.cacheMu.Lock()
@@ -975,7 +1017,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		// get token historical rates
 		for tokenId, token := range platformIdsToTokens {
 			var err error
-			if _, err = cg.getHistoricalTicker(tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
+			if _, err = cg.getHistoricalTicker(context.Background(), tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run
 				glog.Errorf("getHistoricalTicker %s-%s %v", tokenId, cg.platformVsCurrency, err)
@@ -1105,10 +1147,12 @@ func (cg *Coingecko) missingDayWindow(windowDays int) (missing map[uint]struct{}
 // It is a no-op while bootstrap is still in progress (the bootstrap pass owns full-history
 // population) or when no CDN URL is configured.
 //
-// stop is blockbook's chanOsSignal (closed on shutdown). It is polled between series fetches
-// so a SIGTERM mid-repair aborts promptly; any days fetched before the abort are persisted so
-// the next startup resumes from the remaining gap.
-func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, stop <-chan os.Signal) (int, error) {
+// ctx bounds the whole pass: it carries both the shutdown signal and a wall-clock budget, so a
+// SIGTERM or a persistently throttling CDN aborts the pass promptly instead of stalling
+// startup. On abort, any days already fetched are persisted so the next startup resumes from
+// the remaining gap; a budget timeout is also recorded as fiat_rates_unable_total{reason=
+// "budget_exhausted"} so it is visible in monitoring.
+func (cg *Coingecko) ReconcileHistoricalRates(ctx context.Context, windowDays int, maxGapDays int) (int, error) {
 	bootstrapInProgress, _, err := historicalBootstrapInProgress(cg.db)
 	if err != nil {
 		return 0, err
@@ -1154,15 +1198,20 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, st
 	cdnURL := cg.sourceURLForRange(coingeckoRangeBackfill)
 	metaURL := cg.metadataURL()
 
-	// Shutdown may arrive during the cheap stage-1 scan; bail before any network call.
-	if stopRequested(stop) {
-		glog.Warning("FiatRates reconcile: shutdown signaled before backfill, skipping; gap will be reconciled on next startup")
+	// Shutdown/budget may already be signaled during the cheap stage-1 scan; bail before any
+	// network call.
+	if err := ctx.Err(); err != nil {
+		glog.Warningf("FiatRates reconcile: aborted before backfill (%v), skipping; gap will be reconciled on next startup", err)
 		return 0, nil
 	}
 
 	// enumerate the series to repair: base coin x each vsCurrency, plus each token
-	vs, err := cg.simpleSupportedVSCurrenciesAt(metaURL, priorityLow)
+	vs, err := cg.simpleSupportedVSCurrenciesAt(ctx, metaURL, priorityLow)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			glog.Warningf("FiatRates reconcile: aborted fetching supported_vs_currencies (%v); gap will be reconciled on next startup", ctxErr)
+			return 0, nil
+		}
 		return 0, fmt.Errorf("reconcile: supported_vs_currencies: %w", err)
 	}
 	cg.cacheMu.Lock()
@@ -1174,7 +1223,11 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, st
 		targets = append(targets, reconcileTarget{coinId: cg.coin, vsCurrency: currency})
 	}
 	if cg.platformIdentifier != "" && cg.platformVsCurrency != "" {
-		if err := cg.platformIdsAt(metaURL, priorityLow); err != nil {
+		if err := cg.platformIdsAt(ctx, metaURL, priorityLow); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				glog.Warningf("FiatRates reconcile: aborted fetching coins/list (%v); gap will be reconciled on next startup", ctxErr)
+				return 0, nil
+			}
 			return 0, fmt.Errorf("reconcile: coins/list: %w", err)
 		}
 		cg.cacheMu.Lock()
@@ -1193,18 +1246,23 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, st
 	// shared map holds at most len(missingDays) records regardless of how many series we scan.
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
 	filled, failed, repairedTokens := 0, 0, 0
-	var banErr error
-	aborted := false
+	var banErr, abortErr error
+	abortAt := 0
 	for i, c := range targets {
-		// Abort promptly on shutdown; persist what we already fetched (below) so the next
-		// startup resumes from the remaining gap rather than refetching from scratch.
-		if stopRequested(stop) {
-			aborted = true
-			glog.Warningf("FiatRates reconcile: shutdown signaled, aborting after %d/%d series (%d point(s) fetched so far)", i, len(targets), filled)
+		// Abort promptly on shutdown or budget timeout; persist what we already fetched (below)
+		// so the next startup resumes from the remaining gap rather than refetching from scratch.
+		// The check before the fetch catches cancellation between iterations; the one after
+		// catches cancellation during the in-flight fetch.
+		if err := ctx.Err(); err != nil {
+			abortErr, abortAt = err, i
 			break
 		}
-		mc, err := cg.coinMarketChartAt(cdnURL, c.coinId, c.vsCurrency, days, true, priorityLow)
+		mc, err := cg.coinMarketChartAt(ctx, cdnURL, c.coinId, c.vsCurrency, days, true, priorityLow)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				abortErr, abortAt = ctxErr, i
+				break
+			}
 			failed++
 			if isCoingeckoCloudflareBanError(err) {
 				cg.observeUnable(fiatPhaseReconcile, fiatUnableProviderBan, 1)
@@ -1234,8 +1292,14 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, st
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
 		return filled, err
 	}
-	if aborted {
-		glog.Infof("FiatRates reconcile stage 2: aborted on shutdown, persisted %d point(s) (%d token series), %d fetch failures; remaining gap will be reconciled on next startup", filled, repairedTokens, failed)
+	if abortErr != nil {
+		remaining := len(targets) - abortAt
+		// a budget timeout (vs. a clean shutdown) is a problem worth surfacing in monitoring:
+		// the window was too small or the CDN too slow to finish.
+		if errors.Is(abortErr, context.DeadlineExceeded) {
+			cg.observeUnable(fiatPhaseReconcile, fiatUnableBudgetExhausted, remaining)
+		}
+		glog.Warningf("FiatRates reconcile stage 2: aborted (%v), persisted %d point(s) (%d token series), %d fetch failures, %d series unprocessed; remaining gap will be reconciled on next startup", abortErr, filled, repairedTokens, failed, remaining)
 		return filled, nil
 	}
 	glog.Infof("FiatRates reconcile stage 2: filled %d point(s) across %d series (%d token series), %d fetch failures", filled, len(targets), repairedTokens, failed)
@@ -1243,19 +1307,4 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, st
 		return filled, banErr
 	}
 	return filled, nil
-}
-
-// stopRequested reports whether shutdown has been signaled on stop. blockbook closes
-// chanOsSignal on shutdown, so a receive returns immediately once closed; a nil channel
-// (e.g. in tests) is never stopped.
-func stopRequested(stop <-chan os.Signal) bool {
-	if stop == nil {
-		return false
-	}
-	select {
-	case <-stop:
-		return true
-	default:
-		return false
-	}
 }

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,27 +21,27 @@ import (
 )
 
 const (
-	DefaultHTTPTimeout                 = 15 * time.Second
-	DefaultThrottleDelayMs             = 100
-	coingeckoHistoryDaysLimit          = 365
-	coingeckoFreePlanRequestsPerMinute = 25
-	coingeckoRangeHistorical           = "historical"
-	coingeckoRangeTip                  = "tip"
-	coingeckoRangeCapped               = "capped"
-	coingeckoBootstrapURL              = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
-	coingeckoProURL                    = "https://pro-api.coingecko.com/api/v3"
-	coingeckoFreeURL                   = "https://api.coingecko.com/api/v3"
-	coingeckoPlanFree                  = "free"
-	coingeckoPlanPro                   = "pro"
-	coingeckoAPIKeyEnv                 = "COINGECKO_API_KEY"
-	coingeckoAPIKeyEnvSuffix           = "_" + coingeckoAPIKeyEnv
+	DefaultHTTPTimeout                = 15 * time.Second
+	DefaultThrottleDelayMs            = 100
+	coingeckoHistoryDaysLimit         = 365
+	coingeckoKeylessRequestsPerMinute = 10
+	coingeckoRangeHistorical          = "historical"
+	coingeckoRangeTip                 = "tip"
+	coingeckoRangeCapped              = "capped"
+	coingeckoBootstrapURL             = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
+	coingeckoProURL                   = "https://pro-api.coingecko.com/api/v3"
+	coingeckoFreeURL                  = "https://api.coingecko.com/api/v3"
+	coingeckoPlanFree                 = "free"
+	coingeckoPlanPro                  = "pro"
+	coingeckoAPIKeyEnv                = "COINGECKO_API_KEY"
+	coingeckoAPIKeyEnvSuffix          = "_" + coingeckoAPIKeyEnv
 )
 
 var coingeckoThrottleRetryBackoff = []time.Duration{
 	1 * time.Minute,
 	2 * time.Minute,
-	3 * time.Minute,
 	4 * time.Minute,
+	8 * time.Minute,
 }
 
 var errCoingeckoHistoricalTokenUpdateInProgress = errors.New("coingecko historical token update already in progress")
@@ -171,7 +172,7 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, coinShortcut string,
 	minRequestInterval := time.Duration(0)
 	if throttleDown {
 		if normalizedPlan == coingeckoPlanFree {
-			minRequestInterval = time.Minute / coingeckoFreePlanRequestsPerMinute
+			minRequestInterval = time.Minute / coingeckoKeylessRequestsPerMinute
 		} else {
 			minRequestInterval = DefaultThrottleDelayMs * time.Millisecond
 		}
@@ -216,14 +217,44 @@ func getAllowedVsCurrenciesMap(currenciesString string) map[string]struct{} {
 
 // coingeckoHTTPError carries the HTTP status from a non-200 response so throttling can be
 // detected by status code. Error() returns the raw body so existing body-based detection
-// (e.g. the Cloudflare "error code: 1015" page) keeps working.
+// (e.g. the Cloudflare "error code: 1015" page) keeps working. retryAfter holds the parsed
+// Retry-After header (CoinGecko sends it on 429); zero when absent or unparseable.
 type coingeckoHTTPError struct {
-	status int
-	body   string
+	status     int
+	body       string
+	retryAfter time.Duration
 }
 
 func (e *coingeckoHTTPError) Error() string {
 	return e.body
+}
+
+func parseRetryAfter(value string) time.Duration {
+	secs, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// retryAfterFromError extracts the server's Retry-After hint from a coingeckoHTTPError, if any.
+func retryAfterFromError(err error) time.Duration {
+	var httpErr *coingeckoHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.retryAfter
+	}
+	return 0
+}
+
+func throttleBackoffDelay(attempt int, err error) time.Duration {
+	delay := coingeckoThrottleRetryBackoff[attempt]
+	if ra := retryAfterFromError(err); ra > delay {
+		delay = ra
+	}
+	if delay <= 0 {
+		return 0
+	}
+	return delay + time.Duration(rand.Int63n(int64(delay/5)+1))
 }
 
 // doReq HTTP client
@@ -239,8 +270,9 @@ func doReq(req *http.Request, client *http.Client) ([]byte, error) {
 	}
 	if resp.StatusCode != 200 {
 		return nil, &coingeckoHTTPError{
-			status: resp.StatusCode,
-			body:   string(body),
+			status:     resp.StatusCode,
+			body:       string(body),
+			retryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
 		}
 	}
 	return body, nil
@@ -333,7 +365,7 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string) ([]byte, 
 				retries: len(coingeckoThrottleRetryBackoff),
 			}
 		}
-		time.Sleep(coingeckoThrottleRetryBackoff[attempt])
+		time.Sleep(throttleBackoffDelay(attempt, err))
 	}
 }
 

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -55,19 +55,6 @@ const (
 
 var errCoingeckoHistoricalTokenUpdateInProgress = errors.New("coingecko historical token update already in progress")
 
-type coingeckoThrottleRetriesExhaustedError struct {
-	cause   error
-	retries int
-}
-
-func (e *coingeckoThrottleRetriesExhaustedError) Error() string {
-	return fmt.Sprintf("coingecko throttle retries exhausted after %d retries: %v", e.retries, e.cause)
-}
-
-func (e *coingeckoThrottleRetriesExhaustedError) Unwrap() error {
-	return e.cause
-}
-
 // Coingecko is a structure that implements RatesDownloaderInterface
 type Coingecko struct {
 	tipURL                 string
@@ -89,6 +76,10 @@ type Coingecko struct {
 	lastRequestAt          time.Time
 	throttledUntil         time.Time // set on any 429; every request waits past it
 	highPriorityInFlight   int       // high-priority requests currently in flight, including their retries
+	cacheMu                sync.Mutex
+	vsCurrencies           []string          // guarded by cacheMu
+	platformIds            []string          // guarded by cacheMu
+	platformIdsToTokens    map[string]string // guarded by cacheMu
 }
 
 // simpleSupportedVSCurrencies https://api.coingecko.com/api/v3/simple/supported_vs_currencies
@@ -248,13 +239,13 @@ func parseRetryAfter(value string) time.Duration {
 	return time.Duration(secs) * time.Second
 }
 
-// retryAfterFromError extracts the server's Retry-After hint from a coingeckoHTTPError, if any.
+// retryAfterFromError extracts the server's Retry-After hint from a coingeckoHTTPError,
+// if any; zero means no hint and the caller falls back to the fixed backoff.
 func retryAfterFromError(err error) time.Duration {
 	var httpErr *coingeckoHTTPError
 	if errors.As(err, &httpErr) {
 		return httpErr.retryAfter
 	}
-	glog.Errorf("No retryAfter header found in the headers: %s", err.Error())
 	return 0
 }
 
@@ -306,11 +297,6 @@ func isCoingeckoThrottleError(err error) bool {
 		strings.Contains(lowerError, "throttled")
 }
 
-func isCoingeckoThrottleRetriesExhaustedError(err error) bool {
-	var exhaustedErr *coingeckoThrottleRetriesExhaustedError
-	return errors.As(err, &exhaustedErr)
-}
-
 func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 	return errors.Is(err, errCoingeckoHistoricalTokenUpdateInProgress)
 }
@@ -319,6 +305,8 @@ func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 // every request wait out the shared throttle window opened by any 429. While the window
 // is open, low-priority requests additionally yield to in-flight high-priority ones so
 // current/high-granularity fetches reclaim request slots first.
+// With minHttpRequestInterval == 0 (throttleDown disabled) all waiters fire as soon as
+// the window expires; acceptable, as at most a couple of goroutines share one instance.
 func (cg *Coingecko) waitForRequestSlot(priority reqPriority) {
 	for {
 		cg.reqMu.Lock()
@@ -517,10 +505,6 @@ func (cg *Coingecko) coinMarketChartAt(baseURL string, id string, vs_currency st
 	return &m, nil
 }
 
-var vsCurrencies []string
-var platformIds []string
-var platformIdsToTokens map[string]string
-
 func (cg *Coingecko) platformIdsAt(baseURL string, priority reqPriority) error {
 	if cg.platformIdentifier == "" {
 		return nil
@@ -538,8 +522,10 @@ func (cg *Coingecko) platformIdsAt(baseURL string, priority reqPriority) error {
 			ids = append(ids, cl[i].ID)
 		}
 	}
-	platformIds = ids
-	platformIdsToTokens = idsMap
+	cg.cacheMu.Lock()
+	cg.platformIds = ids
+	cg.platformIdsToTokens = idsMap
+	cg.cacheMu.Unlock()
 	return nil
 }
 
@@ -547,12 +533,18 @@ func (cg *Coingecko) platformIdsAt(baseURL string, priority reqPriority) error {
 func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 	var newTickers = common.CurrencyRatesTicker{}
 
+	cg.cacheMu.Lock()
+	vsCurrencies := cg.vsCurrencies
+	cg.cacheMu.Unlock()
 	if vsCurrencies == nil {
 		vs, err := cg.simpleSupportedVSCurrenciesAt(cg.tipURL, priorityHigh)
 		if err != nil {
 			return nil, err
 		}
 		vsCurrencies = vs
+		cg.cacheMu.Lock()
+		cg.vsCurrencies = vs
+		cg.cacheMu.Unlock()
 	}
 	prices, err := cg.simplePrice([]string{cg.coin}, vsCurrencies)
 	if err != nil || prices == nil {
@@ -564,11 +556,17 @@ func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
 	}
 
 	if cg.platformIdentifier != "" && cg.platformVsCurrency != "" {
+		cg.cacheMu.Lock()
+		platformIds, platformIdsToTokens := cg.platformIds, cg.platformIdsToTokens
+		cg.cacheMu.Unlock()
 		if platformIdsToTokens == nil {
 			err = cg.platformIdsAt(cg.tipURL, priorityHigh)
 			if err != nil {
 				return nil, err
 			}
+			cg.cacheMu.Lock()
+			platformIds, platformIdsToTokens = cg.platformIds, cg.platformIdsToTokens
+			cg.cacheMu.Unlock()
 		}
 		newTickers.TokenRates = make(map[string]float32)
 		from := 0
@@ -778,21 +776,16 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	if err != nil {
 		return err
 	}
-	vsCurrencies = vs
+	cg.cacheMu.Lock()
+	cg.vsCurrencies = vs
+	cg.cacheMu.Unlock()
 
 	hadFailures := false
-	var throttleErr error
-	for _, currency := range vsCurrencies {
+	for _, currency := range vs {
 		// get historical rates for each currency
 		var err error
 		if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
 			hadFailures = true
-			if isCoingeckoThrottleRetriesExhaustedError(err) {
-				throttleErr = err
-				// Stop, store and retry on the next cycle
-				glog.Warningf("getHistoricalTicker %s-%s throttled, stopping run with partial currencies: %v", cg.coin, currency, err)
-				break
-			}
 			// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 			// the rates will be updated next run
 			glog.Errorf("getHistoricalTicker %s-%s %v", cg.coin, currency, err)
@@ -800,9 +793,6 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	}
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
 		return err
-	}
-	if throttleErr != nil {
-		return throttleErr
 	}
 	if bootstrapInProgress && hadFailures {
 		return fmt.Errorf("coingecko historical bootstrap incomplete: one or more currency updates failed")
@@ -825,7 +815,6 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		cg.reqMu.Unlock()
 	}()
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
-	var throttleErr error
 
 	if cg.platformIdentifier != "" && cg.platformVsCurrency != "" {
 		allowMax := false
@@ -845,18 +834,15 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		if err := cg.platformIdsAt(historicalSyncURL, priorityLow); err != nil {
 			return err
 		}
+		cg.cacheMu.Lock()
+		platformIds, platformIdsToTokens := cg.platformIds, cg.platformIdsToTokens
+		cg.cacheMu.Unlock()
 		glog.Infof("Coingecko returned %d %s tokens ", len(platformIds), cg.coin)
 		count := 0
 		// get token historical rates
 		for tokenId, token := range platformIdsToTokens {
 			var err error
 			if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
-				if isCoingeckoThrottleRetriesExhaustedError(err) {
-					throttleErr = err
-					// Stop, store and retry on the next cycle
-					glog.Warningf("getHistoricalTicker %s-%s throttled, stopping run with partial tokens: %v", tokenId, cg.platformVsCurrency, err)
-					break
-				}
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run
 				glog.Errorf("getHistoricalTicker %s-%s %v", tokenId, cg.platformVsCurrency, err)
@@ -875,9 +861,6 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
 		return err
-	}
-	if throttleErr != nil {
-		return throttleErr
 	}
 	return nil
 }

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -28,6 +28,10 @@ const (
 	coingeckoRangeHistorical          = "historical"
 	coingeckoRangeTip                 = "tip"
 	coingeckoRangeCapped              = "capped"
+	coingeckoRangeBackfill            = "backfill"
+	// coingeckoTipWindowDays is the only gap still served from the rate-limited tip
+	// endpoint (the chain tip); anything larger is high-volume backfill routed to the CDN.
+	coingeckoTipWindowDays = 1
 	coingeckoBootstrapURL             = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
 	coingeckoProURL                   = "https://pro-api.coingecko.com/api/v3"
 	coingeckoFreeURL                  = "https://api.coingecko.com/api/v3"
@@ -35,6 +39,23 @@ const (
 	coingeckoPlanPro                  = "pro"
 	coingeckoAPIKeyEnv                = "COINGECKO_API_KEY"
 	coingeckoAPIKeyEnvSuffix          = "_" + coingeckoAPIKeyEnv
+)
+
+// Phase labels for the fiat-rate fetch metrics (fiat_rates_fetched_units_total,
+// fiat_rates_fetched_tokens_total, fiat_rates_unable_total).
+const (
+	fiatPhaseTip       = "tip"       // chain tip, gap == 1 day, Free tier
+	fiatPhaseBackfill  = "backfill"  // gap > 1 day or first-seen series, via CDN
+	fiatPhaseBootstrap = "bootstrap" // full-history population, via CDN
+	fiatPhaseReconcile = "reconcile" // startup self-healing pass, via CDN
+)
+
+// Reason labels for fiat_rates_unable_total.
+const (
+	fiatUnableGapTooLarge  = "gap_too_large"  // series stale >= reconcile guard, probable bug
+	fiatUnableFetchFailed  = "fetch_failed"   // HTTP/parse error fetching the range
+	fiatUnableProviderBan  = "provider_banned" // Cloudflare 1015 IP ban
+	fiatUnableNoBaseTicker = "no_base_ticker" // token day without an existing base-currency ticker
 )
 
 // used when retry-after header is missing
@@ -657,11 +678,40 @@ func (cg *Coingecko) canUseBootstrapMax() bool {
 	return coingeckoBootstrapURLAllowed(cg.bootstrapURL)
 }
 
-func (cg *Coingecko) historicalSyncURL(bootstrapInProgress bool) string {
-	if bootstrapInProgress {
+// metadataURL returns the base URL for low-volume metadata calls
+// (supported_vs_currencies, coins/list). These are cheap and stable, so prefer the CDN
+// (no rate limit) whenever it is configured, keeping the Free tier reserved for the tip.
+func (cg *Coingecko) metadataURL() string {
+	if cg.bootstrapURL != "" {
 		return cg.bootstrapURL
 	}
 	return cg.tipURL
+}
+
+// sourceURLForRange routes each historical range to the right backend: the rate-limited
+// tip endpoint is used only for the chain tip (gap == 1 day); every higher-volume range
+// (backfill, capped, full-history) goes to the CDN when configured. When no CDN URL is
+// configured we fall back to the tip endpoint to preserve pre-CDN behavior.
+func (cg *Coingecko) sourceURLForRange(rangeKind string) string {
+	if rangeKind == coingeckoRangeTip {
+		return cg.tipURL
+	}
+	if cg.bootstrapURL != "" {
+		return cg.bootstrapURL
+	}
+	return cg.tipURL
+}
+
+// phaseForRange maps a resolved range kind to the metric phase label.
+func phaseForRange(rangeKind string) string {
+	switch rangeKind {
+	case coingeckoRangeTip:
+		return fiatPhaseTip
+	case coingeckoRangeHistorical:
+		return fiatPhaseBootstrap
+	default: // backfill + capped are both high-volume CDN ranges
+		return fiatPhaseBackfill
+	}
 }
 
 func (cg *Coingecko) resolveHistoricalDays(lastTicker *common.CurrencyRatesTicker, allowMax bool) (string, bool, string) {
@@ -678,17 +728,85 @@ func (cg *Coingecko) resolveHistoricalDays(lastTicker *common.CurrencyRatesTicke
 	if d == 0 { // nothing to do, the last ticker exist
 		return "", false, ""
 	}
+	if d <= coingeckoTipWindowDays {
+		// The chain tip: a single missing day, served from the rate-limited tip endpoint.
+		return strconv.Itoa(d), true, coingeckoRangeTip
+	}
 	if d > coingeckoHistoryDaysLimit {
 		// This happens when the latest stored ticker for a given series is older than 365 days
 		// (for example after downtime, stale/partial historical data, or a newly tracked series
-		// after bootstrap). Outside bootstrap we intentionally cap backfill to 365 days.
-		d = coingeckoHistoryDaysLimit
-		return strconv.Itoa(d), true, coingeckoRangeCapped
+		// after bootstrap). We intentionally cap backfill to 365 days.
+		return strconv.Itoa(coingeckoHistoryDaysLimit), true, coingeckoRangeCapped
 	}
-	return strconv.Itoa(d), true, coingeckoRangeTip
+	// A multi-day gap (downtime catch-up): high-volume, routed to the CDN.
+	return strconv.Itoa(d), true, coingeckoRangeBackfill
 }
 
-func (cg *Coingecko) getHistoricalTicker(baseURL string, tickersToUpdate map[uint]*common.CurrencyRatesTicker, coinId string, vsCurrency string, token string, allowMax bool) (bool, error) {
+// fillFromMarketChart writes the whole-day points from a market_chart response into
+// tickersToUpdate. With fillMissingOnly set, an already-present rate for the series is left
+// intact (used by the startup reconciliation so it repairs holes without rewriting existing
+// data). Returns the number of daily points written and the number of token points skipped
+// because their day had no base-currency ticker yet.
+func (cg *Coingecko) fillFromMarketChart(tickersToUpdate map[uint]*common.CurrencyRatesTicker, mc *marketChartPrices, vsCurrency string, token string, fillMissingOnly bool) (written int, noBaseTicker int, err error) {
+	warningLogged := false
+	for _, p := range mc.Prices {
+		timestamp := uint(p[0])
+		if timestamp > 100000000000 {
+			// convert timestamp from milliseconds to seconds
+			timestamp /= 1000
+		}
+		rate := float32(p[1])
+		if timestamp%(24*3600) != 0 || timestamp == 0 || rate == 0 {
+			// process only tickers for the whole day with non 0 value
+			continue
+		}
+		ticker, found := tickersToUpdate[timestamp]
+		if !found {
+			u := time.Unix(int64(timestamp), 0).UTC()
+			ticker, err = cg.db.FiatRatesGetTicker(&u)
+			if err != nil {
+				return written, noBaseTicker, err
+			}
+			if ticker == nil {
+				if token != "" { // if the base currency is not found in DB, do not create ticker for the token
+					noBaseTicker++
+					if !warningLogged {
+						glog.Warningf("No base currency ticker for date %v for token %s", u, token)
+						warningLogged = true
+					}
+					continue
+				}
+				ticker = &common.CurrencyRatesTicker{
+					Timestamp: u,
+					Rates:     make(map[string]float32),
+				}
+			}
+			tickersToUpdate[timestamp] = ticker
+		}
+		if token == "" {
+			if fillMissingOnly {
+				if _, ok := ticker.Rates[vsCurrency]; ok {
+					continue
+				}
+			}
+			ticker.Rates[vsCurrency] = rate
+		} else {
+			if ticker.TokenRates == nil {
+				ticker.TokenRates = make(map[string]float32)
+			}
+			if fillMissingOnly {
+				if _, ok := ticker.TokenRates[token]; ok {
+					continue
+				}
+			}
+			ticker.TokenRates[token] = rate
+		}
+		written++
+	}
+	return written, noBaseTicker, nil
+}
+
+func (cg *Coingecko) getHistoricalTicker(tickersToUpdate map[uint]*common.CurrencyRatesTicker, coinId string, vsCurrency string, token string, allowMax bool) (bool, error) {
 	lastTicker, err := cg.db.FiatRatesFindLastTicker(vsCurrency, token)
 	if err != nil {
 		return false, err
@@ -700,55 +818,42 @@ func (cg *Coingecko) getHistoricalTicker(baseURL string, tickersToUpdate map[uin
 	if cg.metrics != nil {
 		cg.metrics.CoingeckoRangeRequests.With(common.Labels{"range": rangeKind}).Inc()
 	}
+	// the tip (gap == 1 day) stays on the rate-limited endpoint; everything larger uses the CDN
+	baseURL := cg.sourceURLForRange(rangeKind)
+	phase := phaseForRange(rangeKind)
 	// both callers update historical (daily) tickers, therefore always low priority
 	mc, err := cg.coinMarketChartAt(baseURL, coinId, vsCurrency, days, true, priorityLow)
 	if err != nil {
 		return false, err
 	}
-	warningLogged := false
-	for _, p := range mc.Prices {
-		var timestamp uint
-		timestamp = uint(p[0])
-		if timestamp > 100000000000 {
-			// convert timestamp from milliseconds to seconds
-			timestamp /= 1000
-		}
-		rate := float32(p[1])
-		if timestamp%(24*3600) == 0 && timestamp != 0 && rate != 0 { // process only tickers for the whole day with non 0 value
-			var found bool
-			var ticker *common.CurrencyRatesTicker
-			if ticker, found = tickersToUpdate[timestamp]; !found {
-				u := time.Unix(int64(timestamp), 0).UTC()
-				ticker, err = cg.db.FiatRatesGetTicker(&u)
-				if err != nil {
-					return false, err
-				}
-				if ticker == nil {
-					if token != "" { // if the base currency is not found in DB, do not create ticker for the token
-						if !warningLogged {
-							glog.Warningf("No base currency ticker for date %v for token %s", u, token)
-							warningLogged = true
-						}
-						continue
-					}
-					ticker = &common.CurrencyRatesTicker{
-						Timestamp: u,
-						Rates:     make(map[string]float32),
-					}
-				}
-				tickersToUpdate[timestamp] = ticker
-			}
-			if token == "" {
-				ticker.Rates[vsCurrency] = rate
-			} else {
-				if ticker.TokenRates == nil {
-					ticker.TokenRates = make(map[string]float32)
-				}
-				ticker.TokenRates[token] = rate
-			}
-		}
+	written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, vsCurrency, token, false)
+	if err != nil {
+		return false, err
 	}
+	cg.observeFetchedUnits(phase, written)
+	if token != "" && written > 0 {
+		cg.observeFetchedToken(phase)
+	}
+	cg.observeUnable(phase, fiatUnableNoBaseTicker, noBaseTicker)
 	return true, nil
+}
+
+func (cg *Coingecko) observeFetchedUnits(phase string, n int) {
+	if cg.metrics != nil && n > 0 {
+		cg.metrics.FiatRatesFetchedUnits.With(common.Labels{"phase": phase}).Add(float64(n))
+	}
+}
+
+func (cg *Coingecko) observeFetchedToken(phase string) {
+	if cg.metrics != nil {
+		cg.metrics.FiatRatesFetchedTokens.With(common.Labels{"phase": phase}).Inc()
+	}
+}
+
+func (cg *Coingecko) observeUnable(phase string, reason string, n int) {
+	if cg.metrics != nil && n > 0 {
+		cg.metrics.FiatRatesUnable.With(common.Labels{"phase": phase, "reason": reason}).Add(float64(n))
+	}
 }
 
 func (cg *Coingecko) storeTickers(tickersToUpdate map[uint]*common.CurrencyRatesTicker) error {
@@ -775,7 +880,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	if err != nil {
 		return err
 	}
-	historicalSyncURL := cg.historicalSyncURL(bootstrapInProgress)
+	metadataURL := cg.metadataURL()
 	if bootstrapInProgress {
 		if !cg.canUseBootstrapMax() {
 			return coingeckoBootstrapPreconditionError()
@@ -784,7 +889,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	}
 
 	// reload vs_currencies
-	vs, err := cg.simpleSupportedVSCurrenciesAt(historicalSyncURL, priorityLow)
+	vs, err := cg.simpleSupportedVSCurrenciesAt(metadataURL, priorityLow)
 	if err != nil {
 		return err
 	}
@@ -797,7 +902,7 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	for _, currency := range vs {
 		// get historical rates for each currency
 		var err error
-		if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
+		if _, err = cg.getHistoricalTicker(tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
 			hadFailures = true
 			// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 			// the rates will be updated next run
@@ -842,7 +947,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		if err != nil {
 			return err
 		}
-		historicalSyncURL := cg.historicalSyncURL(bootstrapInProgress)
+		metadataURL := cg.metadataURL()
 		if bootstrapInProgress {
 			if !cg.canUseBootstrapMax() {
 				return coingeckoBootstrapPreconditionError()
@@ -851,7 +956,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		}
 
 		//  reload platform ids
-		if err := cg.platformIdsAt(historicalSyncURL, priorityLow); err != nil {
+		if err := cg.platformIdsAt(metadataURL, priorityLow); err != nil {
 			return err
 		}
 		cg.cacheMu.Lock()
@@ -863,7 +968,7 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		// get token historical rates
 		for tokenId, token := range platformIdsToTokens {
 			var err error
-			if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
+			if _, err = cg.getHistoricalTicker(tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run
 				glog.Errorf("getHistoricalTicker %s-%s %v", tokenId, cg.platformVsCurrency, err)

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -1000,3 +1000,143 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 	}
 	return nil
 }
+
+// reconcileTarget identifies one fiat-rate series to reconcile: a base-coin vsCurrency
+// (token == "") or a token priced in platformVsCurrency.
+type reconcileTarget struct {
+	coinId     string
+	vsCurrency string
+	token      string
+}
+
+// ReconcileHistoricalRates is the blocking startup self-healing pass. Within the trailing
+// windowDays window it repairs daily fiat rates missing from the DB — both interior holes
+// and the trailing gap — for the base coin (every vsCurrency) and every token, filling only
+// the days a series lacks so existing data is never rewritten. All fetching goes to the CDN.
+//
+// It runs in two stages, as a safety valve against runaway repair:
+//   - Stage 1 reads the DB and classifies every series. A series whose most recent ticker is
+//     at least maxGapDays old (a months-long gap) is reported as gap_too_large and skipped —
+//     such a gap signals a bug/misconfiguration, not routine catch-up. First-seen series
+//     (no ticker yet) are left to the runtime downloader's initial population.
+//   - Stage 2 fetches the window for each repair candidate, fills the holes and persists.
+//
+// It is a no-op while bootstrap is still in progress (the bootstrap pass owns full-history
+// population) or when no CDN URL is configured.
+func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) error {
+	bootstrapInProgress, _, err := historicalBootstrapInProgress(cg.db)
+	if err != nil {
+		return err
+	}
+	if bootstrapInProgress {
+		glog.Info("FiatRates reconcile: bootstrap still in progress, skipping startup reconciliation")
+		return nil
+	}
+	if cg.bootstrapURL == "" {
+		glog.Info("FiatRates reconcile: no CDN bootstrap URL configured, skipping startup reconciliation")
+		return nil
+	}
+	days := strconv.Itoa(windowDays)
+	cdnURL := cg.metadataURL()
+
+	// ---- Stage 1: read DB, classify what is missing, collect stats ----
+	vs, err := cg.simpleSupportedVSCurrenciesAt(cdnURL, priorityLow)
+	if err != nil {
+		return fmt.Errorf("reconcile: supported_vs_currencies: %w", err)
+	}
+	cg.cacheMu.Lock()
+	cg.vsCurrencies = vs
+	cg.cacheMu.Unlock()
+
+	candidates := make([]reconcileTarget, 0, len(vs))
+	for _, currency := range vs {
+		candidates = append(candidates, reconcileTarget{coinId: cg.coin, vsCurrency: currency})
+	}
+	if cg.platformIdentifier != "" && cg.platformVsCurrency != "" {
+		if err := cg.platformIdsAt(cdnURL, priorityLow); err != nil {
+			return fmt.Errorf("reconcile: coins/list: %w", err)
+		}
+		cg.cacheMu.Lock()
+		platformIdsToTokens := cg.platformIdsToTokens
+		cg.cacheMu.Unlock()
+		for tokenId, token := range platformIdsToTokens {
+			candidates = append(candidates, reconcileTarget{coinId: tokenId, vsCurrency: cg.platformVsCurrency, token: token})
+		}
+	}
+
+	toRepair := make([]reconcileTarget, 0, len(candidates))
+	flagged, firstSeen := 0, 0
+	for _, c := range candidates {
+		lastTicker, err := cg.db.FiatRatesFindLastTicker(c.vsCurrency, c.token)
+		if err != nil {
+			return fmt.Errorf("reconcile: find last ticker %s/%s: %w", c.vsCurrency, c.token, err)
+		}
+		if lastTicker == nil {
+			// first-seen series: initial population belongs to the runtime downloader
+			firstSeen++
+			continue
+		}
+		gapDays := int(time.Since(lastTicker.Timestamp) / (24 * time.Hour))
+		if gapDays >= maxGapDays {
+			cg.observeUnable(fiatPhaseReconcile, fiatUnableGapTooLarge, 1)
+			flagged++
+			continue
+		}
+		toRepair = append(toRepair, c)
+	}
+	glog.Infof("FiatRates reconcile stage 1: %d series to repair, %d flagged gap_too_large (>=%dd), %d first-seen skipped (of %d candidates, window %dd)",
+		len(toRepair), flagged, maxGapDays, firstSeen, len(candidates), windowDays)
+
+	if len(toRepair) == 0 {
+		return nil
+	}
+
+	// ---- Stage 2: fetch the window from the CDN, fill holes, persist ----
+	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
+	repaired, failed := 0, 0
+	var banErr error
+	for i, c := range toRepair {
+		mc, err := cg.coinMarketChartAt(cg.sourceURLForRange(coingeckoRangeBackfill), c.coinId, c.vsCurrency, days, true, priorityLow)
+		if err != nil {
+			failed++
+			if isCoingeckoCloudflareBanError(err) {
+				cg.observeUnable(fiatPhaseReconcile, fiatUnableProviderBan, 1)
+				banErr = err
+				glog.Errorf("FiatRates reconcile: Cloudflare ban fetching %s/%s, stopping: %v", c.coinId, c.vsCurrency, err)
+				break
+			}
+			cg.observeUnable(fiatPhaseReconcile, fiatUnableFetchFailed, 1)
+			glog.Errorf("FiatRates reconcile: fetch %s/%s failed: %v", c.coinId, c.vsCurrency, err)
+			continue
+		}
+		written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, c.vsCurrency, c.token, true)
+		if err != nil {
+			if storeErr := cg.storeTickers(tickersToUpdate); storeErr != nil {
+				return storeErr
+			}
+			return fmt.Errorf("reconcile: fill %s/%s: %w", c.coinId, c.vsCurrency, err)
+		}
+		cg.observeFetchedUnits(fiatPhaseReconcile, written)
+		if c.token != "" && written > 0 {
+			cg.observeFetchedToken(fiatPhaseReconcile)
+		}
+		cg.observeUnable(fiatPhaseReconcile, fiatUnableNoBaseTicker, noBaseTicker)
+		repaired++
+		// flush periodically to bound memory (token-bearing day records are large)
+		if (i+1)%100 == 0 {
+			if err := cg.storeTickers(tickersToUpdate); err != nil {
+				return err
+			}
+			tickersToUpdate = make(map[uint]*common.CurrencyRatesTicker)
+			glog.Infof("FiatRates reconcile stage 2: processed %d of %d series", i+1, len(toRepair))
+		}
+	}
+	if err := cg.storeTickers(tickersToUpdate); err != nil {
+		return err
+	}
+	glog.Infof("FiatRates reconcile stage 2: repaired %d series, %d fetch failures", repaired, failed)
+	if banErr != nil {
+		return banErr
+	}
+	return nil
+}

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -745,9 +745,11 @@ func (cg *Coingecko) resolveHistoricalDays(lastTicker *common.CurrencyRatesTicke
 // fillFromMarketChart writes the whole-day points from a market_chart response into
 // tickersToUpdate. With fillMissingOnly set, an already-present rate for the series is left
 // intact (used by the startup reconciliation so it repairs holes without rewriting existing
-// data). Returns the number of daily points written and the number of token points skipped
-// because their day had no base-currency ticker yet.
-func (cg *Coingecko) fillFromMarketChart(tickersToUpdate map[uint]*common.CurrencyRatesTicker, mc *marketChartPrices, vsCurrency string, token string, fillMissingOnly bool) (written int, noBaseTicker int, err error) {
+// data). When targetDays is non-nil, only points whose day-bucket is in the set are
+// considered, so the reconciliation touches (and therefore persists) only the missing days.
+// Returns the number of daily points written and the number of token points skipped because
+// their day had no base-currency ticker yet.
+func (cg *Coingecko) fillFromMarketChart(tickersToUpdate map[uint]*common.CurrencyRatesTicker, mc *marketChartPrices, vsCurrency string, token string, fillMissingOnly bool, targetDays map[uint]struct{}) (written int, noBaseTicker int, err error) {
 	warningLogged := false
 	for _, p := range mc.Prices {
 		timestamp := uint(p[0])
@@ -759,6 +761,11 @@ func (cg *Coingecko) fillFromMarketChart(tickersToUpdate map[uint]*common.Curren
 		if timestamp%(24*3600) != 0 || timestamp == 0 || rate == 0 {
 			// process only tickers for the whole day with non 0 value
 			continue
+		}
+		if targetDays != nil {
+			if _, wanted := targetDays[timestamp]; !wanted {
+				continue
+			}
 		}
 		ticker, found := tickersToUpdate[timestamp]
 		if !found {
@@ -826,7 +833,7 @@ func (cg *Coingecko) getHistoricalTicker(tickersToUpdate map[uint]*common.Curren
 	if err != nil {
 		return false, err
 	}
-	written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, vsCurrency, token, false)
+	written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, vsCurrency, token, false, nil)
 	if err != nil {
 		return false, err
 	}
@@ -1009,94 +1016,176 @@ type reconcileTarget struct {
 	token      string
 }
 
-// ReconcileHistoricalRates is the blocking startup self-healing pass. Within the trailing
-// windowDays window it repairs daily fiat rates missing from the DB — both interior holes
-// and the trailing gap — for the base coin (every vsCurrency) and every token, filling only
-// the days a series lacks so existing data is never rewritten. All fetching goes to the CDN.
+// missingDayWindow scans the stored daily tickers and determines which whole days are missing
+// within the reconcile window. It returns the missing day-bucket timestamps (unix seconds),
+// the earliest missing day, and whether any history exists at all. "Missing" means no record
+// for that day between the oldest in-window record and the last reconcilable day (the tip and
+// the still-forming current day are excluded — they belong to the runtime downloader). When
+// the window holds no records but history exists, the whole window counts as missing (a
+// trailing gap larger than the window), which the caller treats as a probable bug.
+func (cg *Coingecko) missingDayWindow(windowDays int) (missing map[uint]struct{}, earliest int64, haveHistory bool, err error) {
+	now := time.Now().UTC().Unix()
+	today := now - now%secondsInDay
+	windowStart := today - int64(windowDays)*secondsInDay
+	// reconciliation owns days strictly older than the tip; the tip (gap <= 1 day) and the
+	// still-forming current day are the runtime downloader's responsibility.
+	lastReconcilable := today - int64(coingeckoTipWindowDays+1)*secondsInDay
+
+	timestamps, err := cg.db.FiatRatesGetTickerTimestamps(time.Unix(windowStart, 0).UTC())
+	if err != nil {
+		return nil, 0, false, err
+	}
+	present := make(map[int64]struct{}, len(timestamps))
+	firstPresent := int64(0)
+	for _, ts := range timestamps {
+		day := ts - ts%secondsInDay
+		if day > lastReconcilable {
+			continue
+		}
+		if _, ok := present[day]; !ok {
+			present[day] = struct{}{}
+			if firstPresent == 0 || day < firstPresent {
+				firstPresent = day
+			}
+		}
+	}
+
+	startDay := windowStart
+	if len(present) > 0 {
+		// don't expect data older than the oldest record we have (the series/coin may simply
+		// not go back that far); only fill gaps from there forward.
+		startDay = firstPresent
+	} else {
+		lastAny, err := cg.db.FiatRatesFindLastTicker("", "")
+		if err != nil {
+			return nil, 0, false, err
+		}
+		if lastAny == nil {
+			return nil, 0, false, nil // no history at all, nothing to reconcile
+		}
+		lastDay := lastAny.Timestamp.UTC().Unix()
+		lastDay -= lastDay % secondsInDay
+		if lastDay >= windowStart {
+			// recent data exists but nothing old enough to reconcile (young DB, or only
+			// tip/current-day records) -> not a gap, nothing to do.
+			return make(map[uint]struct{}), 0, true, nil
+		}
+		// history predates the window entirely -> a trailing gap larger than the window;
+		// startDay stays at windowStart so the whole window is counted missing (-> flagged).
+	}
+
+	missing = make(map[uint]struct{})
+	earliest = 0
+	for day := startDay; day <= lastReconcilable; day += secondsInDay {
+		if _, ok := present[day]; ok {
+			continue
+		}
+		if earliest == 0 {
+			earliest = day
+		}
+		missing[uint(day)] = struct{}{}
+	}
+	return missing, earliest, true, nil
+}
+
+// ReconcileHistoricalRates is the blocking startup self-healing pass. It repairs daily fiat
+// rates missing from the DB — both interior holes and trailing gaps — within the last
+// windowDays days, for the base coin (every vsCurrency) and every token, filling only the
+// missing days so existing data is never rewritten. All fetching goes to the CDN. It returns
+// the number of daily points filled (0 when the DB is already healthy).
 //
-// It runs in two stages, as a safety valve against runaway repair:
-//   - Stage 1 reads the DB and classifies every series. A series whose most recent ticker is
-//     at least maxGapDays old (a months-long gap) is reported as gap_too_large and skipped —
-//     such a gap signals a bug/misconfiguration, not routine catch-up. First-seen series
-//     (no ticker yet) are left to the runtime downloader's initial population.
-//   - Stage 2 fetches the window for each repair candidate, fills the holes and persists.
+// Two stages, with the gap guard acting as a safety valve against runaway repair:
+//   - Stage 1 reads the DB (keys only) and computes which whole days are missing. If 90+ days
+//     (maxGapDays) are missing it is reported as gap_too_large and nothing is fetched, since
+//     such a gap signals a bug/misconfiguration rather than routine catch-up. If zero days are
+//     missing it returns immediately — the common, healthy case makes no network requests.
+//   - Stage 2 fetches just the missing-day range from the CDN for each series and fills only
+//     those days.
 //
 // It is a no-op while bootstrap is still in progress (the bootstrap pass owns full-history
 // population) or when no CDN URL is configured.
-func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) error {
+func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) (int, error) {
 	bootstrapInProgress, _, err := historicalBootstrapInProgress(cg.db)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if bootstrapInProgress {
 		glog.Info("FiatRates reconcile: bootstrap still in progress, skipping startup reconciliation")
-		return nil
+		return 0, nil
 	}
 	if cg.bootstrapURL == "" {
 		glog.Info("FiatRates reconcile: no CDN bootstrap URL configured, skipping startup reconciliation")
-		return nil
+		return 0, nil
 	}
-	days := strconv.Itoa(windowDays)
-	cdnURL := cg.metadataURL()
 
-	// ---- Stage 1: read DB, classify what is missing, collect stats ----
-	vs, err := cg.simpleSupportedVSCurrenciesAt(cdnURL, priorityLow)
+	// ---- Stage 1: read DB (cheap key scan), find which whole days are missing ----
+	missingDays, earliestMissing, haveHistory, err := cg.missingDayWindow(windowDays)
 	if err != nil {
-		return fmt.Errorf("reconcile: supported_vs_currencies: %w", err)
+		return 0, fmt.Errorf("reconcile: scan missing days: %w", err)
+	}
+	if !haveHistory {
+		glog.Info("FiatRates reconcile: no historical rates present, nothing to reconcile")
+		return 0, nil
+	}
+	if len(missingDays) == 0 {
+		glog.Infof("FiatRates reconcile: no missing days within the last %d days, historical rates are healthy", windowDays)
+		return 0, nil
+	}
+	if len(missingDays) >= maxGapDays {
+		// a months-long gap is almost certainly a bug/misconfiguration; surface it instead of
+		// firing a multi-thousand-request backfill on every restart.
+		cg.observeUnable(fiatPhaseReconcile, fiatUnableGapTooLarge, len(missingDays))
+		glog.Warningf("FiatRates reconcile: %d missing days within the %d-day window (>= %d guard), probable bug/misconfiguration; not auto-backfilling", len(missingDays), windowDays, maxGapDays)
+		return 0, nil
+	}
+
+	// fetch a range that spans back to the earliest missing day (capped to the window)
+	nowDay := time.Now().UTC().Unix()
+	nowDay -= nowDay % secondsInDay
+	fetchDays := int((nowDay-earliestMissing)/secondsInDay) + 1
+	if fetchDays > windowDays {
+		fetchDays = windowDays
+	}
+	days := strconv.Itoa(fetchDays)
+	cdnURL := cg.sourceURLForRange(coingeckoRangeBackfill)
+	metaURL := cg.metadataURL()
+
+	// enumerate the series to repair: base coin x each vsCurrency, plus each token
+	vs, err := cg.simpleSupportedVSCurrenciesAt(metaURL, priorityLow)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile: supported_vs_currencies: %w", err)
 	}
 	cg.cacheMu.Lock()
 	cg.vsCurrencies = vs
 	cg.cacheMu.Unlock()
 
-	candidates := make([]reconcileTarget, 0, len(vs))
+	targets := make([]reconcileTarget, 0, len(vs))
 	for _, currency := range vs {
-		candidates = append(candidates, reconcileTarget{coinId: cg.coin, vsCurrency: currency})
+		targets = append(targets, reconcileTarget{coinId: cg.coin, vsCurrency: currency})
 	}
 	if cg.platformIdentifier != "" && cg.platformVsCurrency != "" {
-		if err := cg.platformIdsAt(cdnURL, priorityLow); err != nil {
-			return fmt.Errorf("reconcile: coins/list: %w", err)
+		if err := cg.platformIdsAt(metaURL, priorityLow); err != nil {
+			return 0, fmt.Errorf("reconcile: coins/list: %w", err)
 		}
 		cg.cacheMu.Lock()
 		platformIdsToTokens := cg.platformIdsToTokens
 		cg.cacheMu.Unlock()
 		for tokenId, token := range platformIdsToTokens {
-			candidates = append(candidates, reconcileTarget{coinId: tokenId, vsCurrency: cg.platformVsCurrency, token: token})
+			targets = append(targets, reconcileTarget{coinId: tokenId, vsCurrency: cg.platformVsCurrency, token: token})
 		}
 	}
 
-	toRepair := make([]reconcileTarget, 0, len(candidates))
-	flagged, firstSeen := 0, 0
-	for _, c := range candidates {
-		lastTicker, err := cg.db.FiatRatesFindLastTicker(c.vsCurrency, c.token)
-		if err != nil {
-			return fmt.Errorf("reconcile: find last ticker %s/%s: %w", c.vsCurrency, c.token, err)
-		}
-		if lastTicker == nil {
-			// first-seen series: initial population belongs to the runtime downloader
-			firstSeen++
-			continue
-		}
-		gapDays := int(time.Since(lastTicker.Timestamp) / (24 * time.Hour))
-		if gapDays >= maxGapDays {
-			cg.observeUnable(fiatPhaseReconcile, fiatUnableGapTooLarge, 1)
-			flagged++
-			continue
-		}
-		toRepair = append(toRepair, c)
-	}
-	glog.Infof("FiatRates reconcile stage 1: %d series to repair, %d flagged gap_too_large (>=%dd), %d first-seen skipped (of %d candidates, window %dd)",
-		len(toRepair), flagged, maxGapDays, firstSeen, len(candidates), windowDays)
+	glog.Infof("FiatRates reconcile stage 1: %d missing day(s) within %dd (earliest %s); fetching days=%d for %d series",
+		len(missingDays), windowDays, time.Unix(earliestMissing, 0).UTC().Format("2006-01-02"), fetchDays, len(targets))
 
-	if len(toRepair) == 0 {
-		return nil
-	}
-
-	// ---- Stage 2: fetch the window from the CDN, fill holes, persist ----
+	// ---- Stage 2: fetch the missing-day range from the CDN and fill only those days ----
+	// targetDays ensures only the (few) missing-day records are touched and persisted, so the
+	// shared map holds at most len(missingDays) records regardless of how many series we scan.
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
-	repaired, failed := 0, 0
+	filled, failed, repairedTokens := 0, 0, 0
 	var banErr error
-	for i, c := range toRepair {
-		mc, err := cg.coinMarketChartAt(cg.sourceURLForRange(coingeckoRangeBackfill), c.coinId, c.vsCurrency, days, true, priorityLow)
+	for _, c := range targets {
+		mc, err := cg.coinMarketChartAt(cdnURL, c.coinId, c.vsCurrency, days, true, priorityLow)
 		if err != nil {
 			failed++
 			if isCoingeckoCloudflareBanError(err) {
@@ -1109,34 +1198,27 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) er
 			glog.Errorf("FiatRates reconcile: fetch %s/%s failed: %v", c.coinId, c.vsCurrency, err)
 			continue
 		}
-		written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, c.vsCurrency, c.token, true)
+		written, noBaseTicker, err := cg.fillFromMarketChart(tickersToUpdate, mc, c.vsCurrency, c.token, true, missingDays)
 		if err != nil {
 			if storeErr := cg.storeTickers(tickersToUpdate); storeErr != nil {
-				return storeErr
+				return filled, storeErr
 			}
-			return fmt.Errorf("reconcile: fill %s/%s: %w", c.coinId, c.vsCurrency, err)
+			return filled, fmt.Errorf("reconcile: fill %s/%s: %w", c.coinId, c.vsCurrency, err)
 		}
+		filled += written
 		cg.observeFetchedUnits(fiatPhaseReconcile, written)
 		if c.token != "" && written > 0 {
+			repairedTokens++
 			cg.observeFetchedToken(fiatPhaseReconcile)
 		}
 		cg.observeUnable(fiatPhaseReconcile, fiatUnableNoBaseTicker, noBaseTicker)
-		repaired++
-		// flush periodically to bound memory (token-bearing day records are large)
-		if (i+1)%100 == 0 {
-			if err := cg.storeTickers(tickersToUpdate); err != nil {
-				return err
-			}
-			tickersToUpdate = make(map[uint]*common.CurrencyRatesTicker)
-			glog.Infof("FiatRates reconcile stage 2: processed %d of %d series", i+1, len(toRepair))
-		}
 	}
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
-		return err
+		return filled, err
 	}
-	glog.Infof("FiatRates reconcile stage 2: repaired %d series, %d fetch failures", repaired, failed)
+	glog.Infof("FiatRates reconcile stage 2: filled %d point(s) across %d series (%d token series), %d fetch failures", filled, len(targets), repairedTokens, failed)
 	if banErr != nil {
-		return banErr
+		return filled, banErr
 	}
-	return nil
+	return filled, nil
 }

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -30,8 +30,10 @@ const (
 	coingeckoRangeTip                 = "tip"
 	coingeckoRangeCapped              = "capped"
 	coingeckoRangeBackfill            = "backfill"
-	// coingeckoTipWindowDays is the only gap still served from the rate-limited tip
-	// endpoint (the chain tip); anything larger is high-volume backfill routed to the CDN.
+	// coingeckoTipWindowDays is the daily-series gap (in days) treated as the "tip" range --
+	// yesterday's just-closed daily candle. Like every other daily/historical range it is fetched
+	// from the CDN when one is configured (see sourceURLForRange); only the live current price and
+	// the high-granularity charts stay on the rate-limited Free/Pro tip endpoint.
 	coingeckoTipWindowDays   = 1
 	coingeckoBootstrapURL    = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
 	coingeckoProURL          = "https://pro-api.coingecko.com/api/v3"
@@ -45,7 +47,7 @@ const (
 // Phase labels for the fiat-rate fetch metrics (fiat_rates_fetched_units_total,
 // fiat_rates_fetched_tokens_total, fiat_rates_unable_total).
 const (
-	fiatPhaseTip       = "tip"       // chain tip, gap == 1 day, Free tier
+	fiatPhaseTip       = "tip"       // daily-series tip, gap == 1 day (yesterday's close); CDN when configured
 	fiatPhaseBackfill  = "backfill"  // gap > 1 day or first-seen series, via CDN
 	fiatPhaseBootstrap = "bootstrap" // full-history population, via CDN
 	fiatPhaseReconcile = "reconcile" // startup self-healing pass, via CDN
@@ -730,14 +732,16 @@ func (cg *Coingecko) metadataURL() string {
 	return cg.tipURL
 }
 
-// sourceURLForRange routes each historical range to the right backend: the rate-limited
-// tip endpoint is used only for the chain tip (gap == 1 day); every higher-volume range
-// (backfill, capped, full-history) goes to the CDN when configured. When no CDN URL is
-// configured we fall back to the tip endpoint to preserve pre-CDN behavior.
+// sourceURLForRange routes daily/historical fetches to the right backend. Every daily range --
+// including the 1-day "tip" range (yesterday's just-closed daily candle) -- goes to the CDN when
+// a CDN/bootstrap URL is configured. This matters most for the per-token daily tip, which is
+// thousands of requests for platforms like Ethereum and must not run against the rate-limited
+// Free tier. Only genuinely live, low-volume calls stay on cg.tipURL -- the current price via
+// /simple/price and the high-granularity hourly/5-minute charts -- and those do not go through
+// here. When no CDN URL is configured we fall back to the tip endpoint to preserve pre-CDN
+// behavior. The rangeKind is retained for call-site clarity (and to keep per-range routing easy
+// to reintroduce); routing is currently uniform across all daily ranges.
 func (cg *Coingecko) sourceURLForRange(rangeKind string) string {
-	if rangeKind == coingeckoRangeTip {
-		return cg.tipURL
-	}
 	if cg.bootstrapURL != "" {
 		return cg.bootstrapURL
 	}
@@ -771,7 +775,8 @@ func (cg *Coingecko) resolveHistoricalDays(lastTicker *common.CurrencyRatesTicke
 		return "", false, ""
 	}
 	if d <= coingeckoTipWindowDays {
-		// The chain tip: a single missing day, served from the rate-limited tip endpoint.
+		// The daily-series tip: a single missing day (yesterday's close). Routed to the CDN like
+		// every other daily range when one is configured (see sourceURLForRange).
 		return strconv.Itoa(d), true, coingeckoRangeTip
 	}
 	if d > coingeckoHistoryDaysLimit {
@@ -867,7 +872,8 @@ func (cg *Coingecko) getHistoricalTicker(ctx context.Context, tickersToUpdate ma
 	if cg.metrics != nil {
 		cg.metrics.CoingeckoRangeRequests.With(common.Labels{"range": rangeKind}).Inc()
 	}
-	// the tip (gap == 1 day) stays on the rate-limited endpoint; everything larger uses the CDN
+	// all daily/historical ranges (including the 1-day tip) use the CDN when configured; only the
+	// live current price and high-granularity charts stay on the rate-limited tip endpoint
 	baseURL := cg.sourceURLForRange(rangeKind)
 	phase := phaseForRange(rangeKind)
 	// both callers update historical (daily) tickers, therefore always low priority

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -706,11 +706,9 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 			hadFailures = true
 			if isCoingeckoThrottleRetriesExhaustedError(err) {
 				throttleErr = err
-				if bootstrapInProgress {
-					break
-				}
-				glog.Warningf("getHistoricalTicker %s-%s throttled, continuing with remaining currencies: %v", cg.coin, currency, err)
-				continue
+				// Stop, store and retry on the next cycle
+				glog.Warningf("getHistoricalTicker %s-%s throttled, stopping run with partial currencies: %v", cg.coin, currency, err)
+				break
 			}
 			// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 			// the rates will be updated next run
@@ -765,11 +763,9 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 			if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
 				if isCoingeckoThrottleRetriesExhaustedError(err) {
 					throttleErr = err
-					if bootstrapInProgress {
-						break
-					}
-					glog.Warningf("getHistoricalTicker %s-%s throttled, continuing with remaining tokens: %v", tokenId, cg.platformVsCurrency, err)
-					continue
+					// Stop, store and retry on the next cycle
+					glog.Warningf("getHistoricalTicker %s-%s throttled, stopping run with partial tokens: %v", tokenId, cg.platformVsCurrency, err)
+					break
 				}
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -19,19 +20,20 @@ import (
 )
 
 const (
-	DefaultHTTPTimeout        = 15 * time.Second
-	DefaultThrottleDelayMs    = 100 // 100 ms delay between requests
-	coingeckoHistoryDaysLimit = 365
-	coingeckoRangeHistorical  = "historical"
-	coingeckoRangeTip         = "tip"
-	coingeckoRangeCapped      = "capped"
-	coingeckoBootstrapURL     = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
-	coingeckoProURL           = "https://pro-api.coingecko.com/api/v3"
-	coingeckoFreeURL          = "https://api.coingecko.com/api/v3"
-	coingeckoPlanFree         = "free"
-	coingeckoPlanPro          = "pro"
-	coingeckoAPIKeyEnv        = "COINGECKO_API_KEY"
-	coingeckoAPIKeyEnvSuffix  = "_" + coingeckoAPIKeyEnv
+	DefaultHTTPTimeout                 = 15 * time.Second
+	DefaultThrottleDelayMs             = 100
+	coingeckoHistoryDaysLimit          = 365
+	coingeckoFreePlanRequestsPerMinute = 25
+	coingeckoRangeHistorical           = "historical"
+	coingeckoRangeTip                  = "tip"
+	coingeckoRangeCapped               = "capped"
+	coingeckoBootstrapURL              = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
+	coingeckoProURL                    = "https://pro-api.coingecko.com/api/v3"
+	coingeckoFreeURL                   = "https://api.coingecko.com/api/v3"
+	coingeckoPlanFree                  = "free"
+	coingeckoPlanPro                   = "pro"
+	coingeckoAPIKeyEnv                 = "COINGECKO_API_KEY"
+	coingeckoAPIKeyEnvSuffix           = "_" + coingeckoAPIKeyEnv
 )
 
 var coingeckoThrottleRetryBackoff = []time.Duration{
@@ -58,22 +60,23 @@ func (e *coingeckoThrottleRetriesExhaustedError) Unwrap() error {
 
 // Coingecko is a structure that implements RatesDownloaderInterface
 type Coingecko struct {
-	tipURL              string
-	bootstrapURL        string
-	apiKey              string
-	coin                string
-	platformIdentifier  string
-	platformVsCurrency  string
-	allowedVsCurrencies map[string]struct{}
-	httpTimeout         time.Duration
-	throttlingDelay     time.Duration
-	timeFormat          string
-	httpClient          *http.Client
-	db                  *db.RocksDB
-	updatingCurrent     bool
-	updatingTokens      bool
-	metrics             *common.Metrics
-	plan                string
+	tipURL                 string
+	bootstrapURL           string
+	apiKey                 string
+	coin                   string
+	platformIdentifier     string
+	platformVsCurrency     string
+	allowedVsCurrencies    map[string]struct{}
+	httpTimeout            time.Duration
+	timeFormat             string
+	httpClient             *http.Client
+	db                     *db.RocksDB
+	updatingTokens         bool
+	metrics                *common.Metrics
+	plan                   string
+	minHttpRequestInterval time.Duration
+	reqMu                  sync.Mutex
+	lastRequestAt          time.Time
 }
 
 // simpleSupportedVSCurrencies https://api.coingecko.com/api/v3/simple/supported_vs_currencies
@@ -160,15 +163,19 @@ func resolveCoinGeckoBootstrapURL(bootstrapURL string) string {
 
 // NewCoinGeckoDownloader creates a coingecko structure that implements the RatesDownloaderInterface
 func NewCoinGeckoDownloader(db *db.RocksDB, network string, coinShortcut string, bootstrapURL string, coin string, platformIdentifier string, platformVsCurrency string, allowedVsCurrencies string, timeFormat string, plan string, metrics *common.Metrics, throttleDown bool) RatesDownloaderInterface {
-	throttlingDelayMs := 0 // No delay by default
-	if throttleDown {
-		throttlingDelayMs = DefaultThrottleDelayMs
-	}
-
 	allowedVsCurrenciesMap := getAllowedVsCurrenciesMap(allowedVsCurrencies)
 
 	apiKey := resolveCoinGeckoAPIKey(network, coinShortcut)
 	normalizedPlan := normalizeCoinGeckoPlan(plan)
+
+	minRequestInterval := time.Duration(0)
+	if throttleDown {
+		if normalizedPlan == coingeckoPlanFree {
+			minRequestInterval = time.Minute / coingeckoFreePlanRequestsPerMinute
+		} else {
+			minRequestInterval = DefaultThrottleDelayMs * time.Millisecond
+		}
+	}
 	resolvedBootstrapURL := resolveCoinGeckoBootstrapURL(bootstrapURL)
 	tipURL := coingeckoFreeURL
 	if normalizedPlan == coingeckoPlanPro {
@@ -189,10 +196,10 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, coinShortcut string,
 		httpClient: &http.Client{
 			Timeout: DefaultHTTPTimeout,
 		},
-		db:              db,
-		throttlingDelay: time.Duration(throttlingDelayMs) * time.Millisecond,
-		metrics:         metrics,
-		plan:            normalizedPlan,
+		db:                     db,
+		minHttpRequestInterval: minRequestInterval,
+		metrics:                metrics,
+		plan:                   normalizedPlan,
 	}
 }
 
@@ -207,6 +214,18 @@ func getAllowedVsCurrenciesMap(currenciesString string) map[string]struct{} {
 	return allowedVsCurrenciesMap
 }
 
+// coingeckoHTTPError carries the HTTP status from a non-200 response so throttling can be
+// detected by status code. Error() returns the raw body so existing body-based detection
+// (e.g. the Cloudflare "error code: 1015" page) keeps working.
+type coingeckoHTTPError struct {
+	status int
+	body   string
+}
+
+func (e *coingeckoHTTPError) Error() string {
+	return e.body
+}
+
 // doReq HTTP client
 func doReq(req *http.Request, client *http.Client) ([]byte, error) {
 	resp, err := client.Do(req)
@@ -219,7 +238,10 @@ func doReq(req *http.Request, client *http.Client) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("%s", body)
+		return nil, &coingeckoHTTPError{
+			status: resp.StatusCode,
+			body:   string(body),
+		}
 	}
 	return body, nil
 }
@@ -227,6 +249,10 @@ func doReq(req *http.Request, client *http.Client) ([]byte, error) {
 func isCoingeckoThrottleError(err error) bool {
 	if err == nil {
 		return false
+	}
+	var httpErr *coingeckoHTTPError
+	if errors.As(err, &httpErr) && httpErr.status == http.StatusTooManyRequests {
+		return true
 	}
 	lowerError := strings.ToLower(err.Error())
 	return err.Error() == "error code: 1015" ||
@@ -243,10 +269,30 @@ func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 	return errors.Is(err, errCoingeckoHistoricalTokenUpdateInProgress)
 }
 
+// waitForRateLimit enforces minHttpRequestInterval spacing between requests
+func (cg *Coingecko) waitForRateLimit() {
+	if cg.minHttpRequestInterval <= 0 {
+		return
+	}
+	cg.reqMu.Lock()
+	slot := time.Now()
+	if !cg.lastRequestAt.IsZero() {
+		if next := cg.lastRequestAt.Add(cg.minHttpRequestInterval); next.After(slot) {
+			slot = next
+		}
+	}
+	cg.lastRequestAt = slot
+	cg.reqMu.Unlock()
+	if d := time.Until(slot); d > 0 {
+		time.Sleep(d)
+	}
+}
+
 // makeReq HTTP request helper with bounded retries for throttling errors.
 func (cg *Coingecko) makeReq(url string, endpoint string, plan string) ([]byte, error) {
 	for attempt := 0; ; attempt++ {
 		// glog.Infof("Coingecko makeReq %v", url)
+		cg.waitForRateLimit()
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err
@@ -417,9 +463,6 @@ func (cg *Coingecko) platformIdsAt(baseURL string) error {
 
 // CurrentTickers returns the latest exchange rates
 func (cg *Coingecko) CurrentTickers() (*common.CurrencyRatesTicker, error) {
-	cg.updatingCurrent = true
-	defer func() { cg.updatingCurrent = false }()
-
 	var newTickers = common.CurrencyRatesTicker{}
 
 	if vsCurrencies == nil {
@@ -631,15 +674,6 @@ func (cg *Coingecko) storeTickers(tickersToUpdate map[uint]*common.CurrencyRates
 	return nil
 }
 
-func (cg *Coingecko) throttleHistoricalDownload() {
-	// long delay next request to avoid throttling if downloading current tickers at the same time
-	delay := 1
-	if cg.updatingCurrent {
-		delay = 600
-	}
-	time.Sleep(cg.throttlingDelay * time.Duration(delay))
-}
-
 // UpdateHistoricalTickers gets historical tickers for the main crypto currency
 func (cg *Coingecko) UpdateHistoricalTickers() error {
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
@@ -668,19 +702,19 @@ func (cg *Coingecko) UpdateHistoricalTickers() error {
 	for _, currency := range vsCurrencies {
 		// get historical rates for each currency
 		var err error
-		var req bool
-		if req, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
+		if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, cg.coin, currency, "", allowMax); err != nil {
 			hadFailures = true
 			if isCoingeckoThrottleRetriesExhaustedError(err) {
 				throttleErr = err
-				break
+				if bootstrapInProgress {
+					break
+				}
+				glog.Warningf("getHistoricalTicker %s-%s throttled, continuing with remaining currencies: %v", cg.coin, currency, err)
+				continue
 			}
 			// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 			// the rates will be updated next run
 			glog.Errorf("getHistoricalTicker %s-%s %v", cg.coin, currency, err)
-		}
-		if req {
-			cg.throttleHistoricalDownload()
 		}
 	}
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
@@ -728,11 +762,14 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		// get token historical rates
 		for tokenId, token := range platformIdsToTokens {
 			var err error
-			var req bool
-			if req, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
+			if _, err = cg.getHistoricalTicker(historicalSyncURL, tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
 				if isCoingeckoThrottleRetriesExhaustedError(err) {
 					throttleErr = err
-					break
+					if bootstrapInProgress {
+						break
+					}
+					glog.Warningf("getHistoricalTicker %s-%s throttled, continuing with remaining tokens: %v", tokenId, cg.platformVsCurrency, err)
+					continue
 				}
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run
@@ -746,9 +783,6 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 				}
 				tickersToUpdate = make(map[uint]*common.CurrencyRatesTicker)
 				glog.Infof("Coingecko updated %d of %d token tickers", count, len(platformIds))
-			}
-			if req {
-				cg.throttleHistoricalDownload()
 			}
 		}
 	}

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -1019,11 +1019,13 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 		cg.cacheMu.Unlock()
 		glog.Infof("Coingecko returned %d %s tokens ", len(platformIds), cg.coin)
 		count := 0
+		failed := 0
 		var banErr error
 		// get token historical rates
 		for tokenId, token := range platformIdsToTokens {
 			var err error
 			if _, err = cg.getHistoricalTicker(context.Background(), tickersToUpdate, tokenId, cg.platformVsCurrency, token, allowMax); err != nil {
+				failed++
 				// report error and continue, Coingecko may return error like "Could not find coin with the given id"
 				// the rates will be updated next run
 				glog.Errorf("getHistoricalTicker %s-%s %v", tokenId, cg.platformVsCurrency, err)
@@ -1034,25 +1036,26 @@ func (cg *Coingecko) UpdateHistoricalTokenTickers() error {
 			}
 			count++
 			if count%100 == 0 {
-				err := cg.storeTickers(tickersToUpdate)
-				if err != nil {
+				if err := cg.storeTickers(tickersToUpdate); err != nil {
 					return err
 				}
 				tickersToUpdate = make(map[uint]*common.CurrencyRatesTicker)
 				glog.Infof("Coingecko updated %d of %d token tickers", count, len(platformIds))
 			}
 		}
+		// Persist the final (sub-100) batch, then log a clear completion line so the progress
+		// sequence ends on the full count instead of stopping at the last multiple of 100.
+		if err := cg.storeTickers(tickersToUpdate); err != nil {
+			return err
+		}
 		if banErr != nil {
-			if err := cg.storeTickers(tickersToUpdate); err != nil {
-				return err
-			}
+			glog.Warningf("Coingecko stopped updating token tickers after %d of %d (provider ban), %d failed", count, len(platformIds), failed)
 			return banErr
 		}
+		glog.Infof("Coingecko finished updating %d of %d token tickers (%d failed)", count, len(platformIds), failed)
+		return nil
 	}
 
-	if err := cg.storeTickers(tickersToUpdate); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -40,8 +40,6 @@ const (
 // used when retry-after header is missing
 var coingeckoThrottleBackoff = time.Minute
 
-// how often a parked low-priority request re-checks the throttle gate
-// var (not const) so tests can shrink it to avoid real waits
 var coingeckoLowPriorityPollInterval = time.Second
 
 // reqPriority determines which requests reclaim request slots first while a
@@ -71,16 +69,16 @@ type Coingecko struct {
 	updatingTokens           bool
 	metrics                  *common.Metrics
 	plan                     string
-	minHttpRequestInterval   time.Duration // spacing between requests to the rate-limited CoinGecko API hosts (plan-based)
-	bootstrapRequestInterval time.Duration // spacing between requests to the bootstrap CDN, which has no CoinGecko rate limit
+	minHttpRequestInterval   time.Duration
+	bootstrapRequestInterval time.Duration
 	reqMu                    sync.Mutex
 	lastRequestAt            time.Time
-	throttledUntil           time.Time // set on any 429; every request waits past it
-	highPriorityInFlight     int       // high-priority requests currently in flight, including their retries
+	throttledUntil           time.Time
+	highPriorityInFlight     int
 	cacheMu                  sync.Mutex
-	vsCurrencies             []string          // guarded by cacheMu
-	platformIds              []string          // guarded by cacheMu
-	platformIdsToTokens      map[string]string // guarded by cacheMu
+	vsCurrencies             []string
+	platformIds              []string
+	platformIdsToTokens      map[string]string
 }
 
 // simpleSupportedVSCurrencies https://api.coingecko.com/api/v3/simple/supported_vs_currencies
@@ -180,12 +178,6 @@ func NewCoinGeckoDownloader(db *db.RocksDB, network string, coinShortcut string,
 		} else {
 			minRequestInterval = DefaultThrottleDelayMs * time.Millisecond
 		}
-		// The bootstrap CDN (cdn.trezor.io) serves cached CoinGecko data and is not
-		// subject to CoinGecko's per-minute rate limit, so it keeps the light default
-		// spacing regardless of plan. Without this, the free-plan 6s spacing would
-		// stretch the initial bootstrap (tens of currencies + thousands of tokens)
-		// from minutes to hours and, because the bootstrap token pass runs
-		// synchronously on the downloader goroutine, starve current-ticker refreshes.
 		bootstrapRequestInterval = DefaultThrottleDelayMs * time.Millisecond
 	}
 	resolvedBootstrapURL := resolveCoinGeckoBootstrapURL(bootstrapURL)
@@ -227,10 +219,6 @@ func getAllowedVsCurrenciesMap(currenciesString string) map[string]struct{} {
 	return allowedVsCurrenciesMap
 }
 
-// coingeckoHTTPError carries the HTTP status from a non-200 response so throttling can be
-// detected by status code. Error() returns the raw body so existing body-based detection
-// (e.g. the Cloudflare "error code: 1015" page) keeps working. retryAfter holds the parsed
-// Retry-After header (CoinGecko sends it on 429); zero when absent or unparseable.
 type coingeckoHTTPError struct {
 	status     int
 	body       string
@@ -311,15 +299,10 @@ func isCoingeckoHistoricalTokenUpdateInProgressError(err error) bool {
 	return errors.Is(err, errCoingeckoHistoricalTokenUpdateInProgress)
 }
 
-// targetsBootstrapCDN reports whether url points at the bootstrap CDN, which serves
-// cached CoinGecko data and has no CoinGecko per-minute rate limit. Requests to it must
-// not inherit the plan-based pacing meant for the rate-limited CoinGecko API hosts.
 func (cg *Coingecko) targetsBootstrapCDN(url string) bool {
 	return cg.bootstrapURL != "" && strings.HasPrefix(url, cg.bootstrapURL)
 }
 
-// requestIntervalFor returns the minimum spacing to enforce before a request to url:
-// the light CDN spacing for bootstrap requests, the plan-based spacing otherwise.
 func (cg *Coingecko) requestIntervalFor(url string) time.Duration {
 	if cg.targetsBootstrapCDN(url) {
 		return cg.bootstrapRequestInterval
@@ -327,13 +310,6 @@ func (cg *Coingecko) requestIntervalFor(url string) time.Duration {
 	return cg.minHttpRequestInterval
 }
 
-// waitForRequestSlot enforces minInterval spacing between requests and makes every
-// request wait out the shared throttle window opened by any 429. While the window
-// is open, low-priority requests additionally yield to in-flight high-priority ones so
-// current/high-granularity fetches reclaim request slots first.
-// With minInterval == 0 (throttleDown disabled, or a bootstrap request in tests) all
-// waiters fire as soon as the window expires; acceptable, as at most a couple of
-// goroutines share one instance.
 func (cg *Coingecko) waitForRequestSlot(priority reqPriority, minInterval time.Duration) {
 	for {
 		cg.reqMu.Lock()
@@ -423,11 +399,7 @@ func (cg *Coingecko) makeReq(url string, endpoint string, plan string, priority 
 		if cg.metrics != nil {
 			cg.metrics.CoingeckoRequests.With(common.Labels{"endpoint": endpoint, "status": "throttle"}).Inc()
 		}
-		// Retry throttled requests indefinitely (no attempt cap) so historical rate downloads
-		// always finish eventually, even when a provider-wide 429 persists for many hours.
-		// Retry-After is honored when present; otherwise a flat ~1-minute backoff (plus jitter).
-		// The delay opens a throttle window shared by all requests; the next
-		// waitForRequestSlot waits it out, so no local sleep is needed here.
+
 		delay := throttleBackoffDelay(err)
 		cg.markThrottled(delay)
 		glog.Warningf("Coingecko makeReq %v throttled on attempt %d, retrying in %v: %v", url, attempt+1, delay, err)

--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -31,14 +31,14 @@ const (
 	coingeckoRangeBackfill            = "backfill"
 	// coingeckoTipWindowDays is the only gap still served from the rate-limited tip
 	// endpoint (the chain tip); anything larger is high-volume backfill routed to the CDN.
-	coingeckoTipWindowDays = 1
-	coingeckoBootstrapURL             = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
-	coingeckoProURL                   = "https://pro-api.coingecko.com/api/v3"
-	coingeckoFreeURL                  = "https://api.coingecko.com/api/v3"
-	coingeckoPlanFree                 = "free"
-	coingeckoPlanPro                  = "pro"
-	coingeckoAPIKeyEnv                = "COINGECKO_API_KEY"
-	coingeckoAPIKeyEnvSuffix          = "_" + coingeckoAPIKeyEnv
+	coingeckoTipWindowDays   = 1
+	coingeckoBootstrapURL    = "https://cdn.trezor.io/dynamic/coingecko/api/v3"
+	coingeckoProURL          = "https://pro-api.coingecko.com/api/v3"
+	coingeckoFreeURL         = "https://api.coingecko.com/api/v3"
+	coingeckoPlanFree        = "free"
+	coingeckoPlanPro         = "pro"
+	coingeckoAPIKeyEnv       = "COINGECKO_API_KEY"
+	coingeckoAPIKeyEnvSuffix = "_" + coingeckoAPIKeyEnv
 )
 
 // Phase labels for the fiat-rate fetch metrics (fiat_rates_fetched_units_total,
@@ -52,10 +52,10 @@ const (
 
 // Reason labels for fiat_rates_unable_total.
 const (
-	fiatUnableGapTooLarge  = "gap_too_large"  // series stale >= reconcile guard, probable bug
-	fiatUnableFetchFailed  = "fetch_failed"   // HTTP/parse error fetching the range
+	fiatUnableGapTooLarge  = "gap_too_large"   // series stale >= reconcile guard, probable bug
+	fiatUnableFetchFailed  = "fetch_failed"    // HTTP/parse error fetching the range
 	fiatUnableProviderBan  = "provider_banned" // Cloudflare 1015 IP ban
-	fiatUnableNoBaseTicker = "no_base_ticker" // token day without an existing base-currency ticker
+	fiatUnableNoBaseTicker = "no_base_ticker"  // token day without an existing base-currency ticker
 )
 
 // used when retry-after header is missing
@@ -1104,7 +1104,11 @@ func (cg *Coingecko) missingDayWindow(windowDays int) (missing map[uint]struct{}
 //
 // It is a no-op while bootstrap is still in progress (the bootstrap pass owns full-history
 // population) or when no CDN URL is configured.
-func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) (int, error) {
+//
+// stop is blockbook's chanOsSignal (closed on shutdown). It is polled between series fetches
+// so a SIGTERM mid-repair aborts promptly; any days fetched before the abort are persisted so
+// the next startup resumes from the remaining gap.
+func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int, stop <-chan os.Signal) (int, error) {
 	bootstrapInProgress, _, err := historicalBootstrapInProgress(cg.db)
 	if err != nil {
 		return 0, err
@@ -1150,6 +1154,12 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) (i
 	cdnURL := cg.sourceURLForRange(coingeckoRangeBackfill)
 	metaURL := cg.metadataURL()
 
+	// Shutdown may arrive during the cheap stage-1 scan; bail before any network call.
+	if stopRequested(stop) {
+		glog.Warning("FiatRates reconcile: shutdown signaled before backfill, skipping; gap will be reconciled on next startup")
+		return 0, nil
+	}
+
 	// enumerate the series to repair: base coin x each vsCurrency, plus each token
 	vs, err := cg.simpleSupportedVSCurrenciesAt(metaURL, priorityLow)
 	if err != nil {
@@ -1184,7 +1194,15 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) (i
 	tickersToUpdate := make(map[uint]*common.CurrencyRatesTicker)
 	filled, failed, repairedTokens := 0, 0, 0
 	var banErr error
-	for _, c := range targets {
+	aborted := false
+	for i, c := range targets {
+		// Abort promptly on shutdown; persist what we already fetched (below) so the next
+		// startup resumes from the remaining gap rather than refetching from scratch.
+		if stopRequested(stop) {
+			aborted = true
+			glog.Warningf("FiatRates reconcile: shutdown signaled, aborting after %d/%d series (%d point(s) fetched so far)", i, len(targets), filled)
+			break
+		}
 		mc, err := cg.coinMarketChartAt(cdnURL, c.coinId, c.vsCurrency, days, true, priorityLow)
 		if err != nil {
 			failed++
@@ -1216,9 +1234,28 @@ func (cg *Coingecko) ReconcileHistoricalRates(windowDays int, maxGapDays int) (i
 	if err := cg.storeTickers(tickersToUpdate); err != nil {
 		return filled, err
 	}
+	if aborted {
+		glog.Infof("FiatRates reconcile stage 2: aborted on shutdown, persisted %d point(s) (%d token series), %d fetch failures; remaining gap will be reconciled on next startup", filled, repairedTokens, failed)
+		return filled, nil
+	}
 	glog.Infof("FiatRates reconcile stage 2: filled %d point(s) across %d series (%d token series), %d fetch failures", filled, len(targets), repairedTokens, failed)
 	if banErr != nil {
 		return filled, banErr
 	}
 	return filled, nil
+}
+
+// stopRequested reports whether shutdown has been signaled on stop. blockbook closes
+// chanOsSignal on shutdown, so a receive returns immediately once closed; a nil channel
+// (e.g. in tests) is never stopped.
+func stopRequested(stop <-chan os.Signal) bool {
+	if stop == nil {
+		return false
+	}
+	select {
+	case <-stop:
+		return true
+	default:
+		return false
+	}
 }

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -237,18 +237,59 @@ func TestResolveHistoricalDays(t *testing.T) {
 		}
 	})
 
-	t.Run("recent ticker is tip query", func(t *testing.T) {
+	t.Run("one day gap is the tip", func(t *testing.T) {
 		cg := Coingecko{}
 		days, shouldRequest, rangeKind := cg.resolveHistoricalDays(&common.CurrencyRatesTicker{
-			Timestamp: time.Now().AddDate(0, 0, -5),
+			Timestamp: time.Now().AddDate(0, 0, -1),
 		}, false)
-		if !shouldRequest || days != "5" {
+		if !shouldRequest || days != "1" {
 			t.Fatalf("unexpected tip result: days=%q shouldRequest=%v", days, shouldRequest)
 		}
 		if rangeKind != coingeckoRangeTip {
 			t.Fatalf("unexpected range kind: got %q, want %q", rangeKind, coingeckoRangeTip)
 		}
 	})
+
+	t.Run("multi-day gap is backfill", func(t *testing.T) {
+		cg := Coingecko{}
+		days, shouldRequest, rangeKind := cg.resolveHistoricalDays(&common.CurrencyRatesTicker{
+			Timestamp: time.Now().AddDate(0, 0, -5),
+		}, false)
+		if !shouldRequest || days != "5" {
+			t.Fatalf("unexpected backfill result: days=%q shouldRequest=%v", days, shouldRequest)
+		}
+		if rangeKind != coingeckoRangeBackfill {
+			t.Fatalf("unexpected range kind: got %q, want %q", rangeKind, coingeckoRangeBackfill)
+		}
+	})
+}
+
+func TestSourceURLForRange(t *testing.T) {
+	cdn := "https://cdn.trezor.io/dynamic/coingecko/api/v3"
+	tip := "https://api.coingecko.com/api/v3"
+	withCDN := &Coingecko{tipURL: tip, bootstrapURL: cdn}
+	noCDN := &Coingecko{tipURL: tip}
+
+	tests := []struct {
+		name      string
+		cg        *Coingecko
+		rangeKind string
+		want      string
+	}{
+		{name: "tip stays on free tier", cg: withCDN, rangeKind: coingeckoRangeTip, want: tip},
+		{name: "backfill routes to CDN", cg: withCDN, rangeKind: coingeckoRangeBackfill, want: cdn},
+		{name: "capped routes to CDN", cg: withCDN, rangeKind: coingeckoRangeCapped, want: cdn},
+		{name: "historical routes to CDN", cg: withCDN, rangeKind: coingeckoRangeHistorical, want: cdn},
+		{name: "backfill falls back to tip without CDN", cg: noCDN, rangeKind: coingeckoRangeBackfill, want: tip},
+		{name: "tip without CDN stays on free tier", cg: noCDN, rangeKind: coingeckoRangeTip, want: tip},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cg.sourceURLForRange(tt.rangeKind); got != tt.want {
+				t.Fatalf("sourceURLForRange(%q) = %q, want %q", tt.rangeKind, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestUpdateHistoricalTickers_BootstrapStoresSuccessfulCurrenciesEvenWhenSomeFail(t *testing.T) {

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -357,6 +357,96 @@ func TestMakeReq_ThrottleRetriesEventuallySuccess(t *testing.T) {
 	}
 }
 
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"seconds", "5", 5 * time.Second},
+		{"trimmed seconds", "  10 ", 10 * time.Second},
+		{"zero", "0", 0},
+		{"negative", "-3", 0},
+		{"empty", "", 0},
+		{"garbage", "soon", 0},
+		{"http-date unsupported", "Wed, 10 Jun 2026 11:34:33 GMT", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRetryAfter(tt.value); got != tt.want {
+				t.Fatalf("parseRetryAfter(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryAfterFromError(t *testing.T) {
+	if got := retryAfterFromError(&coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 7 * time.Second}); got != 7*time.Second {
+		t.Fatalf("retryAfterFromError direct = %v, want 7s", got)
+	}
+	// errors.As must unwrap the throttle-exhausted wrapper to reach the underlying Retry-After.
+	wrapped := &coingeckoThrottleRetriesExhaustedError{cause: &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 7 * time.Second}, retries: 4}
+	if got := retryAfterFromError(wrapped); got != 7*time.Second {
+		t.Fatalf("retryAfterFromError wrapped = %v, want 7s", got)
+	}
+	if got := retryAfterFromError(errors.New("boom")); got != 0 {
+		t.Fatalf("retryAfterFromError non-http = %v, want 0", got)
+	}
+}
+
+func TestThrottleBackoffDelay(t *testing.T) {
+	originalBackoff := coingeckoThrottleRetryBackoff
+	coingeckoThrottleRetryBackoff = []time.Duration{10 * time.Second, 20 * time.Second}
+	defer func() { coingeckoThrottleRetryBackoff = originalBackoff }()
+
+	within := func(t *testing.T, got, base time.Duration) {
+		t.Helper()
+		upper := base + base/5 // base + up to ~20% jitter
+		if got < base || got > upper {
+			t.Fatalf("delay %v out of expected [%v, %v]", got, base, upper)
+		}
+	}
+
+	noRetryAfter := &coingeckoHTTPError{status: http.StatusTooManyRequests}
+	// Exponential base is used when there is no Retry-After hint.
+	within(t, throttleBackoffDelay(0, noRetryAfter), 10*time.Second)
+	within(t, throttleBackoffDelay(1, noRetryAfter), 20*time.Second)
+	// A Retry-After longer than the base raises the floor to Retry-After.
+	within(t, throttleBackoffDelay(0, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 30 * time.Second}), 30*time.Second)
+	// A Retry-After shorter than the base is ignored (base wins).
+	within(t, throttleBackoffDelay(1, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 5 * time.Second}), 20*time.Second)
+
+	// A zeroed backoff with no Retry-After stays instant (keeps the throttle tests fast).
+	coingeckoThrottleRetryBackoff = []time.Duration{0}
+	if got := throttleBackoffDelay(0, noRetryAfter); got != 0 {
+		t.Fatalf("zeroed backoff delay = %v, want 0", got)
+	}
+}
+
+func TestDoReq_ParsesRetryAfter(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header()["retry-after"] = []string{"5"}
+		http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+	}))
+	defer mockServer.Close()
+
+	req, err := http.NewRequest("GET", mockServer.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	_, err = doReq(req, mockServer.Client())
+	var httpErr *coingeckoHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected coingeckoHTTPError, got %v", err)
+	}
+	if httpErr.status != http.StatusTooManyRequests {
+		t.Fatalf("unexpected status: %d", httpErr.status)
+	}
+	if httpErr.retryAfter != 5*time.Second {
+		t.Fatalf("unexpected retryAfter: %v, want 5s", httpErr.retryAfter)
+	}
+}
+
 func TestIsCoingeckoThrottleError_StatusCode(t *testing.T) {
 	// A 429 must be detected even when the body has none of the legacy throttle keywords.
 	if !isCoingeckoThrottleError(&coingeckoHTTPError{status: http.StatusTooManyRequests, body: `{"msg":"slow down"}`}) {

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -434,10 +434,11 @@ func TestMakeReq_PacesRequests(t *testing.T) {
 	}
 }
 
-// In steady state (bootstrap complete) a throttled currency must not abort the whole pass:
-// the loop continues with the remaining currencies, and the throttle error is still returned so
-// the cycle retries the unfinished ones next run.
-func TestUpdateHistoricalTickers_ContinuesPastThrottleInSteadyState(t *testing.T) {
+// A throttle-retries-exhausted error reflects sustained, provider-wide 429s: makeReq already
+// waited out the full backoff ladder and the provider kept returning 429. So even in steady state
+// the pass stops early rather than repeating the ladder for every remaining currency. The throttle
+// error is still returned so the unfinished currencies are retried next run.
+func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionInSteadyState(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -509,17 +510,18 @@ func TestUpdateHistoricalTickers_ContinuesPastThrottleInSteadyState(t *testing.T
 	if got := int(usdRequests.Load()); got != wantUSDRequests {
 		t.Fatalf("unexpected usd request count: got %d, want %d", got, wantUSDRequests)
 	}
-	// eur must still be attempted after usd was throttled (continue, not break).
-	if got := int(eurRequests.Load()); got != 1 {
-		t.Fatalf("expected eur to be requested once after usd throttle, got %d", got)
+	// eur must NOT be attempted after usd exhausted its throttle retries (break, not continue):
+	// the 429 is provider-wide, so hammering eur would only repeat the full ladder for nothing.
+	if got := int(eurRequests.Load()); got != 0 {
+		t.Fatalf("expected eur not to be requested after usd throttle exhaustion, got %d", got)
 	}
-	// the eur ticker that succeeded must be persisted despite the usd throttle.
+	// eur is never fetched, so nothing for it is stored; the next cycle retries from usd.
 	eurTicker, err := d.FiatRatesFindLastTicker("eur", "")
 	if err != nil {
 		t.Fatalf("FiatRatesFindLastTicker eur failed: %v", err)
 	}
-	if eurTicker == nil {
-		t.Fatal("expected eur ticker to be stored after continuing past usd throttle")
+	if eurTicker != nil {
+		t.Fatal("expected no eur ticker to be stored after stopping on usd throttle")
 	}
 }
 
@@ -602,10 +604,11 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionDuringBootstrap(t *tes
 	}
 }
 
-// In steady state a throttled token must not abort the whole token pass: the loop continues with
-// the remaining tokens (each gets its own bounded retries) and the throttle error is still
-// returned so the unfinished tokens are retried next run.
-func TestUpdateHistoricalTokenTickers_ContinuesPastThrottleInSteadyState(t *testing.T) {
+// A throttle-retries-exhausted error reflects sustained, provider-wide 429s, so even in steady
+// state the token pass stops after the first exhausted token instead of repeating the ~10-minute
+// ladder for every remaining token (which would also hold updatingTokens and block later cycles).
+// The throttle error is still returned so the unfinished tokens are retried next run.
+func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustionInSteadyState(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -669,8 +672,9 @@ func TestUpdateHistoricalTokenTickers_ContinuesPastThrottleInSteadyState(t *test
 		t.Fatalf("expected throttle exhaustion error, got %v", err)
 	}
 
-	// Both tokens are throttled; continuing means each one is attempted with its own bounded retries.
-	wantRequests := 2 * (1 + len(coingeckoThrottleRetryBackoff))
+	// Only the first token (random map order, but both behave identically) is attempted; the pass
+	// breaks on its throttle exhaustion instead of repeating the ladder for the remaining token.
+	wantRequests := 1 + len(coingeckoThrottleRetryBackoff)
 	if got := int(marketChartRequests.Load()); got != wantRequests {
 		t.Fatalf("unexpected market_chart request count: got %d, want %d", got, wantRequests)
 	}

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -13,8 +13,32 @@ import (
 	"testing"
 	"time"
 
+	"github.com/linxGnu/grocksdb"
 	"github.com/trezor/blockbook/common"
+	"github.com/trezor/blockbook/db"
 )
+
+// midnightDaysAgo returns the UTC midnight (a whole-day bucket) n days before today.
+func midnightDaysAgo(n int) time.Time {
+	s := time.Now().UTC().Unix()
+	s -= s % secondsInDay
+	s -= int64(n) * secondsInDay
+	return time.Unix(s, 0).UTC()
+}
+
+// seedDailyTicker stores a single daily ticker directly into the DB for test setup.
+func seedDailyTicker(t *testing.T, d *db.RocksDB, ts time.Time, rates map[string]float32, tokenRates map[string]float32) {
+	t.Helper()
+	wb := grocksdb.NewWriteBatch()
+	defer wb.Destroy()
+	ticker := &common.CurrencyRatesTicker{Timestamp: ts, Rates: rates, TokenRates: tokenRates}
+	if err := d.FiatRatesStoreTicker(wb, ticker); err != nil {
+		t.Fatalf("FiatRatesStoreTicker failed: %v", err)
+	}
+	if err := d.WriteBatch(wb); err != nil {
+		t.Fatalf("WriteBatch failed: %v", err)
+	}
+}
 
 // roundTripFunc serves canned HTTP responses without binding a loopback port
 // (httptest needs a local listener, which some sandboxes disallow) and lets a
@@ -1280,5 +1304,140 @@ func TestGetHighGranularityTickers_NotEnoughPricePoints(t *testing.T) {
 	}
 	if tickers != nil {
 		t.Fatal("expected nil tickers")
+	}
+}
+
+// Reconciliation repairs an interior hole in daily history within the window, fetching from
+// the CDN, and must not overwrite a day whose rate is already present (fill-missing only).
+func TestReconcileHistoricalRates_RepairsInteriorHole(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+
+	d0, d1, d2 := midnightDaysAgo(0), midnightDaysAgo(1), midnightDaysAgo(2)
+	// d0 (sentinel 111) and d2 present for usd; d1 is an interior hole.
+	seedDailyTicker(t, d, d0, map[string]float32{"usd": 111}, nil)
+	seedDailyTicker(t, d, d2, map[string]float32{"usd": 333}, nil)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			_, _ = w.Write([]byte(`["usd"]`))
+		case "/coins/ethereum/market_chart":
+			if got := r.URL.Query().Get("days"); got != "365" {
+				http.Error(w, fmt.Sprintf("unexpected days %q", got), http.StatusBadRequest)
+				return
+			}
+			// d0 returns 999 to prove fill-missing does NOT overwrite the existing 111.
+			body := fmt.Sprintf(`{"prices":[[%d,333],[%d,222],[%d,999]]}`,
+				d2.Unix()*1000, d1.Unix()*1000, d0.Unix()*1000)
+			_, _ = w.Write([]byte(body))
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: mockServer.URL,
+		tipURL:       mockServer.URL,
+		httpClient:   mockServer.Client(),
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	if err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+
+	t1, err := d.FiatRatesGetTicker(&d1)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d1 failed: %v", err)
+	}
+	if t1 == nil || t1.Rates["usd"] != 222 {
+		t.Fatalf("interior hole not repaired: got %+v, want usd=222", t1)
+	}
+	t0, err := d.FiatRatesGetTicker(&d0)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d0 failed: %v", err)
+	}
+	if t0 == nil || t0.Rates["usd"] != 111 {
+		t.Fatalf("fill-missing overwrote existing rate: got %+v, want usd=111", t0)
+	}
+}
+
+// A series whose most recent ticker is older than the gap guard must be flagged and skipped,
+// not refetched.
+func TestReconcileHistoricalRates_GapTooLargeSkipsFetch(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// last usd ticker is 100 days old (>= 90-day guard)
+	seedDailyTicker(t, d, midnightDaysAgo(100), map[string]float32{"usd": 100}, nil)
+
+	var fetched int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			_, _ = w.Write([]byte(`["usd"]`))
+		case "/coins/ethereum/market_chart":
+			atomic.StoreInt32(&fetched, 1)
+			http.Error(w, "market_chart must not be called for a gap_too_large series", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: mockServer.URL,
+		tipURL:       mockServer.URL,
+		httpClient:   mockServer.Client(),
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	if err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+	if atomic.LoadInt32(&fetched) != 0 {
+		t.Fatal("expected no market_chart fetch for a gap_too_large series")
+	}
+}
+
+// Reconciliation is a no-op when no CDN URL is configured (must not hit any endpoint).
+func TestReconcileHistoricalRates_NoCDNIsNoOp(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+
+	called := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("no HTTP request expected without a CDN URL, got %s", r.URL)
+		return stubHTTPResponse(http.StatusNotFound, ""), nil
+	})
+	cg := &Coingecko{
+		coin:       "ethereum",
+		tipURL:     "http://coingecko.test",
+		httpClient: &http.Client{Transport: called},
+		db:         d,
+		plan:       coingeckoPlanFree,
+	}
+
+	if err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
 }

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -537,6 +537,71 @@ func TestMakeReq_PacesRequests(t *testing.T) {
 	}
 }
 
+// The bootstrap CDN has no CoinGecko rate limit, so requests to it must use the light
+// bootstrap spacing instead of the (potentially multi-second) plan pacing. Otherwise the
+// free-plan 6s spacing would stretch the initial bootstrap from minutes to hours.
+func TestMakeReq_BootstrapCDNBypassesPlanPacing(t *testing.T) {
+	var requests atomic.Int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		httpClient:               mockServer.Client(),
+		minHttpRequestInterval:   10 * time.Second, // plan pacing, must NOT apply to the CDN
+		bootstrapRequestInterval: 0,
+		bootstrapURL:             mockServer.URL,
+	}
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		if _, err := cg.makeReq(mockServer.URL+"/coins/list", "coins/list", coingeckoPlanFree, priorityLow); err != nil {
+			t.Fatalf("makeReq failed on call %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	// With plan pacing applied this would take >= 20s; the CDN path must be far faster.
+	if elapsed > time.Second {
+		t.Fatalf("bootstrap CDN requests were paced at the plan interval: 3 requests took %v", elapsed)
+	}
+	if got := int(requests.Load()); got != 3 {
+		t.Fatalf("unexpected number of requests: got %d, want %d", got, 3)
+	}
+}
+
+// A configured bootstrap URL must not relax pacing for the rate-limited CoinGecko API
+// hosts: only requests whose URL actually targets the CDN get the light spacing.
+func TestMakeReq_NonBootstrapURLStillPacedWhenBootstrapConfigured(t *testing.T) {
+	interval := 60 * time.Millisecond
+	var requests atomic.Int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		httpClient:               mockServer.Client(),
+		minHttpRequestInterval:   interval,
+		bootstrapRequestInterval: 0,
+		bootstrapURL:             "https://cdn.trezor.io/dynamic/coingecko/api/v3", // different host than mockServer
+	}
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
+			t.Fatalf("makeReq failed on call %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	if minElapsed := 2 * interval; elapsed < minElapsed {
+		t.Fatalf("expected pacing to take at least %v across 3 requests, took %v", minElapsed, elapsed)
+	}
+	if got := int(requests.Load()); got != 3 {
+		t.Fatalf("unexpected number of requests: got %d, want %d", got, 3)
+	}
+}
+
 func TestMarkThrottled_ExtendsNeverShortens(t *testing.T) {
 	cg := &Coingecko{}
 	cg.markThrottled(time.Minute)
@@ -564,7 +629,7 @@ func TestWaitForRequestSlot_HighPriorityWaitsOutWindowButIsNotParked(t *testing.
 	until := cg.throttledUntil
 	done := make(chan time.Time, 1)
 	go func() {
-		cg.waitForRequestSlot(priorityHigh)
+		cg.waitForRequestSlot(priorityHigh, cg.minHttpRequestInterval)
 		done <- time.Now()
 	}()
 	select {
@@ -588,7 +653,7 @@ func TestWaitForRequestSlot_LowPriorityParksUntilHighPriorityCompletes(t *testin
 	}
 	done := make(chan struct{})
 	go func() {
-		cg.waitForRequestSlot(priorityLow)
+		cg.waitForRequestSlot(priorityLow, cg.minHttpRequestInterval)
 		close(done)
 	}()
 	// while throttled with a high-priority request in flight, low priority must stay parked
@@ -615,7 +680,7 @@ func TestWaitForRequestSlot_RechecksWindowExtendedDuringSleep(t *testing.T) {
 	cg.markThrottled(200 * time.Millisecond)
 	done := make(chan time.Time, 1)
 	go func() {
-		cg.waitForRequestSlot(priorityHigh)
+		cg.waitForRequestSlot(priorityHigh, cg.minHttpRequestInterval)
 		done <- time.Now()
 	}()
 	// wait until the goroutine reserved its slot inside the first window

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -1614,3 +1614,139 @@ func TestReconcileHistoricalRates_BudgetExhaustedAbortsMidBackfill(t *testing.T)
 		t.Fatal("expected the backfill loop to attempt at least one market_chart fetch before the budget expired")
 	}
 }
+
+// A budget/shutdown abort during the token phase must NOT persist the base-only day records
+// already accumulated by the (finished) base phase. If it did, stage-1's whole-day key-only scan
+// would treat those days as "present" next startup and never reconcile their token rates again.
+// The aborted pass must discard everything so the gap is re-reconciled in full later. (The same
+// discard path covers a base-phase abort, which would persist partial base rates.)
+func TestReconcileHistoricalRates_TokenPhaseAbortDiscardsBaseOnly(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// present d2, d4, d5; d3 is the interior hole to repair.
+	d2, d3, d4, d5 := midnightDaysAgo(2), midnightDaysAgo(3), midnightDaysAgo(4), midnightDaysAgo(5)
+	seedDailyTicker(t, d, d2, map[string]float32{"usd": 222}, nil)
+	seedDailyTicker(t, d, d4, map[string]float32{"usd": 444}, nil)
+	seedDailyTicker(t, d, d5, map[string]float32{"usd": 555}, nil)
+
+	var baseFetched int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			_, _ = w.Write([]byte(`["usd"]`))
+		case "/coins/list":
+			_, _ = w.Write([]byte(`[{"id":"ethereum","symbol":"eth","name":"Ethereum","platforms":{}},{"id":"token-a","symbol":"ta","name":"Token A","platforms":{"ethereum":"0xabc"}}]`))
+		case "/coins/ethereum/market_chart":
+			// base phase succeeds, filling d3's base rate into the shared map
+			atomic.AddInt32(&baseFetched, 1)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"prices":[[%d,333]]}`, d3.Unix()*1000)))
+		case "/coins/token-a/market_chart":
+			// token phase blocks until the budget cancels the request -> abort mid-token-phase
+			<-r.Context().Done()
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		coin:               "ethereum",
+		platformIdentifier: "ethereum",
+		platformVsCurrency: "eth",
+		bootstrapURL:       mockServer.URL,
+		tipURL:             mockServer.URL,
+		httpClient:         mockServer.Client(),
+		db:                 d,
+		plan:               coingeckoPlanFree,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	filled, err := cg.ReconcileHistoricalRates(ctx, 365, 90)
+	if err != nil {
+		t.Fatalf("token-phase abort must not return an error, got: %v", err)
+	}
+	if filled != 0 {
+		t.Fatalf("aborted reconciliation must persist nothing, got filled=%d", filled)
+	}
+	if atomic.LoadInt32(&baseFetched) == 0 {
+		t.Fatal("expected the base phase to run (and fill d3) before the abort")
+	}
+	// Key assertion: the base-only d3 record must NOT have been persisted, so d3 stays a hole and
+	// is re-reconciled later instead of being silently frozen without its token rate.
+	t3, err := d.FiatRatesGetTicker(&d3)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d3 failed: %v", err)
+	}
+	if t3 != nil {
+		t.Fatalf("base-only day was persisted on abort (token rates would be lost forever): %+v", t3)
+	}
+	// present days must remain untouched
+	t2, err := d.FiatRatesGetTicker(&d2)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d2 failed: %v", err)
+	}
+	if t2 == nil || t2.Rates["usd"] != 222 {
+		t.Fatalf("present day was modified: got %+v, want usd=222", t2)
+	}
+}
+
+// A coin without tokens reconciles base rates only; a clean pass must still persist them
+// (base-only is "complete" when no tokens are configured -- the discard-on-abort guard must not
+// over-prune the normal completion path).
+func TestReconcileHistoricalRates_NoTokensPersistsBaseOnly(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// present d2, d4, d5; d3 is the interior hole to repair.
+	d2, d3, d4, d5 := midnightDaysAgo(2), midnightDaysAgo(3), midnightDaysAgo(4), midnightDaysAgo(5)
+	seedDailyTicker(t, d, d2, map[string]float32{"usd": 222}, nil)
+	seedDailyTicker(t, d, d4, map[string]float32{"usd": 444}, nil)
+	seedDailyTicker(t, d, d5, map[string]float32{"usd": 555}, nil)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			_, _ = w.Write([]byte(`["usd"]`))
+		case "/coins/ethereum/market_chart":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"prices":[[%d,333]]}`, d3.Unix()*1000)))
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: mockServer.URL,
+		tipURL:       mockServer.URL,
+		httpClient:   mockServer.Client(),
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	filled, err := cg.ReconcileHistoricalRates(context.Background(), 365, 90)
+	if err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+	if filled != 1 {
+		t.Fatalf("unexpected filled points: got %d, want 1", filled)
+	}
+	t3, err := d.FiatRatesGetTicker(&d3)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d3 failed: %v", err)
+	}
+	if t3 == nil || t3.Rates["usd"] != 333 {
+		t.Fatalf("interior hole base rate not repaired: got %+v, want usd=333", t3)
+	}
+}

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1355,7 +1356,7 @@ func TestReconcileHistoricalRates_RepairsInteriorHole(t *testing.T) {
 		plan:               coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1409,7 +1410,7 @@ func TestReconcileHistoricalRates_HealthyMakesNoRequests(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1445,7 +1446,7 @@ func TestReconcileHistoricalRates_YoungDBMakesNoRequests(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1482,7 +1483,7 @@ func TestReconcileHistoricalRates_GapTooLargeSkipsFetch(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1513,7 +1514,49 @@ func TestReconcileHistoricalRates_NoCDNIsNoOp(t *testing.T) {
 		plan:       coingeckoPlanFree,
 	}
 
-	if _, err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+	if _, err := cg.ReconcileHistoricalRates(365, 90, nil); err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+}
+
+// A shutdown signaled before backfill aborts the pass without issuing any request, even
+// when there is a genuine (sub-guard) gap to repair.
+func TestReconcileHistoricalRates_ShutdownAbortsBeforeFetch(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// a real interior hole at d3 (present d1,d2,d4,d5) -> work to do, but well under the guard
+	seedDailyTicker(t, d, midnightDaysAgo(5), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(4), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(2), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(1), map[string]float32{"usd": 100}, nil)
+
+	called := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("shutdown before backfill must not issue requests, got %s", r.URL)
+		return stubHTTPResponse(http.StatusNotFound, ""), nil
+	})
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: "https://cdn.trezor.io/dynamic/coingecko/api/v3",
+		tipURL:       "http://coingecko.test",
+		httpClient:   &http.Client{Transport: called},
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	// a closed channel reads as immediately signaled, simulating an in-flight shutdown
+	stop := make(chan os.Signal)
+	close(stop)
+
+	filled, err := cg.ReconcileHistoricalRates(365, 90, stop)
+	if err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+	if filled != 0 {
+		t.Fatalf("aborted reconciliation should fill nothing, got %d", filled)
 	}
 }

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -5,6 +5,7 @@ package fiat
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +15,23 @@ import (
 
 	"github.com/trezor/blockbook/common"
 )
+
+// roundTripFunc serves canned HTTP responses without binding a loopback port
+// (httptest needs a local listener, which some sandboxes disallow) and lets a
+// test assert the exact number of attempts deterministically.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func stubHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+const cloudflareBanBody = "<!DOCTYPE html><html><body>The owner of this website has banned you temporarily. error code: 1015</body></html>"
 
 func testCoinGeckoScopedAPIKeyEnvName(prefix string) string {
 	return strings.ToUpper(strings.TrimSpace(prefix)) + coingeckoAPIKeyEnvSuffix
@@ -298,6 +316,71 @@ func TestUpdateHistoricalTickers_BootstrapStoresSuccessfulCurrenciesEvenWhenSome
 	}
 }
 
+func TestUpdateHistoricalTickers_CloudflareBanStopsPassAndStoresPartial(t *testing.T) {
+	config := common.Config{
+		CoinName: "fakecoin",
+	}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{
+		BitcoinParser: bitcoinTestnetParser(),
+	}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	// steady state (bootstrap already complete) so the pass targets the tip URL
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+
+	// usd succeeds, eur returns a Cloudflare 1015 ban (served as a 403 HTML page)
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			return stubHTTPResponse(http.StatusOK, `["usd","eur"]`), nil
+		case "/coins/ethereum/market_chart":
+			switch r.URL.Query().Get("vs_currency") {
+			case "usd":
+				return stubHTTPResponse(http.StatusOK, `{"prices":[[1654732800000,1234.5]]}`), nil
+			case "eur":
+				return stubHTTPResponse(http.StatusForbidden, cloudflareBanBody), nil
+			}
+			return stubHTTPResponse(http.StatusBadRequest, "unexpected vs_currency"), nil
+		}
+		return stubHTTPResponse(http.StatusNotFound, "unexpected path "+r.URL.Path), nil
+	})
+
+	cg := &Coingecko{
+		coin:       "ethereum",
+		tipURL:     "http://coingecko.test",
+		httpClient: &http.Client{Transport: transport},
+		db:         d,
+		plan:       coingeckoPlanFree,
+	}
+
+	err := cg.UpdateHistoricalTickers()
+	if err == nil {
+		t.Fatal("expected UpdateHistoricalTickers to return the Cloudflare ban error")
+	}
+	if !isCoingeckoCloudflareBanError(err) {
+		t.Fatalf("expected a Cloudflare ban error, got %v", err)
+	}
+
+	// currencies processed before the ban must be persisted (partial progress)
+	usdTicker, err := d.FiatRatesFindLastTicker("usd", "")
+	if err != nil {
+		t.Fatalf("FiatRatesFindLastTicker usd failed: %v", err)
+	}
+	if usdTicker == nil {
+		t.Fatal("expected usd ticker to be stored before the ban")
+	}
+	// the banned currency (and anything after it) must be absent; resumed next cycle
+	eurTicker, err := d.FiatRatesFindLastTicker("eur", "")
+	if err != nil {
+		t.Fatalf("FiatRatesFindLastTicker eur failed: %v", err)
+	}
+	if eurTicker != nil {
+		t.Fatalf("expected eur ticker to be missing after the ban, got %+v", eurTicker)
+	}
+}
+
 func TestMakeReq_ThrottleRetriesWithoutCap(t *testing.T) {
 	originalBackoff := coingeckoThrottleBackoff
 	coingeckoThrottleBackoff = 0
@@ -362,6 +445,68 @@ func TestMakeReq_ThrottleRetriesEventuallySuccess(t *testing.T) {
 	}
 	if got := int(requests.Load()); got != 3 {
 		t.Fatalf("unexpected number of requests: got %d, want %d", got, 3)
+	}
+}
+
+func TestIsCoingeckoCloudflareBanError(t *testing.T) {
+	bans := []error{
+		errors.New("error code: 1015"),
+		errors.New("Error Code: 1015"), // case-insensitive
+		&coingeckoHTTPError{status: http.StatusForbidden, body: cloudflareBanBody},
+		&coingeckoHTTPError{status: http.StatusTooManyRequests, body: "error code: 1015"},
+		fmt.Errorf("wrapped: %w", &coingeckoHTTPError{status: http.StatusForbidden, body: cloudflareBanBody}),
+	}
+	for _, err := range bans {
+		if !isCoingeckoCloudflareBanError(err) {
+			t.Fatalf("expected Cloudflare ban detection for %v", err)
+		}
+	}
+
+	notBans := []error{
+		nil,
+		errors.New("exceeded the rate limit"), // application-level 429, must stay retryable
+		&coingeckoHTTPError{status: http.StatusTooManyRequests, body: `{"msg":"slow down"}`},
+		errors.New("could not find coin with the given id"),
+	}
+	for _, err := range notBans {
+		if isCoingeckoCloudflareBanError(err) {
+			t.Fatalf("did not expect Cloudflare ban detection for %v", err)
+		}
+	}
+}
+
+func TestMakeReq_CloudflareBanFastFails(t *testing.T) {
+	// A genuine 1015 ban must fast-fail immediately (no retry), unlike a plain 429.
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
+	defer func() { coingeckoThrottleBackoff = originalBackoff }()
+
+	var requests atomic.Int32
+	cg := &Coingecko{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(cloudflareBanBody)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+
+	resp, err := cg.makeReq("http://coingecko.invalid/coins/x/market_chart", "market_chart", coingeckoPlanFree, priorityLow)
+	if err == nil {
+		t.Fatal("expected makeReq to fast-fail on a Cloudflare 1015 ban, got nil error")
+	}
+	if !isCoingeckoCloudflareBanError(err) {
+		t.Fatalf("expected a Cloudflare ban error, got %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on ban, got %q", string(resp))
+	}
+	if got := int(requests.Load()); got != 1 {
+		t.Fatalf("expected exactly 1 request (no retry on a ban), got %d", got)
 	}
 }
 

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -1307,8 +1307,8 @@ func TestGetHighGranularityTickers_NotEnoughPricePoints(t *testing.T) {
 	}
 }
 
-// Reconciliation repairs an interior hole in daily history within the window, fetching from
-// the CDN, and must not overwrite a day whose rate is already present (fill-missing only).
+// Reconciliation fills an interior missing day (no record at all) for both the base coin and
+// a token, fetching from the CDN, and must touch only the missing day (existing days intact).
 func TestReconcileHistoricalRates_RepairsInteriorHole(t *testing.T) {
 	config := common.Config{CoinName: "fakecoin"}
 	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
@@ -1318,23 +1318,25 @@ func TestReconcileHistoricalRates_RepairsInteriorHole(t *testing.T) {
 		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
 	}
 
-	d0, d1, d2 := midnightDaysAgo(0), midnightDaysAgo(1), midnightDaysAgo(2)
-	// d0 (sentinel 111) and d2 present for usd; d1 is an interior hole.
-	seedDailyTicker(t, d, d0, map[string]float32{"usd": 111}, nil)
-	seedDailyTicker(t, d, d2, map[string]float32{"usd": 333}, nil)
+	// present: d2, d4, d5 (all older than the tip); d3 is an interior hole (no record).
+	d2, d3, d4, d5 := midnightDaysAgo(2), midnightDaysAgo(3), midnightDaysAgo(4), midnightDaysAgo(5)
+	seedDailyTicker(t, d, d2, map[string]float32{"usd": 222}, nil)
+	seedDailyTicker(t, d, d4, map[string]float32{"usd": 444}, nil)
+	seedDailyTicker(t, d, d5, map[string]float32{"usd": 555}, nil)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/simple/supported_vs_currencies":
 			_, _ = w.Write([]byte(`["usd"]`))
+		case "/coins/list":
+			_, _ = w.Write([]byte(`[{"id":"ethereum","symbol":"eth","name":"Ethereum","platforms":{}},{"id":"token-a","symbol":"ta","name":"Token A","platforms":{"ethereum":"0xabc"}}]`))
 		case "/coins/ethereum/market_chart":
-			if got := r.URL.Query().Get("days"); got != "365" {
-				http.Error(w, fmt.Sprintf("unexpected days %q", got), http.StatusBadRequest)
-				return
-			}
-			// d0 returns 999 to prove fill-missing does NOT overwrite the existing 111.
-			body := fmt.Sprintf(`{"prices":[[%d,333],[%d,222],[%d,999]]}`,
-				d2.Unix()*1000, d1.Unix()*1000, d0.Unix()*1000)
+			// d2 returns 999 to prove the present day is not touched (only d3 is wanted).
+			body := fmt.Sprintf(`{"prices":[[%d,999],[%d,333],[%d,888]]}`,
+				d2.Unix()*1000, d3.Unix()*1000, d4.Unix()*1000)
+			_, _ = w.Write([]byte(body))
+		case "/coins/token-a/market_chart":
+			body := fmt.Sprintf(`{"prices":[[%d,0.5]]}`, d3.Unix()*1000)
 			_, _ = w.Write([]byte(body))
 		default:
 			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
@@ -1343,36 +1345,118 @@ func TestReconcileHistoricalRates_RepairsInteriorHole(t *testing.T) {
 	defer mockServer.Close()
 
 	cg := &Coingecko{
+		coin:               "ethereum",
+		platformIdentifier: "ethereum",
+		platformVsCurrency: "eth",
+		bootstrapURL:       mockServer.URL,
+		tipURL:             mockServer.URL,
+		httpClient:         mockServer.Client(),
+		db:                 d,
+		plan:               coingeckoPlanFree,
+	}
+
+	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	if err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+	if filled != 2 { // usd + token on d3
+		t.Fatalf("unexpected filled points: got %d, want 2", filled)
+	}
+
+	t3, err := d.FiatRatesGetTicker(&d3)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d3 failed: %v", err)
+	}
+	if t3 == nil || t3.Rates["usd"] != 333 {
+		t.Fatalf("interior hole base rate not repaired: got %+v, want usd=333", t3)
+	}
+	if t3.TokenRates["0xabc"] != 0.5 {
+		t.Fatalf("interior hole token rate not repaired: got %+v, want 0xabc=0.5", t3.TokenRates)
+	}
+	t2, err := d.FiatRatesGetTicker(&d2)
+	if err != nil {
+		t.Fatalf("FiatRatesGetTicker d2 failed: %v", err)
+	}
+	if t2 == nil || t2.Rates["usd"] != 222 {
+		t.Fatalf("present day was modified: got %+v, want usd=222", t2)
+	}
+}
+
+// A healthy DB (no missing days in the window) must make no network requests at all.
+func TestReconcileHistoricalRates_HealthyMakesNoRequests(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// continuous coverage from d5 to d2 (the last reconcilable day) -> no gaps
+	for _, n := range []int{2, 3, 4, 5} {
+		seedDailyTicker(t, d, midnightDaysAgo(n), map[string]float32{"usd": 100}, nil)
+	}
+
+	called := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("healthy DB must not issue requests, got %s", r.URL)
+		return stubHTTPResponse(http.StatusNotFound, ""), nil
+	})
+	cg := &Coingecko{
 		coin:         "ethereum",
-		bootstrapURL: mockServer.URL,
-		tipURL:       mockServer.URL,
-		httpClient:   mockServer.Client(),
+		bootstrapURL: "https://cdn.trezor.io/dynamic/coingecko/api/v3",
+		tipURL:       "http://coingecko.test",
+		httpClient:   &http.Client{Transport: called},
 		db:           d,
 		plan:         coingeckoPlanFree,
 	}
 
-	if err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
-
-	t1, err := d.FiatRatesGetTicker(&d1)
-	if err != nil {
-		t.Fatalf("FiatRatesGetTicker d1 failed: %v", err)
-	}
-	if t1 == nil || t1.Rates["usd"] != 222 {
-		t.Fatalf("interior hole not repaired: got %+v, want usd=222", t1)
-	}
-	t0, err := d.FiatRatesGetTicker(&d0)
-	if err != nil {
-		t.Fatalf("FiatRatesGetTicker d0 failed: %v", err)
-	}
-	if t0 == nil || t0.Rates["usd"] != 111 {
-		t.Fatalf("fill-missing overwrote existing rate: got %+v, want usd=111", t0)
+	if filled != 0 {
+		t.Fatalf("healthy DB should fill nothing, got %d", filled)
 	}
 }
 
-// A series whose most recent ticker is older than the gap guard must be flagged and skipped,
-// not refetched.
+// A young DB whose only records are in the tip zone (today/yesterday) is not a gap and must
+// not be flagged or fetched.
+func TestReconcileHistoricalRates_YoungDBMakesNoRequests(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// only tip-zone records exist (today, yesterday) -> nothing older to reconcile
+	seedDailyTicker(t, d, midnightDaysAgo(0), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(1), map[string]float32{"usd": 100}, nil)
+
+	called := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("young DB must not issue requests, got %s", r.URL)
+		return stubHTTPResponse(http.StatusNotFound, ""), nil
+	})
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: "https://cdn.trezor.io/dynamic/coingecko/api/v3",
+		tipURL:       "http://coingecko.test",
+		httpClient:   &http.Client{Transport: called},
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	if err != nil {
+		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
+	}
+	if filled != 0 {
+		t.Fatalf("young DB should fill nothing, got %d", filled)
+	}
+}
+
+// When the number of missing days reaches the guard it is flagged as gap_too_large and
+// nothing is fetched (not even the series enumeration), avoiding a backfill storm on a
+// probably-broken DB.
 func TestReconcileHistoricalRates_GapTooLargeSkipsFetch(t *testing.T) {
 	config := common.Config{CoinName: "fakecoin"}
 	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
@@ -1381,37 +1465,29 @@ func TestReconcileHistoricalRates_GapTooLargeSkipsFetch(t *testing.T) {
 	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
 		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
 	}
-	// last usd ticker is 100 days old (>= 90-day guard)
-	seedDailyTicker(t, d, midnightDaysAgo(100), map[string]float32{"usd": 100}, nil)
+	// only two records far apart -> ~197 missing days between them, well over the 90 guard
+	seedDailyTicker(t, d, midnightDaysAgo(2), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(200), map[string]float32{"usd": 100}, nil)
 
-	var fetched int32
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/simple/supported_vs_currencies":
-			_, _ = w.Write([]byte(`["usd"]`))
-		case "/coins/ethereum/market_chart":
-			atomic.StoreInt32(&fetched, 1)
-			http.Error(w, "market_chart must not be called for a gap_too_large series", http.StatusInternalServerError)
-		default:
-			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
-		}
-	}))
-	defer mockServer.Close()
-
+	called := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("gap_too_large must not issue requests, got %s", r.URL)
+		return stubHTTPResponse(http.StatusNotFound, ""), nil
+	})
 	cg := &Coingecko{
 		coin:         "ethereum",
-		bootstrapURL: mockServer.URL,
-		tipURL:       mockServer.URL,
-		httpClient:   mockServer.Client(),
+		bootstrapURL: "https://cdn.trezor.io/dynamic/coingecko/api/v3",
+		tipURL:       "http://coingecko.test",
+		httpClient:   &http.Client{Transport: called},
 		db:           d,
 		plan:         coingeckoPlanFree,
 	}
 
-	if err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+	filled, err := cg.ReconcileHistoricalRates(365, 90)
+	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
-	if atomic.LoadInt32(&fetched) != 0 {
-		t.Fatal("expected no market_chart fetch for a gap_too_large series")
+	if filled != 0 {
+		t.Fatalf("gap_too_large should fill nothing, got %d", filled)
 	}
 }
 
@@ -1437,7 +1513,7 @@ func TestReconcileHistoricalRates_NoCDNIsNoOp(t *testing.T) {
 		plan:       coingeckoPlanFree,
 	}
 
-	if err := cg.ReconcileHistoricalRates(365, 90); err != nil {
+	if _, err := cg.ReconcileHistoricalRates(365, 90); err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
 }

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -392,8 +392,8 @@ func TestRetryAfterFromError(t *testing.T) {
 	if got := retryAfterFromError(&coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 7 * time.Second}); got != 7*time.Second {
 		t.Fatalf("retryAfterFromError direct = %v, want 7s", got)
 	}
-	// errors.As must unwrap the throttle-exhausted wrapper to reach the underlying Retry-After.
-	wrapped := &coingeckoThrottleRetriesExhaustedError{cause: &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 7 * time.Second}, retries: 4}
+	// errors.As must unwrap wrapped errors to reach the underlying Retry-After.
+	wrapped := fmt.Errorf("wrapped: %w", &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 7 * time.Second})
 	if got := retryAfterFromError(wrapped); got != 7*time.Second {
 		t.Fatalf("retryAfterFromError wrapped = %v, want 7s", got)
 	}
@@ -778,15 +778,6 @@ func TestUpdateHistoricalTickers_RetriesThrottleUntilSuccess(t *testing.T) {
 	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
 		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
 	}
-	originalVsCurrencies := vsCurrencies
-	originalPlatformIds := platformIds
-	originalPlatformIdsToTokens := platformIdsToTokens
-	defer func() {
-		vsCurrencies = originalVsCurrencies
-		platformIds = originalPlatformIds
-		platformIdsToTokens = originalPlatformIdsToTokens
-	}()
-
 	originalBackoff := coingeckoThrottleBackoff
 	coingeckoThrottleBackoff = 0
 	defer func() {
@@ -869,15 +860,6 @@ func TestUpdateHistoricalTickers_RetriesThrottleUntilSuccessDuringBootstrap(t *t
 	if err := d.FiatRatesSetHistoricalBootstrapComplete(false); err != nil {
 		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
 	}
-	originalVsCurrencies := vsCurrencies
-	originalPlatformIds := platformIds
-	originalPlatformIdsToTokens := platformIdsToTokens
-	defer func() {
-		vsCurrencies = originalVsCurrencies
-		platformIds = originalPlatformIds
-		platformIdsToTokens = originalPlatformIdsToTokens
-	}()
-
 	originalBackoff := coingeckoThrottleBackoff
 	coingeckoThrottleBackoff = 0
 	defer func() {
@@ -960,15 +942,6 @@ func TestUpdateHistoricalTokenTickers_RetriesThrottleUntilSuccess(t *testing.T) 
 	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
 		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
 	}
-	originalVsCurrencies := vsCurrencies
-	originalPlatformIds := platformIds
-	originalPlatformIdsToTokens := platformIdsToTokens
-	defer func() {
-		vsCurrencies = originalVsCurrencies
-		platformIds = originalPlatformIds
-		platformIdsToTokens = originalPlatformIdsToTokens
-	}()
-
 	originalBackoff := coingeckoThrottleBackoff
 	coingeckoThrottleBackoff = 0
 	defer func() {

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -301,7 +301,7 @@ func TestSourceURLForRange(t *testing.T) {
 		rangeKind string
 		want      string
 	}{
-		{name: "tip stays on free tier", cg: withCDN, rangeKind: coingeckoRangeTip, want: tip},
+		{name: "tip routes to CDN when configured", cg: withCDN, rangeKind: coingeckoRangeTip, want: cdn},
 		{name: "backfill routes to CDN", cg: withCDN, rangeKind: coingeckoRangeBackfill, want: cdn},
 		{name: "capped routes to CDN", cg: withCDN, rangeKind: coingeckoRangeCapped, want: cdn},
 		{name: "historical routes to CDN", cg: withCDN, rangeKind: coingeckoRangeHistorical, want: cdn},

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -408,13 +408,13 @@ func TestThrottleBackoffDelay(t *testing.T) {
 	}
 
 	noRetryAfter := &coingeckoHTTPError{status: http.StatusTooManyRequests}
-	// Exponential base is used when there is no Retry-After hint.
+	// The exponential base for the attempt is used only when there is no Retry-After hint.
 	within(t, throttleBackoffDelay(0, noRetryAfter), 10*time.Second)
 	within(t, throttleBackoffDelay(1, noRetryAfter), 20*time.Second)
-	// A Retry-After longer than the base raises the floor to Retry-After.
+	// A Retry-After hint takes priority over the ladder, whether it is longer than the base...
 	within(t, throttleBackoffDelay(0, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 30 * time.Second}), 30*time.Second)
-	// A Retry-After shorter than the base is ignored (base wins).
-	within(t, throttleBackoffDelay(1, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 5 * time.Second}), 20*time.Second)
+	// ...or shorter than the base for this attempt.
+	within(t, throttleBackoffDelay(1, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 5 * time.Second}), 5*time.Second)
 
 	// A zeroed backoff with no Retry-After stays instant (keeps the throttle tests fast).
 	coingeckoThrottleRetryBackoff = []time.Duration{0}

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -106,17 +106,17 @@ func TestValidateCoinGeckoAPIKeyEnv(t *testing.T) {
 func TestCanUseBootstrapMax(t *testing.T) {
 	tests := []struct {
 		name        string
-		cg          Coingecko
+		cg          *Coingecko
 		expectAllow bool
 	}{
 		{
 			name:        "bootstrap url allows max",
-			cg:          Coingecko{bootstrapURL: "https://cdn.trezor.io/dynamic/coingecko/api/v3"},
+			cg:          &Coingecko{bootstrapURL: "https://cdn.trezor.io/dynamic/coingecko/api/v3"},
 			expectAllow: true,
 		},
 		{
 			name:        "missing bootstrap url does not allow max",
-			cg:          Coingecko{},
+			cg:          &Coingecko{},
 			expectAllow: false,
 		},
 	}
@@ -357,7 +357,87 @@ func TestMakeReq_ThrottleRetriesEventuallySuccess(t *testing.T) {
 	}
 }
 
-func TestUpdateHistoricalTickers_StopsOnThrottleExhaustion(t *testing.T) {
+func TestIsCoingeckoThrottleError_StatusCode(t *testing.T) {
+	// A 429 must be detected even when the body has none of the legacy throttle keywords.
+	if !isCoingeckoThrottleError(&coingeckoHTTPError{status: http.StatusTooManyRequests, body: `{"msg":"slow down"}`}) {
+		t.Fatal("expected 429 to be detected as throttle")
+	}
+	if isCoingeckoThrottleError(&coingeckoHTTPError{status: http.StatusInternalServerError, body: "boom"}) {
+		t.Fatal("did not expect 500 to be detected as throttle")
+	}
+	// Legacy keyless-endpoint signal still matches via body text.
+	if !isCoingeckoThrottleError(errors.New("error code: 1015")) {
+		t.Fatal("expected Cloudflare 1015 to be detected as throttle")
+	}
+	if isCoingeckoThrottleError(nil) {
+		t.Fatal("nil error must not be a throttle error")
+	}
+}
+
+func TestMakeReq_Detects429ByStatus(t *testing.T) {
+	originalBackoff := coingeckoThrottleRetryBackoff
+	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	defer func() {
+		coingeckoThrottleRetryBackoff = originalBackoff
+	}()
+
+	var requests atomic.Int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 429 with a body that contains none of the legacy keywords; detection must rely on status.
+		if requests.Add(1) <= 2 {
+			http.Error(w, `{"error":"please slow down"}`, http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{httpClient: mockServer.Client()}
+	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree)
+	if err != nil {
+		t.Fatalf("makeReq unexpectedly failed: %v", err)
+	}
+	if string(resp) != `{"ok":true}` {
+		t.Fatalf("unexpected response body: %s", string(resp))
+	}
+	if got := int(requests.Load()); got != 3 {
+		t.Fatalf("unexpected number of requests: got %d, want %d", got, 3)
+	}
+}
+
+func TestMakeReq_PacesRequests(t *testing.T) {
+	interval := 60 * time.Millisecond
+	var requests atomic.Int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		httpClient:             mockServer.Client(),
+		minHttpRequestInterval: interval,
+	}
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree); err != nil {
+			t.Fatalf("makeReq failed on call %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	// 3 requests => 2 enforced gaps of at least `interval` each.
+	if minElapsed := 2 * interval; elapsed < minElapsed {
+		t.Fatalf("expected pacing to take at least %v across 3 requests, took %v", minElapsed, elapsed)
+	}
+	if got := int(requests.Load()); got != 3 {
+		t.Fatalf("unexpected number of requests: got %d, want %d", got, 3)
+	}
+}
+
+// In steady state (bootstrap complete) a throttled currency must not abort the whole pass:
+// the loop continues with the remaining currencies, and the throttle error is still returned so
+// the cycle retries the unfinished ones next run.
+func TestUpdateHistoricalTickers_ContinuesPastThrottleInSteadyState(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -429,12 +509,103 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustion(t *testing.T) {
 	if got := int(usdRequests.Load()); got != wantUSDRequests {
 		t.Fatalf("unexpected usd request count: got %d, want %d", got, wantUSDRequests)
 	}
-	if got := int(eurRequests.Load()); got != 0 {
-		t.Fatalf("expected eur request count 0 after throttle exhaustion, got %d", got)
+	// eur must still be attempted after usd was throttled (continue, not break).
+	if got := int(eurRequests.Load()); got != 1 {
+		t.Fatalf("expected eur to be requested once after usd throttle, got %d", got)
+	}
+	// the eur ticker that succeeded must be persisted despite the usd throttle.
+	eurTicker, err := d.FiatRatesFindLastTicker("eur", "")
+	if err != nil {
+		t.Fatalf("FiatRatesFindLastTicker eur failed: %v", err)
+	}
+	if eurTicker == nil {
+		t.Fatal("expected eur ticker to be stored after continuing past usd throttle")
 	}
 }
 
-func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustion(t *testing.T) {
+// During bootstrap the pass is strict: a throttled currency stops the pass early (break) so the
+// failed attempt is counted and bootstrap retries terminate.
+func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionDuringBootstrap(t *testing.T) {
+	config := common.Config{
+		CoinName: "fakecoin",
+	}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{
+		BitcoinParser: bitcoinTestnetParser(),
+	}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(false); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	originalVsCurrencies := vsCurrencies
+	originalPlatformIds := platformIds
+	originalPlatformIdsToTokens := platformIdsToTokens
+	defer func() {
+		vsCurrencies = originalVsCurrencies
+		platformIds = originalPlatformIds
+		platformIdsToTokens = originalPlatformIdsToTokens
+	}()
+
+	originalBackoff := coingeckoThrottleRetryBackoff
+	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	defer func() {
+		coingeckoThrottleRetryBackoff = originalBackoff
+	}()
+
+	var usdRequests atomic.Int32
+	var eurRequests atomic.Int32
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			_, _ = w.Write([]byte(`["usd","eur"]`))
+		case "/coins/ethereum/market_chart":
+			switch r.URL.Query().Get("vs_currency") {
+			case "usd":
+				usdRequests.Add(1)
+				http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+			case "eur":
+				eurRequests.Add(1)
+				_, _ = w.Write([]byte(`{"prices":[[1654732800000,1234.5]]}`))
+			default:
+				http.Error(w, "unexpected vs_currency", http.StatusBadRequest)
+			}
+		default:
+			http.Error(w, fmt.Sprintf("unexpected path %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: mockServer.URL,
+		tipURL:       mockServer.URL,
+		httpClient:   mockServer.Client(),
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	err := cg.UpdateHistoricalTickers()
+	if err == nil {
+		t.Fatal("expected throttle exhaustion error")
+	}
+	if !isCoingeckoThrottleRetriesExhaustedError(err) {
+		t.Fatalf("expected throttle exhaustion error, got %v", err)
+	}
+
+	wantUSDRequests := 1 + len(coingeckoThrottleRetryBackoff)
+	if got := int(usdRequests.Load()); got != wantUSDRequests {
+		t.Fatalf("unexpected usd request count: got %d, want %d", got, wantUSDRequests)
+	}
+	if got := int(eurRequests.Load()); got != 0 {
+		t.Fatalf("expected eur request count 0 after bootstrap throttle exhaustion (break), got %d", got)
+	}
+}
+
+// In steady state a throttled token must not abort the whole token pass: the loop continues with
+// the remaining tokens (each gets its own bounded retries) and the throttle error is still
+// returned so the unfinished tokens are retried next run.
+func TestUpdateHistoricalTokenTickers_ContinuesPastThrottleInSteadyState(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -498,7 +669,8 @@ func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustion(t *testing.T) {
 		t.Fatalf("expected throttle exhaustion error, got %v", err)
 	}
 
-	wantRequests := 1 + len(coingeckoThrottleRetryBackoff)
+	// Both tokens are throttled; continuing means each one is attempted with its own bounded retries.
+	wantRequests := 2 * (1 + len(coingeckoThrottleRetryBackoff))
 	if got := int(marketChartRequests.Load()); got != wantRequests {
 		t.Fatalf("unexpected market_chart request count: got %d, want %d", got, wantRequests)
 	}

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -298,38 +298,46 @@ func TestUpdateHistoricalTickers_BootstrapStoresSuccessfulCurrenciesEvenWhenSome
 	}
 }
 
-func TestMakeReq_ThrottleRetriesExhausted(t *testing.T) {
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+func TestMakeReq_ThrottleRetriesWithoutCap(t *testing.T) {
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
 	defer func() {
-		coingeckoThrottleRetryBackoff = originalBackoff
+		coingeckoThrottleBackoff = originalBackoff
 	}()
 
+	// 429 more times than the old retry cap (4) to prove makeReq keeps retrying past it instead
+	// of giving up, then succeeds once the provider stops throttling.
+	throttleHits := 9
 	var requests atomic.Int32
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests.Add(1)
-		http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+		if int(requests.Add(1)) <= throttleHits {
+			http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer mockServer.Close()
 
 	cg := &Coingecko{
 		httpClient: mockServer.Client(),
 	}
-	_, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree)
-	if err == nil {
-		t.Fatal("expected makeReq to fail after retries are exhausted")
+	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
+	if err != nil {
+		t.Fatalf("makeReq unexpectedly failed: %v", err)
 	}
-	wantRequests := 1 + len(coingeckoThrottleRetryBackoff)
-	if got := int(requests.Load()); got != wantRequests {
-		t.Fatalf("unexpected number of requests: got %d, want %d", got, wantRequests)
+	if string(resp) != `{"ok":true}` {
+		t.Fatalf("unexpected response body: %s", string(resp))
+	}
+	if got, want := int(requests.Load()), throttleHits+1; got != want {
+		t.Fatalf("unexpected number of requests: got %d, want %d", got, want)
 	}
 }
 
 func TestMakeReq_ThrottleRetriesEventuallySuccess(t *testing.T) {
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
 	defer func() {
-		coingeckoThrottleRetryBackoff = originalBackoff
+		coingeckoThrottleBackoff = originalBackoff
 	}()
 
 	var requests atomic.Int32
@@ -345,7 +353,7 @@ func TestMakeReq_ThrottleRetriesEventuallySuccess(t *testing.T) {
 	cg := &Coingecko{
 		httpClient: mockServer.Client(),
 	}
-	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree)
+	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
 	if err != nil {
 		t.Fatalf("makeReq unexpectedly failed: %v", err)
 	}
@@ -395,9 +403,9 @@ func TestRetryAfterFromError(t *testing.T) {
 }
 
 func TestThrottleBackoffDelay(t *testing.T) {
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{10 * time.Second, 20 * time.Second}
-	defer func() { coingeckoThrottleRetryBackoff = originalBackoff }()
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 10 * time.Second
+	defer func() { coingeckoThrottleBackoff = originalBackoff }()
 
 	within := func(t *testing.T, got, base time.Duration) {
 		t.Helper()
@@ -408,17 +416,16 @@ func TestThrottleBackoffDelay(t *testing.T) {
 	}
 
 	noRetryAfter := &coingeckoHTTPError{status: http.StatusTooManyRequests}
-	// The exponential base for the attempt is used only when there is no Retry-After hint.
-	within(t, throttleBackoffDelay(0, noRetryAfter), 10*time.Second)
-	within(t, throttleBackoffDelay(1, noRetryAfter), 20*time.Second)
-	// A Retry-After hint takes priority over the ladder, whether it is longer than the base...
-	within(t, throttleBackoffDelay(0, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 30 * time.Second}), 30*time.Second)
-	// ...or shorter than the base for this attempt.
-	within(t, throttleBackoffDelay(1, &coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 5 * time.Second}), 5*time.Second)
+	// The fixed backoff is used only when there is no Retry-After hint.
+	within(t, throttleBackoffDelay(noRetryAfter), 10*time.Second)
+	// A Retry-After hint takes priority over the fixed backoff, whether it is longer...
+	within(t, throttleBackoffDelay(&coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 30 * time.Second}), 30*time.Second)
+	// ...or shorter than the fixed backoff.
+	within(t, throttleBackoffDelay(&coingeckoHTTPError{status: http.StatusTooManyRequests, retryAfter: 5 * time.Second}), 5*time.Second)
 
 	// A zeroed backoff with no Retry-After stays instant (keeps the throttle tests fast).
-	coingeckoThrottleRetryBackoff = []time.Duration{0}
-	if got := throttleBackoffDelay(0, noRetryAfter); got != 0 {
+	coingeckoThrottleBackoff = 0
+	if got := throttleBackoffDelay(noRetryAfter); got != 0 {
 		t.Fatalf("zeroed backoff delay = %v, want 0", got)
 	}
 }
@@ -459,16 +466,22 @@ func TestIsCoingeckoThrottleError_StatusCode(t *testing.T) {
 	if !isCoingeckoThrottleError(errors.New("error code: 1015")) {
 		t.Fatal("expected Cloudflare 1015 to be detected as throttle")
 	}
+	// Cloudflare actually returns the 1015 code inside a full HTML page, so the
+	// substring must be detected even when it is not the entire error string.
+	cloudflareBody := "<!DOCTYPE html><html><body>The owner of this website has banned you temporarily. error code: 1015</body></html>"
+	if !isCoingeckoThrottleError(&coingeckoHTTPError{status: http.StatusForbidden, body: cloudflareBody}) {
+		t.Fatal("expected Cloudflare 1015 HTML page to be detected as throttle")
+	}
 	if isCoingeckoThrottleError(nil) {
 		t.Fatal("nil error must not be a throttle error")
 	}
 }
 
 func TestMakeReq_Detects429ByStatus(t *testing.T) {
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
 	defer func() {
-		coingeckoThrottleRetryBackoff = originalBackoff
+		coingeckoThrottleBackoff = originalBackoff
 	}()
 
 	var requests atomic.Int32
@@ -483,7 +496,7 @@ func TestMakeReq_Detects429ByStatus(t *testing.T) {
 	defer mockServer.Close()
 
 	cg := &Coingecko{httpClient: mockServer.Client()}
-	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree)
+	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
 	if err != nil {
 		t.Fatalf("makeReq unexpectedly failed: %v", err)
 	}
@@ -510,7 +523,7 @@ func TestMakeReq_PacesRequests(t *testing.T) {
 	}
 	start := time.Now()
 	for i := 0; i < 3; i++ {
-		if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree); err != nil {
+		if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
 			t.Fatalf("makeReq failed on call %d: %v", i, err)
 		}
 	}
@@ -524,11 +537,236 @@ func TestMakeReq_PacesRequests(t *testing.T) {
 	}
 }
 
-// A throttle-retries-exhausted error reflects sustained, provider-wide 429s: makeReq already
-// waited out the full backoff ladder and the provider kept returning 429. So even in steady state
-// the pass stops early rather than repeating the ladder for every remaining currency. The throttle
-// error is still returned so the unfinished currencies are retried next run.
-func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionInSteadyState(t *testing.T) {
+func TestMarkThrottled_ExtendsNeverShortens(t *testing.T) {
+	cg := &Coingecko{}
+	cg.markThrottled(time.Minute)
+	first := cg.throttledUntil
+	if first.IsZero() {
+		t.Fatal("markThrottled did not open the throttle window")
+	}
+	// a shorter delay must not shorten the already open window
+	cg.markThrottled(time.Second)
+	if !cg.throttledUntil.Equal(first) {
+		t.Fatalf("shorter delay moved the window: %v -> %v", first, cg.throttledUntil)
+	}
+	// a longer delay extends it
+	cg.markThrottled(2 * time.Minute)
+	if !cg.throttledUntil.After(first) {
+		t.Fatalf("longer delay did not extend the window past %v: %v", first, cg.throttledUntil)
+	}
+}
+
+func TestWaitForRequestSlot_HighPriorityWaitsOutWindowButIsNotParked(t *testing.T) {
+	cg := &Coingecko{
+		throttledUntil:       time.Now().Add(100 * time.Millisecond),
+		highPriorityInFlight: 1, // a concurrent high-priority request must not park another one
+	}
+	until := cg.throttledUntil
+	done := make(chan time.Time, 1)
+	go func() {
+		cg.waitForRequestSlot(priorityHigh)
+		done <- time.Now()
+	}()
+	select {
+	case returnedAt := <-done:
+		if returnedAt.Before(until) {
+			t.Fatalf("high priority request fired at %v, before the throttle window cleared at %v", returnedAt, until)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("high priority request was parked; it must only wait out the throttle window")
+	}
+}
+
+func TestWaitForRequestSlot_LowPriorityParksUntilHighPriorityCompletes(t *testing.T) {
+	originalPoll := coingeckoLowPriorityPollInterval
+	coingeckoLowPriorityPollInterval = time.Millisecond
+	defer func() { coingeckoLowPriorityPollInterval = originalPoll }()
+
+	cg := &Coingecko{
+		throttledUntil:       time.Now().Add(10 * time.Second),
+		highPriorityInFlight: 1,
+	}
+	done := make(chan struct{})
+	go func() {
+		cg.waitForRequestSlot(priorityLow)
+		close(done)
+	}()
+	// while throttled with a high-priority request in flight, low priority must stay parked
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("low priority request fired while throttled with a high priority request in flight")
+	default:
+	}
+	// once the high-priority request completes and the window clears, low priority proceeds
+	cg.reqMu.Lock()
+	cg.highPriorityInFlight = 0
+	cg.throttledUntil = time.Now()
+	cg.reqMu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("low priority request stayed parked after the gate cleared")
+	}
+}
+
+func TestWaitForRequestSlot_RechecksWindowExtendedDuringSleep(t *testing.T) {
+	cg := &Coingecko{}
+	cg.markThrottled(200 * time.Millisecond)
+	done := make(chan time.Time, 1)
+	go func() {
+		cg.waitForRequestSlot(priorityHigh)
+		done <- time.Now()
+	}()
+	// wait until the goroutine reserved its slot inside the first window
+	for {
+		cg.reqMu.Lock()
+		reserved := !cg.lastRequestAt.IsZero()
+		cg.reqMu.Unlock()
+		if reserved {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// extend the window while the goroutine sleeps on its already-reserved slot
+	cg.markThrottled(500 * time.Millisecond)
+	cg.reqMu.Lock()
+	extendedUntil := cg.throttledUntil
+	cg.reqMu.Unlock()
+	returnedAt := <-done
+	if returnedAt.Before(extendedUntil) {
+		t.Fatalf("request fired at %v, inside the extended throttle window ending %v", returnedAt, extendedUntil)
+	}
+}
+
+// A 429 received by one request opens a throttle window that a second, unrelated request
+// waits out as well.
+func TestMakeReq_SharedThrottleWindow(t *testing.T) {
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 100 * time.Millisecond
+	defer func() { coingeckoThrottleBackoff = originalBackoff }()
+
+	var requests atomic.Int32
+	var windowUntil atomic.Int64 // unix nanos of the shared window once opened
+	var violations atomic.Int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if until := windowUntil.Load(); until != 0 && time.Now().UnixNano() < until {
+			violations.Add(1)
+		}
+		if requests.Add(1) == 1 {
+			http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{httpClient: mockServer.Client()}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityLow)
+		firstDone <- err
+	}()
+	// wait until the first request's 429 opened the shared window
+	for {
+		cg.reqMu.Lock()
+		until := cg.throttledUntil
+		cg.reqMu.Unlock()
+		if !until.IsZero() {
+			windowUntil.Store(until.UnixNano())
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// a second request on another endpoint must wait out the shared window too
+	if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
+		t.Fatalf("second makeReq failed: %v", err)
+	}
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first makeReq failed: %v", err)
+	}
+	if violations.Load() != 0 {
+		t.Fatal("a request reached the server inside the shared throttle window")
+	}
+}
+
+// While a high-priority request keeps retrying through a 429 storm, a concurrent
+// low-priority request stays parked and reaches the server only after the high-priority
+// request succeeded.
+func TestMakeReq_LowPriorityYieldsToHighDuringThrottle(t *testing.T) {
+	originalBackoff := coingeckoThrottleBackoff
+	originalPoll := coingeckoLowPriorityPollInterval
+	coingeckoThrottleBackoff = 60 * time.Millisecond
+	coingeckoLowPriorityPollInterval = time.Millisecond
+	defer func() {
+		coingeckoThrottleBackoff = originalBackoff
+		coingeckoLowPriorityPollInterval = originalPoll
+	}()
+
+	var highThrottleHits atomic.Int32
+	var highSucceededAt atomic.Int64
+	var lowArrivedAt atomic.Int64
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/high":
+			if highThrottleHits.Add(1) <= 2 {
+				http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+				return
+			}
+			highSucceededAt.Store(time.Now().UnixNano())
+		case "/low":
+			lowArrivedAt.Store(time.Now().UnixNano())
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		httpClient: mockServer.Client(),
+		// spacing larger than the loopback round trip keeps an unparked low-priority
+		// request from firing in the instant between a window expiring and the retrying
+		// high-priority request extending it
+		minHttpRequestInterval: 20 * time.Millisecond,
+	}
+	highDone := make(chan error, 1)
+	go func() {
+		_, err := cg.makeReq(mockServer.URL+"/high", "market_chart", coingeckoPlanFree, priorityHigh)
+		highDone <- err
+	}()
+	// wait until the high-priority request opened the window (it stays in flight while retrying)
+	for {
+		cg.reqMu.Lock()
+		opened := !cg.throttledUntil.IsZero()
+		cg.reqMu.Unlock()
+		if opened {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	lowDone := make(chan error, 1)
+	go func() {
+		_, err := cg.makeReq(mockServer.URL+"/low", "simple/price", coingeckoPlanFree, priorityLow)
+		lowDone <- err
+	}()
+	if err := <-highDone; err != nil {
+		t.Fatalf("high priority makeReq failed: %v", err)
+	}
+	if err := <-lowDone; err != nil {
+		t.Fatalf("low priority makeReq failed: %v", err)
+	}
+	high, low := highSucceededAt.Load(), lowArrivedAt.Load()
+	if high == 0 || low == 0 {
+		t.Fatal("expected both endpoints to be hit")
+	}
+	if low < high {
+		t.Fatalf("low priority request reached the server %v before the high priority request succeeded", time.Duration(high-low))
+	}
+}
+
+// Throttled requests are retried without an attempt cap, so a provider-wide 429 no longer ends
+// the pass: makeReq keeps backing off until the request succeeds, then the pass proceeds through
+// the remaining currencies. Every currency is eventually fetched and stored.
+func TestUpdateHistoricalTickers_RetriesThrottleUntilSuccess(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -549,12 +787,14 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionInSteadyState(t *testi
 		platformIdsToTokens = originalPlatformIdsToTokens
 	}()
 
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
 	defer func() {
-		coingeckoThrottleRetryBackoff = originalBackoff
+		coingeckoThrottleBackoff = originalBackoff
 	}()
 
+	// Throttle usd more times than the old retry cap (4) to prove the attempt cap is gone.
+	throttleHits := 7
 	var usdRequests atomic.Int32
 	var eurRequests atomic.Int32
 
@@ -565,8 +805,11 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionInSteadyState(t *testi
 		case "/coins/ethereum/market_chart":
 			switch r.URL.Query().Get("vs_currency") {
 			case "usd":
-				usdRequests.Add(1)
-				http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+				if int(usdRequests.Add(1)) <= throttleHits {
+					http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+					return
+				}
+				_, _ = w.Write([]byte(`{"prices":[[1654732800000,1111.1]]}`))
 			case "eur":
 				eurRequests.Add(1)
 				_, _ = w.Write([]byte(`{"prices":[[1654732800000,1234.5]]}`))
@@ -588,36 +831,33 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionInSteadyState(t *testi
 		plan:         coingeckoPlanFree,
 	}
 
-	err := cg.UpdateHistoricalTickers()
-	if err == nil {
-		t.Fatal("expected throttle exhaustion error")
-	}
-	if !isCoingeckoThrottleRetriesExhaustedError(err) {
-		t.Fatalf("expected throttle exhaustion error, got %v", err)
+	if err := cg.UpdateHistoricalTickers(); err != nil {
+		t.Fatalf("UpdateHistoricalTickers returned error: %v", err)
 	}
 
-	wantUSDRequests := 1 + len(coingeckoThrottleRetryBackoff)
-	if got := int(usdRequests.Load()); got != wantUSDRequests {
-		t.Fatalf("unexpected usd request count: got %d, want %d", got, wantUSDRequests)
+	// usd is retried past the old attempt cap until it finally succeeds.
+	if got, want := int(usdRequests.Load()), throttleHits+1; got != want {
+		t.Fatalf("unexpected usd request count: got %d, want %d", got, want)
 	}
-	// eur must NOT be attempted after usd exhausted its throttle retries (break, not continue):
-	// the 429 is provider-wide, so hammering eur would only repeat the full ladder for nothing.
-	if got := int(eurRequests.Load()); got != 0 {
-		t.Fatalf("expected eur not to be requested after usd throttle exhaustion, got %d", got)
+	// once usd succeeds the pass continues to eur (no break on throttle anymore).
+	if got := int(eurRequests.Load()); got != 1 {
+		t.Fatalf("unexpected eur request count: got %d, want 1", got)
 	}
-	// eur is never fetched, so nothing for it is stored; the next cycle retries from usd.
-	eurTicker, err := d.FiatRatesFindLastTicker("eur", "")
-	if err != nil {
-		t.Fatalf("FiatRatesFindLastTicker eur failed: %v", err)
-	}
-	if eurTicker != nil {
-		t.Fatal("expected no eur ticker to be stored after stopping on usd throttle")
+	for _, cur := range []string{"usd", "eur"} {
+		ticker, err := d.FiatRatesFindLastTicker(cur, "")
+		if err != nil {
+			t.Fatalf("FiatRatesFindLastTicker %s failed: %v", cur, err)
+		}
+		if ticker == nil {
+			t.Fatalf("expected %s ticker to be stored after retry-until-success", cur)
+		}
 	}
 }
 
-// During bootstrap the pass is strict: a throttled currency stops the pass early (break) so the
-// failed attempt is counted and bootstrap retries terminate.
-func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionDuringBootstrap(t *testing.T) {
+// Even during bootstrap, throttled requests are retried without an attempt cap: the pass waits
+// out the provider-wide 429 instead of failing the bootstrap cycle. Once the requests succeed,
+// every currency is fetched and the bootstrap pass completes without error.
+func TestUpdateHistoricalTickers_RetriesThrottleUntilSuccessDuringBootstrap(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -638,12 +878,14 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionDuringBootstrap(t *tes
 		platformIdsToTokens = originalPlatformIdsToTokens
 	}()
 
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
 	defer func() {
-		coingeckoThrottleRetryBackoff = originalBackoff
+		coingeckoThrottleBackoff = originalBackoff
 	}()
 
+	// Throttle usd more times than the old retry cap (4) to prove the attempt cap is gone.
+	throttleHits := 7
 	var usdRequests atomic.Int32
 	var eurRequests atomic.Int32
 
@@ -654,8 +896,11 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionDuringBootstrap(t *tes
 		case "/coins/ethereum/market_chart":
 			switch r.URL.Query().Get("vs_currency") {
 			case "usd":
-				usdRequests.Add(1)
-				http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+				if int(usdRequests.Add(1)) <= throttleHits {
+					http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+					return
+				}
+				_, _ = w.Write([]byte(`{"prices":[[1654732800000,1111.1]]}`))
 			case "eur":
 				eurRequests.Add(1)
 				_, _ = w.Write([]byte(`{"prices":[[1654732800000,1234.5]]}`))
@@ -677,28 +922,33 @@ func TestUpdateHistoricalTickers_StopsOnThrottleExhaustionDuringBootstrap(t *tes
 		plan:         coingeckoPlanFree,
 	}
 
-	err := cg.UpdateHistoricalTickers()
-	if err == nil {
-		t.Fatal("expected throttle exhaustion error")
-	}
-	if !isCoingeckoThrottleRetriesExhaustedError(err) {
-		t.Fatalf("expected throttle exhaustion error, got %v", err)
+	if err := cg.UpdateHistoricalTickers(); err != nil {
+		t.Fatalf("UpdateHistoricalTickers returned error during bootstrap: %v", err)
 	}
 
-	wantUSDRequests := 1 + len(coingeckoThrottleRetryBackoff)
-	if got := int(usdRequests.Load()); got != wantUSDRequests {
-		t.Fatalf("unexpected usd request count: got %d, want %d", got, wantUSDRequests)
+	// usd is retried past the old attempt cap until it finally succeeds.
+	if got, want := int(usdRequests.Load()), throttleHits+1; got != want {
+		t.Fatalf("unexpected usd request count: got %d, want %d", got, want)
 	}
-	if got := int(eurRequests.Load()); got != 0 {
-		t.Fatalf("expected eur request count 0 after bootstrap throttle exhaustion (break), got %d", got)
+	// once usd succeeds the bootstrap pass continues to eur (no break on throttle anymore).
+	if got := int(eurRequests.Load()); got != 1 {
+		t.Fatalf("unexpected eur request count: got %d, want 1", got)
+	}
+	for _, cur := range []string{"usd", "eur"} {
+		ticker, err := d.FiatRatesFindLastTicker(cur, "")
+		if err != nil {
+			t.Fatalf("FiatRatesFindLastTicker %s failed: %v", cur, err)
+		}
+		if ticker == nil {
+			t.Fatalf("expected %s ticker to be stored after retry-until-success", cur)
+		}
 	}
 }
 
-// A throttle-retries-exhausted error reflects sustained, provider-wide 429s, so even in steady
-// state the token pass stops after the first exhausted token instead of repeating the ~10-minute
-// ladder for every remaining token (which would also hold updatingTokens and block later cycles).
-// The throttle error is still returned so the unfinished tokens are retried next run.
-func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustionInSteadyState(t *testing.T) {
+// Throttled requests are retried without an attempt cap, so a provider-wide 429 no longer stops
+// the token pass after the first throttled token: makeReq waits out the 429 until the request
+// succeeds, and the pass then continues through the remaining tokens.
+func TestUpdateHistoricalTokenTickers_RetriesThrottleUntilSuccess(t *testing.T) {
 	config := common.Config{
 		CoinName: "fakecoin",
 	}
@@ -719,12 +969,14 @@ func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustionInSteadyState(t *
 		platformIdsToTokens = originalPlatformIdsToTokens
 	}()
 
-	originalBackoff := coingeckoThrottleRetryBackoff
-	coingeckoThrottleRetryBackoff = []time.Duration{0, 0, 0, 0}
+	originalBackoff := coingeckoThrottleBackoff
+	coingeckoThrottleBackoff = 0
 	defer func() {
-		coingeckoThrottleRetryBackoff = originalBackoff
+		coingeckoThrottleBackoff = originalBackoff
 	}()
 
+	// Throttle the token requests more times than the old retry cap (4) to prove the cap is gone.
+	throttleHits := 7
 	var marketChartRequests atomic.Int32
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -735,8 +987,11 @@ func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustionInSteadyState(t *
 				{"id":"token-b","symbol":"b","name":"B","platforms":{"ethereum":"0xb"}}
 			]`))
 		case "/coins/token-a/market_chart", "/coins/token-b/market_chart":
-			marketChartRequests.Add(1)
-			http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+			if int(marketChartRequests.Add(1)) <= throttleHits {
+				http.Error(w, "exceeded the rate limit", http.StatusTooManyRequests)
+				return
+			}
+			_, _ = w.Write([]byte(`{"prices":[[1654732800000,1.5]]}`))
 		default:
 			http.Error(w, fmt.Sprintf("unexpected path %s", r.URL.Path), http.StatusNotFound)
 		}
@@ -754,19 +1009,14 @@ func TestUpdateHistoricalTokenTickers_StopsOnThrottleExhaustionInSteadyState(t *
 		plan:               coingeckoPlanFree,
 	}
 
-	err := cg.UpdateHistoricalTokenTickers()
-	if err == nil {
-		t.Fatal("expected throttle exhaustion error")
-	}
-	if !isCoingeckoThrottleRetriesExhaustedError(err) {
-		t.Fatalf("expected throttle exhaustion error, got %v", err)
+	if err := cg.UpdateHistoricalTokenTickers(); err != nil {
+		t.Fatalf("UpdateHistoricalTokenTickers returned error: %v", err)
 	}
 
-	// Only the first token (random map order, but both behave identically) is attempted; the pass
-	// breaks on its throttle exhaustion instead of repeating the ladder for the remaining token.
-	wantRequests := 1 + len(coingeckoThrottleRetryBackoff)
-	if got := int(marketChartRequests.Load()); got != wantRequests {
-		t.Fatalf("unexpected market_chart request count: got %d, want %d", got, wantRequests)
+	// The first token absorbs all the throttles (retried past the old cap until it succeeds); the
+	// remaining token then succeeds on its first request. No token is dropped on a 429.
+	if got, want := int(marketChartRequests.Load()), throttleHits+2; got != want {
+		t.Fatalf("unexpected market_chart request count: got %d, want %d", got, want)
 	}
 }
 

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -3,12 +3,12 @@
 package fiat
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -470,7 +470,7 @@ func TestMakeReq_ThrottleRetriesWithoutCap(t *testing.T) {
 	cg := &Coingecko{
 		httpClient: mockServer.Client(),
 	}
-	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
+	resp, err := cg.makeReq(context.Background(), mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
 	if err != nil {
 		t.Fatalf("makeReq unexpectedly failed: %v", err)
 	}
@@ -502,7 +502,7 @@ func TestMakeReq_ThrottleRetriesEventuallySuccess(t *testing.T) {
 	cg := &Coingecko{
 		httpClient: mockServer.Client(),
 	}
-	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
+	resp, err := cg.makeReq(context.Background(), mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
 	if err != nil {
 		t.Fatalf("makeReq unexpectedly failed: %v", err)
 	}
@@ -561,7 +561,7 @@ func TestMakeReq_CloudflareBanFastFails(t *testing.T) {
 		},
 	}
 
-	resp, err := cg.makeReq("http://coingecko.invalid/coins/x/market_chart", "market_chart", coingeckoPlanFree, priorityLow)
+	resp, err := cg.makeReq(context.Background(), "http://coingecko.invalid/coins/x/market_chart", "market_chart", coingeckoPlanFree, priorityLow)
 	if err == nil {
 		t.Fatal("expected makeReq to fast-fail on a Cloudflare 1015 ban, got nil error")
 	}
@@ -707,7 +707,7 @@ func TestMakeReq_Detects429ByStatus(t *testing.T) {
 	defer mockServer.Close()
 
 	cg := &Coingecko{httpClient: mockServer.Client()}
-	resp, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
+	resp, err := cg.makeReq(context.Background(), mockServer.URL, "market_chart", coingeckoPlanFree, priorityHigh)
 	if err != nil {
 		t.Fatalf("makeReq unexpectedly failed: %v", err)
 	}
@@ -734,7 +734,7 @@ func TestMakeReq_PacesRequests(t *testing.T) {
 	}
 	start := time.Now()
 	for i := 0; i < 3; i++ {
-		if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
+		if _, err := cg.makeReq(context.Background(), mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
 			t.Fatalf("makeReq failed on call %d: %v", i, err)
 		}
 	}
@@ -767,7 +767,7 @@ func TestMakeReq_BootstrapCDNBypassesPlanPacing(t *testing.T) {
 	}
 	start := time.Now()
 	for i := 0; i < 3; i++ {
-		if _, err := cg.makeReq(mockServer.URL+"/coins/list", "coins/list", coingeckoPlanFree, priorityLow); err != nil {
+		if _, err := cg.makeReq(context.Background(), mockServer.URL+"/coins/list", "coins/list", coingeckoPlanFree, priorityLow); err != nil {
 			t.Fatalf("makeReq failed on call %d: %v", i, err)
 		}
 	}
@@ -800,7 +800,7 @@ func TestMakeReq_NonBootstrapURLStillPacedWhenBootstrapConfigured(t *testing.T) 
 	}
 	start := time.Now()
 	for i := 0; i < 3; i++ {
-		if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
+		if _, err := cg.makeReq(context.Background(), mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
 			t.Fatalf("makeReq failed on call %d: %v", i, err)
 		}
 	}
@@ -840,7 +840,7 @@ func TestWaitForRequestSlot_HighPriorityWaitsOutWindowButIsNotParked(t *testing.
 	until := cg.throttledUntil
 	done := make(chan time.Time, 1)
 	go func() {
-		cg.waitForRequestSlot(priorityHigh, cg.minHttpRequestInterval)
+		cg.waitForRequestSlot(context.Background(), priorityHigh, cg.minHttpRequestInterval)
 		done <- time.Now()
 	}()
 	select {
@@ -864,7 +864,7 @@ func TestWaitForRequestSlot_LowPriorityParksUntilHighPriorityCompletes(t *testin
 	}
 	done := make(chan struct{})
 	go func() {
-		cg.waitForRequestSlot(priorityLow, cg.minHttpRequestInterval)
+		cg.waitForRequestSlot(context.Background(), priorityLow, cg.minHttpRequestInterval)
 		close(done)
 	}()
 	// while throttled with a high-priority request in flight, low priority must stay parked
@@ -891,7 +891,7 @@ func TestWaitForRequestSlot_RechecksWindowExtendedDuringSleep(t *testing.T) {
 	cg.markThrottled(200 * time.Millisecond)
 	done := make(chan time.Time, 1)
 	go func() {
-		cg.waitForRequestSlot(priorityHigh, cg.minHttpRequestInterval)
+		cg.waitForRequestSlot(context.Background(), priorityHigh, cg.minHttpRequestInterval)
 		done <- time.Now()
 	}()
 	// wait until the goroutine reserved its slot inside the first window
@@ -940,7 +940,7 @@ func TestMakeReq_SharedThrottleWindow(t *testing.T) {
 	cg := &Coingecko{httpClient: mockServer.Client()}
 	firstDone := make(chan error, 1)
 	go func() {
-		_, err := cg.makeReq(mockServer.URL, "market_chart", coingeckoPlanFree, priorityLow)
+		_, err := cg.makeReq(context.Background(), mockServer.URL, "market_chart", coingeckoPlanFree, priorityLow)
 		firstDone <- err
 	}()
 	// wait until the first request's 429 opened the shared window
@@ -955,7 +955,7 @@ func TestMakeReq_SharedThrottleWindow(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 	// a second request on another endpoint must wait out the shared window too
-	if _, err := cg.makeReq(mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
+	if _, err := cg.makeReq(context.Background(), mockServer.URL, "simple/price", coingeckoPlanFree, priorityHigh); err != nil {
 		t.Fatalf("second makeReq failed: %v", err)
 	}
 	if err := <-firstDone; err != nil {
@@ -1006,7 +1006,7 @@ func TestMakeReq_LowPriorityYieldsToHighDuringThrottle(t *testing.T) {
 	}
 	highDone := make(chan error, 1)
 	go func() {
-		_, err := cg.makeReq(mockServer.URL+"/high", "market_chart", coingeckoPlanFree, priorityHigh)
+		_, err := cg.makeReq(context.Background(), mockServer.URL+"/high", "market_chart", coingeckoPlanFree, priorityHigh)
 		highDone <- err
 	}()
 	// wait until the high-priority request opened the window (it stays in flight while retrying)
@@ -1021,7 +1021,7 @@ func TestMakeReq_LowPriorityYieldsToHighDuringThrottle(t *testing.T) {
 	}
 	lowDone := make(chan error, 1)
 	go func() {
-		_, err := cg.makeReq(mockServer.URL+"/low", "simple/price", coingeckoPlanFree, priorityLow)
+		_, err := cg.makeReq(context.Background(), mockServer.URL+"/low", "simple/price", coingeckoPlanFree, priorityLow)
 		lowDone <- err
 	}()
 	if err := <-highDone; err != nil {
@@ -1356,7 +1356,7 @@ func TestReconcileHistoricalRates_RepairsInteriorHole(t *testing.T) {
 		plan:               coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
+	filled, err := cg.ReconcileHistoricalRates(context.Background(), 365, 90)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1410,7 +1410,7 @@ func TestReconcileHistoricalRates_HealthyMakesNoRequests(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
+	filled, err := cg.ReconcileHistoricalRates(context.Background(), 365, 90)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1446,7 +1446,7 @@ func TestReconcileHistoricalRates_YoungDBMakesNoRequests(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
+	filled, err := cg.ReconcileHistoricalRates(context.Background(), 365, 90)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1483,7 +1483,7 @@ func TestReconcileHistoricalRates_GapTooLargeSkipsFetch(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90, nil)
+	filled, err := cg.ReconcileHistoricalRates(context.Background(), 365, 90)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
@@ -1514,14 +1514,14 @@ func TestReconcileHistoricalRates_NoCDNIsNoOp(t *testing.T) {
 		plan:       coingeckoPlanFree,
 	}
 
-	if _, err := cg.ReconcileHistoricalRates(365, 90, nil); err != nil {
+	if _, err := cg.ReconcileHistoricalRates(context.Background(), 365, 90); err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
 }
 
-// A shutdown signaled before backfill aborts the pass without issuing any request, even
-// when there is a genuine (sub-guard) gap to repair.
-func TestReconcileHistoricalRates_ShutdownAbortsBeforeFetch(t *testing.T) {
+// An already-cancelled context (shutdown or budget timeout) aborts the pass without issuing
+// any request, even when there is a genuine (sub-guard) gap to repair.
+func TestReconcileHistoricalRates_CancelledContextAbortsBeforeFetch(t *testing.T) {
 	config := common.Config{CoinName: "fakecoin"}
 	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
 	defer closeAndDestroyRocksDB(t, d, tmp)
@@ -1548,15 +1548,69 @@ func TestReconcileHistoricalRates_ShutdownAbortsBeforeFetch(t *testing.T) {
 		plan:         coingeckoPlanFree,
 	}
 
-	// a closed channel reads as immediately signaled, simulating an in-flight shutdown
-	stop := make(chan os.Signal)
-	close(stop)
+	// an already-cancelled context simulates an in-flight shutdown / elapsed budget
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	filled, err := cg.ReconcileHistoricalRates(365, 90, stop)
+	filled, err := cg.ReconcileHistoricalRates(ctx, 365, 90)
 	if err != nil {
 		t.Fatalf("ReconcileHistoricalRates failed: %v", err)
 	}
 	if filled != 0 {
 		t.Fatalf("aborted reconciliation should fill nothing, got %d", filled)
+	}
+}
+
+// When the wall-clock budget elapses while a backfill fetch is in flight, the pass aborts
+// (without error) instead of stalling startup: metadata succeeds fast, the first chart fetch
+// blocks until the budget cancels the request context.
+func TestReconcileHistoricalRates_BudgetExhaustedAbortsMidBackfill(t *testing.T) {
+	config := common.Config{CoinName: "fakecoin"}
+	d, _, tmp := setupRocksDB(t, &testBitcoinParser{BitcoinParser: bitcoinTestnetParser()}, &config)
+	defer closeAndDestroyRocksDB(t, d, tmp)
+
+	if err := d.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+		t.Fatalf("FiatRatesSetHistoricalBootstrapComplete failed: %v", err)
+	}
+	// a real interior hole at d3 -> work to do, well under the gap guard
+	seedDailyTicker(t, d, midnightDaysAgo(2), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(4), map[string]float32{"usd": 100}, nil)
+	seedDailyTicker(t, d, midnightDaysAgo(5), map[string]float32{"usd": 100}, nil)
+
+	var chartReqs int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/simple/supported_vs_currencies":
+			_, _ = w.Write([]byte(`["usd","eur"]`)) // metadata returns immediately
+		case "/coins/ethereum/market_chart":
+			atomic.AddInt32(&chartReqs, 1)
+			<-r.Context().Done() // block until the reconcile budget cancels the request
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cg := &Coingecko{
+		coin:         "ethereum",
+		bootstrapURL: mockServer.URL,
+		tipURL:       mockServer.URL,
+		httpClient:   mockServer.Client(),
+		db:           d,
+		plan:         coingeckoPlanFree,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	filled, err := cg.ReconcileHistoricalRates(ctx, 365, 90)
+	if err != nil {
+		t.Fatalf("budget-exhausted reconciliation must not return an error, got: %v", err)
+	}
+	if filled != 0 {
+		t.Fatalf("a fetch cut short by the budget should fill nothing, got %d", filled)
+	}
+	if atomic.LoadInt32(&chartReqs) == 0 {
+		t.Fatal("expected the backfill loop to attempt at least one market_chart fetch before the budget expired")
 	}
 }

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -35,7 +35,16 @@ type RatesDownloaderInterface interface {
 	FiveMinutesTickers() (*[]common.CurrencyRatesTicker, error)
 	UpdateHistoricalTickers() error
 	UpdateHistoricalTokenTickers() error
+	ReconcileHistoricalRates(windowDays int, maxGapDays int) error
 }
+
+const (
+	// reconcileWindowDays bounds how far back the startup self-healing pass repairs missing
+	// daily rates; reconcileMaxGapDays is the trailing-gap guard above which a series is
+	// treated as a probable bug and reported instead of refetched.
+	reconcileWindowDays = 365
+	reconcileMaxGapDays = 90
+)
 
 // FiatRates is used to fetch and refresh fiat rates
 type FiatRates struct {
@@ -47,6 +56,7 @@ type FiatRates struct {
 	callbackOnNewTicker    OnNewFiatRatesTicker
 	downloader             RatesDownloaderInterface
 	downloadTokens         bool
+	reconcileAtStartup     bool
 	provider               string
 	allowedVsCurrencies    string
 	mux                    sync.RWMutex
@@ -87,6 +97,9 @@ func NewFiatRates(db *db.RocksDB, config *common.Config, metrics *common.Metrics
 		PlatformVsCurrency string `json:"platformVsCurrency"`
 		PeriodSeconds      int64  `json:"periodSeconds"`
 		Plan               string `json:"plan"`
+		// ReconcileHistoricalAtStartup toggles the blocking startup self-healing pass that
+		// repairs missing historical rates. Absent (nil) means enabled; set false to disable.
+		ReconcileHistoricalAtStartup *bool `json:"reconcileHistoricalAtStartup"`
 	}
 	rdParams := &fiatRatesParams{}
 	err := json.Unmarshal([]byte(config.FiatRatesParams), &rdParams)
@@ -105,6 +118,7 @@ func NewFiatRates(db *db.RocksDB, config *common.Config, metrics *common.Metrics
 	fr.metrics = metrics
 	fr.callbackOnNewTicker = callback
 	fr.downloadTokens = rdParams.PlatformIdentifier != "" && rdParams.PlatformVsCurrency != ""
+	fr.reconcileAtStartup = rdParams.ReconcileHistoricalAtStartup == nil || *rdParams.ReconcileHistoricalAtStartup
 	if fr.downloadTokens {
 		common.TickerRecalculateTokenRate = strings.ToLower(db.GetInternalState().CoinShortcut) != rdParams.PlatformVsCurrency
 		common.TickerTokenVsCurrency = rdParams.PlatformVsCurrency
@@ -476,6 +490,34 @@ func logFiatRatesDownloaderError(message string, err error) {
 const historicalPollInterval = time.Minute
 
 const historicalBanBackoff = 30 * time.Minute
+
+// ReconcileHistoricalRatesAtStartup runs the blocking startup self-healing pass that repairs
+// missing historical fiat rates (interior holes and trailing gaps) within the reconcile
+// window. It is meant to run once, before the periodic downloader loops start, so the DB is
+// consistent and there is no concurrent Free-tier throttling. Honors the per-coin config
+// toggle and is a no-op when fiat rates are disabled.
+func (fr *FiatRates) ReconcileHistoricalRatesAtStartup() {
+	if !fr.Enabled || fr.downloader == nil {
+		return
+	}
+	if !fr.reconcileAtStartup {
+		glog.Info("FiatRatesDownloader: startup historical reconciliation disabled by config")
+		return
+	}
+	start := time.Now()
+	glog.Info("FiatRatesDownloader: starting historical rates reconciliation (startup self-healing)")
+	if err := fr.downloader.ReconcileHistoricalRates(reconcileWindowDays, reconcileMaxGapDays); err != nil {
+		fr.observeUpdateDuration("reconcile", "error", start)
+		logFiatRatesDownloaderError("FiatRatesDownloader: reconciliation error ", err)
+		return
+	}
+	fr.observeUpdateDuration("reconcile", "success", start)
+	// refresh the in-memory daily cache so repaired tickers are served immediately
+	if err := fr.loadDailyTickers(); err != nil {
+		glog.Error("FiatRatesDownloader: loadDailyTickers after reconciliation error ", err)
+	}
+	glog.Infof("FiatRatesDownloader: historical rates reconciliation finished in %v", time.Since(start))
+}
 
 func (fr *FiatRates) RunDownloader() error {
 	glog.Infof("Starting %v FiatRates downloader...", fr.provider)

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -35,7 +35,7 @@ type RatesDownloaderInterface interface {
 	FiveMinutesTickers() (*[]common.CurrencyRatesTicker, error)
 	UpdateHistoricalTickers() error
 	UpdateHistoricalTokenTickers() error
-	ReconcileHistoricalRates(windowDays int, maxGapDays int) error
+	ReconcileHistoricalRates(windowDays int, maxGapDays int) (int, error)
 }
 
 const (
@@ -504,19 +504,28 @@ func (fr *FiatRates) ReconcileHistoricalRatesAtStartup() {
 		glog.Info("FiatRatesDownloader: startup historical reconciliation disabled by config")
 		return
 	}
+	// A fiat-rate bug must never brick startup; recover, log and let blockbook come up.
+	defer func() {
+		if r := recover(); r != nil {
+			glog.Errorf("FiatRatesDownloader: reconciliation panic recovered, continuing startup: %v", r)
+		}
+	}()
 	start := time.Now()
 	glog.Info("FiatRatesDownloader: starting historical rates reconciliation (startup self-healing)")
-	if err := fr.downloader.ReconcileHistoricalRates(reconcileWindowDays, reconcileMaxGapDays); err != nil {
+	filled, err := fr.downloader.ReconcileHistoricalRates(reconcileWindowDays, reconcileMaxGapDays)
+	if err != nil {
 		fr.observeUpdateDuration("reconcile", "error", start)
 		logFiatRatesDownloaderError("FiatRatesDownloader: reconciliation error ", err)
 		return
 	}
 	fr.observeUpdateDuration("reconcile", "success", start)
-	// refresh the in-memory daily cache so repaired tickers are served immediately
-	if err := fr.loadDailyTickers(); err != nil {
-		glog.Error("FiatRatesDownloader: loadDailyTickers after reconciliation error ", err)
+	// only refresh the in-memory daily cache (a full-history scan) if anything was repaired
+	if filled > 0 {
+		if err := fr.loadDailyTickers(); err != nil {
+			glog.Error("FiatRatesDownloader: loadDailyTickers after reconciliation error ", err)
+		}
 	}
-	glog.Infof("FiatRatesDownloader: historical rates reconciliation finished in %v", time.Since(start))
+	glog.Infof("FiatRatesDownloader: historical rates reconciliation finished in %v (%d points filled)", time.Since(start), filled)
 }
 
 func (fr *FiatRates) RunDownloader() error {

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -473,11 +473,18 @@ func logFiatRatesDownloaderError(message string, err error) {
 	glog.Error(message, err)
 }
 
-// RunDownloader periodically downloads current (every 15 minutes) and historical (once a day) tickers
+const historicalPollInterval = time.Minute
+
+const historicalBanBackoff = 30 * time.Minute
+
 func (fr *FiatRates) RunDownloader() error {
 	glog.Infof("Starting %v FiatRates downloader...", fr.provider)
-	var lastHistoricalTickers time.Time
-	is := fr.db.GetInternalState()
+	go fr.runHistoricalLoop()
+	fr.runCurrentLoop()
+	return nil
+}
+
+func (fr *FiatRates) runCurrentLoop() {
 	tickerFromIs := fr.GetCurrentTicker("", "")
 	firstRun := true
 	for {
@@ -492,177 +499,188 @@ func (fr *FiatRates) RunDownloader() error {
 		}
 		firstRun = false
 
-		// load current tickers
-		currentTickersStart := time.Now()
-		currentTicker, err := fr.downloader.CurrentTickers()
-		if err != nil || currentTicker == nil {
-			fr.observeUpdateDuration("current_tickers", "error", currentTickersStart)
-			logFiatRatesDownloaderError("FiatRatesDownloader: CurrentTickers error ", err)
-		} else {
-			fr.setCurrentTicker(currentTicker)
-			fr.observeUpdateDuration("current_tickers", "success", currentTickersStart)
-			glog.Info("FiatRatesDownloader: CurrentTickers updated")
-			if fr.callbackOnNewTicker != nil {
-				fr.callbackOnNewTicker(currentTicker)
-			}
-		}
+		fr.updateCurrentTickers()
+		fr.updateHourlyTickersIfDue()
+		fr.updateFiveMinutesTickersIfDue()
+	}
+}
 
-		// load hourly tickers, it is necessary to wait about 1 hour to prepare the tickers
-		if time.Now().UTC().Unix() >= fr.hourlyTickersTo+secondsInHour+secondsInHour {
-			hourlyTickersStart := time.Now()
-			hourlyTickers, err := fr.downloader.HourlyTickers()
-			if err != nil || hourlyTickers == nil {
-				fr.observeUpdateDuration("hourly_tickers", "error", hourlyTickersStart)
-				logFiatRatesDownloaderError("FiatRatesDownloader: HourlyTickers error ", err)
-			} else {
-				fr.setHourlyTickers(hourlyTickers)
-				fr.observeUpdateDuration("hourly_tickers", "success", hourlyTickersStart)
-				glog.Info("FiatRatesDownloader: HourlyTickers updated")
-			}
-		}
+func (fr *FiatRates) updateCurrentTickers() {
+	start := time.Now()
+	currentTicker, err := fr.downloader.CurrentTickers()
+	if err != nil || currentTicker == nil {
+		fr.observeUpdateDuration("current_tickers", "error", start)
+		logFiatRatesDownloaderError("FiatRatesDownloader: CurrentTickers error ", err)
+		return
+	}
+	fr.setCurrentTicker(currentTicker)
+	fr.observeUpdateDuration("current_tickers", "success", start)
+	glog.Info("FiatRatesDownloader: CurrentTickers updated")
+	if fr.callbackOnNewTicker != nil {
+		fr.callbackOnNewTicker(currentTicker)
+	}
+}
 
-		// load five minute tickers, it is necessary to wait about 10 minutes to prepare the tickers
-		if time.Now().UTC().Unix() >= fr.fiveMinutesTickersTo+3*secondsInFiveMinutes {
-			fiveMinutesTickersStart := time.Now()
-			fiveMinutesTickers, err := fr.downloader.FiveMinutesTickers()
-			if err != nil || fiveMinutesTickers == nil {
-				fr.observeUpdateDuration("five_minutes_tickers", "error", fiveMinutesTickersStart)
-				logFiatRatesDownloaderError("FiatRatesDownloader: FiveMinutesTickers error ", err)
-			} else {
-				fr.setFiveMinutesTickers(fiveMinutesTickers)
-				fr.observeUpdateDuration("five_minutes_tickers", "success", fiveMinutesTickersStart)
-				glog.Info("FiatRatesDownloader: FiveMinutesTickers updated")
-			}
-		}
+func (fr *FiatRates) updateHourlyTickersIfDue() {
+	// it is necessary to wait about 1 hour to prepare the tickers
+	if time.Now().UTC().Unix() < fr.hourlyTickersTo+secondsInHour+secondsInHour {
+		return
+	}
+	start := time.Now()
+	hourlyTickers, err := fr.downloader.HourlyTickers()
+	if err != nil || hourlyTickers == nil {
+		fr.observeUpdateDuration("hourly_tickers", "error", start)
+		logFiatRatesDownloaderError("FiatRatesDownloader: HourlyTickers error ", err)
+		return
+	}
+	fr.setHourlyTickers(hourlyTickers)
+	fr.observeUpdateDuration("hourly_tickers", "success", start)
+	glog.Info("FiatRatesDownloader: HourlyTickers updated")
+}
 
-		// once a day, 1 hour after UTC midnight (to let the provider prepare historical rates) update historical tickers
+func (fr *FiatRates) updateFiveMinutesTickersIfDue() {
+	// it is necessary to wait about 10 minutes to prepare the tickers
+	if time.Now().UTC().Unix() < fr.fiveMinutesTickersTo+3*secondsInFiveMinutes {
+		return
+	}
+	start := time.Now()
+	fiveMinutesTickers, err := fr.downloader.FiveMinutesTickers()
+	if err != nil || fiveMinutesTickers == nil {
+		fr.observeUpdateDuration("five_minutes_tickers", "error", start)
+		logFiatRatesDownloaderError("FiatRatesDownloader: FiveMinutesTickers error ", err)
+		return
+	}
+	fr.setFiveMinutesTickers(fiveMinutesTickers)
+	fr.observeUpdateDuration("five_minutes_tickers", "success", start)
+	glog.Info("FiatRatesDownloader: FiveMinutesTickers updated")
+}
+
+// runHistoricalLoop updates historical (daily) tickers once a day, 1 hour after
+// UTC midnight (to let the provider prepare historical rates).
+func (fr *FiatRates) runHistoricalLoop() {
+	is := fr.db.GetInternalState()
+	var lastHistoricalTickers time.Time
+	for {
 		now := time.Now().UTC()
 		if (now.YearDay() != lastHistoricalTickers.YearDay() || now.Year() != lastHistoricalTickers.Year()) && now.Hour() > 0 {
-			bootstrapInProgress, _, bootstrapErr := historicalBootstrapInProgress(fr.db)
-			if bootstrapErr != nil {
-				glog.Error("FiatRatesDownloader: bootstrap state check error ", bootstrapErr)
-				continue
-			}
-
-			historicalTickersStart := time.Now()
-			err = fr.downloader.UpdateHistoricalTickers()
-			if err != nil {
-				fr.observeUpdateDuration("historical_tickers", "error", historicalTickersStart)
-				logFiatRatesDownloaderError("FiatRatesDownloader: UpdateHistoricalTickers error ", err)
-				if bootstrapInProgress {
-					// Bootstrap policy: count failed cycles and stop bootstrap mode after the
-					// configured limit so we do not retry full-history downloads forever.
-					attempts, exhausted, attemptsErr := registerHistoricalBootstrapAttemptFailure(fr.db)
-					if attemptsErr != nil {
-						glog.Error("FiatRatesDownloader: recording bootstrap attempt failure failed ", attemptsErr)
-					} else if exhausted {
-						glog.Warningf("FiatRatesDownloader: bootstrap failed %d/%d times, stopping bootstrap retries", attempts, maxHistoricalBootstrapAttempts)
-						// Also advance the in-memory daily guard to avoid re-entering the
-						// historical block again in the same UTC day.
-						lastHistoricalTickers = time.Now().UTC()
-					} else {
-						glog.Warningf("FiatRatesDownloader: bootstrap attempt %d/%d failed", attempts, maxHistoricalBootstrapAttempts)
-					}
-				}
-				// Base historical pass failed; skip token/bootstrap-completion handling for this cycle.
-				continue
-			}
-
-			fr.observeUpdateDuration("historical_tickers", "success", historicalTickersStart)
-			loadDailyTickersStart := time.Now()
-			if err = fr.loadDailyTickers(); err != nil {
-				fr.observeUpdateDuration("load_daily_tickers", "error", loadDailyTickersStart)
-				// Cache refresh failure does not mean downloaded historical data is invalid;
-				// keep processing the cycle and rely on next runs to refresh in-memory cache.
-				glog.Error("FiatRatesDownloader: loadDailyTickers error ", err)
-			} else {
-				fr.observeUpdateDuration("load_daily_tickers", "success", loadDailyTickersStart)
-				ticker, found := fr.dailyTickers[fr.dailyTickersTo]
-				if !found || ticker == nil {
-					glog.Error("FiatRatesDownloader: dailyTickers not loaded")
-				} else {
-					glog.Infof("FiatRatesDownloader: UpdateHistoricalTickers finished, last ticker from %v", ticker.Timestamp)
-					fr.logTickersInfo()
-					if is != nil {
-						is.HistoricalFiatRatesTime = ticker.Timestamp
-					}
-				}
-			}
-
-			cycleSuccessful := true
-			if fr.downloadTokens {
-				if bootstrapInProgress {
-					// During bootstrap keep completion state incomplete until token bootstrap succeeds.
-					historicalTokenTickersStart := time.Now()
-					err = fr.downloader.UpdateHistoricalTokenTickers()
-					if err != nil {
-						cycleSuccessful = false
-						if isCoingeckoHistoricalTokenUpdateInProgressError(err) {
-							fr.observeUpdateDuration("historical_token_tickers", "skipped", historicalTokenTickersStart)
-							glog.Info("FiatRatesDownloader: UpdateHistoricalTokenTickers skipped, update already in progress")
-						} else {
-							fr.observeUpdateDuration("historical_token_tickers", "error", historicalTokenTickersStart)
-							logFiatRatesDownloaderError("FiatRatesDownloader: UpdateHistoricalTokenTickers error ", err)
-						}
-					} else {
-						fr.observeUpdateDuration("historical_token_tickers", "success", historicalTokenTickersStart)
-						glog.Info("FiatRatesDownloader: UpdateHistoricalTokenTickers finished")
-						if is != nil {
-							is.HistoricalTokenFiatRatesTime = time.Now().UTC()
-						}
-					}
-				} else {
-					// UpdateHistoricalTokenTickers in a goroutine, it can take quite some time as there are many tokens
-					go func() {
-						historicalTokenTickersStart := time.Now()
-						err := fr.downloader.UpdateHistoricalTokenTickers()
-						if err != nil {
-							if isCoingeckoHistoricalTokenUpdateInProgressError(err) {
-								fr.observeUpdateDuration("historical_token_tickers", "skipped", historicalTokenTickersStart)
-								glog.Info("FiatRatesDownloader: UpdateHistoricalTokenTickers skipped, update already in progress")
-								return
-							}
-							fr.observeUpdateDuration("historical_token_tickers", "error", historicalTokenTickersStart)
-							logFiatRatesDownloaderError("FiatRatesDownloader: UpdateHistoricalTokenTickers error ", err)
-						} else {
-							fr.observeUpdateDuration("historical_token_tickers", "success", historicalTokenTickersStart)
-							glog.Info("FiatRatesDownloader: UpdateHistoricalTokenTickers finished")
-							if is != nil {
-								is.HistoricalTokenFiatRatesTime = time.Now().UTC()
-							}
-						}
-					}()
-				}
-			}
-
-			if bootstrapInProgress && cycleSuccessful {
-				// Bootstrap can be marked complete only after both base and token historical
-				// updates finished successfully in this cycle.
-				if err := fr.db.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
-					cycleSuccessful = false
-					glog.Error("FiatRatesDownloader: setting bootstrap completion failed ", err)
-				} else if err := resetHistoricalBootstrapAttempts(fr.db); err != nil {
-					cycleSuccessful = false
-					glog.Error("FiatRatesDownloader: resetting bootstrap attempt counter failed ", err)
-				}
-			}
-
-			if bootstrapInProgress && !cycleSuccessful {
-				// Token/bootstrap-finalization failures count as a failed bootstrap cycle too.
-				attempts, exhausted, attemptsErr := registerHistoricalBootstrapAttemptFailure(fr.db)
-				if attemptsErr != nil {
-					glog.Error("FiatRatesDownloader: recording bootstrap attempt failure failed ", attemptsErr)
-				} else if exhausted {
-					cycleSuccessful = true
-					glog.Warningf("FiatRatesDownloader: bootstrap failed %d/%d times, stopping bootstrap retries", attempts, maxHistoricalBootstrapAttempts)
-				} else {
-					glog.Warningf("FiatRatesDownloader: bootstrap attempt %d/%d failed", attempts, maxHistoricalBootstrapAttempts)
-				}
-			}
-
-			if cycleSuccessful {
+			done, banned := fr.runHistoricalCycle(is)
+			if done {
 				lastHistoricalTickers = time.Now().UTC()
+			} else if banned {
+				// Cloudflare IP ban: do not re-probe the banned endpoint every poll
+				// interval. Back off; the next attempt resumes from the gap.
+				time.Sleep(historicalBanBackoff)
+				continue
+			}
+			// non-ban failure falls through to the poll-interval retry
+		}
+		time.Sleep(historicalPollInterval)
+	}
+}
+
+// runHistoricalCycle runs one daily historical update.
+func (fr *FiatRates) runHistoricalCycle(is *common.InternalState) (done bool, banned bool) {
+	bootstrapInProgress, _, bootstrapErr := historicalBootstrapInProgress(fr.db)
+	if bootstrapErr != nil {
+		glog.Error("FiatRatesDownloader: bootstrap state check error ", bootstrapErr)
+		return false, false
+	}
+
+	historicalTickersStart := time.Now()
+	err := fr.downloader.UpdateHistoricalTickers()
+	if err != nil {
+		fr.observeUpdateDuration("historical_tickers", "error", historicalTickersStart)
+		logFiatRatesDownloaderError("FiatRatesDownloader: UpdateHistoricalTickers error ", err)
+		ban := isCoingeckoCloudflareBanError(err)
+		if bootstrapInProgress {
+			// Bootstrap policy: count failed cycles and stop bootstrap mode after the
+			// configured limit so we do not retry full-history downloads forever.
+			attempts, exhausted, attemptsErr := registerHistoricalBootstrapAttemptFailure(fr.db)
+			if attemptsErr != nil {
+				glog.Error("FiatRatesDownloader: recording bootstrap attempt failure failed ", attemptsErr)
+			} else if exhausted {
+				glog.Warningf("FiatRatesDownloader: bootstrap failed %d/%d times, stopping bootstrap retries", attempts, maxHistoricalBootstrapAttempts)
+				// Advance the daily guard so we do not re-enter the historical block
+				// again in the same UTC day.
+				return true, ban
+			} else {
+				glog.Warningf("FiatRatesDownloader: bootstrap attempt %d/%d failed", attempts, maxHistoricalBootstrapAttempts)
+			}
+		}
+		// Base historical pass failed; skip token/bootstrap-completion handling for this cycle.
+		return false, ban
+	}
+
+	fr.observeUpdateDuration("historical_tickers", "success", historicalTickersStart)
+	loadDailyTickersStart := time.Now()
+	if err = fr.loadDailyTickers(); err != nil {
+		fr.observeUpdateDuration("load_daily_tickers", "error", loadDailyTickersStart)
+		// Cache refresh failure does not mean downloaded historical data is invalid;
+		// keep processing the cycle and rely on next runs to refresh in-memory cache.
+		glog.Error("FiatRatesDownloader: loadDailyTickers error ", err)
+	} else {
+		fr.observeUpdateDuration("load_daily_tickers", "success", loadDailyTickersStart)
+		ticker, found := fr.dailyTickers[fr.dailyTickersTo]
+		if !found || ticker == nil {
+			glog.Error("FiatRatesDownloader: dailyTickers not loaded")
+		} else {
+			glog.Infof("FiatRatesDownloader: UpdateHistoricalTickers finished, last ticker from %v", ticker.Timestamp)
+			fr.logTickersInfo()
+			if is != nil {
+				is.HistoricalFiatRatesTime = ticker.Timestamp
 			}
 		}
 	}
+
+	cycleSuccessful := true
+	if fr.downloadTokens {
+		historicalTokenTickersStart := time.Now()
+		tokErr := fr.downloader.UpdateHistoricalTokenTickers()
+		if tokErr != nil {
+			banned = banned || isCoingeckoCloudflareBanError(tokErr)
+			if bootstrapInProgress {
+				cycleSuccessful = false
+			}
+			if isCoingeckoHistoricalTokenUpdateInProgressError(tokErr) {
+				fr.observeUpdateDuration("historical_token_tickers", "skipped", historicalTokenTickersStart)
+				glog.Info("FiatRatesDownloader: UpdateHistoricalTokenTickers skipped, update already in progress")
+			} else {
+				fr.observeUpdateDuration("historical_token_tickers", "error", historicalTokenTickersStart)
+				logFiatRatesDownloaderError("FiatRatesDownloader: UpdateHistoricalTokenTickers error ", tokErr)
+			}
+		} else {
+			fr.observeUpdateDuration("historical_token_tickers", "success", historicalTokenTickersStart)
+			glog.Info("FiatRatesDownloader: UpdateHistoricalTokenTickers finished")
+			if is != nil {
+				is.HistoricalTokenFiatRatesTime = time.Now().UTC()
+			}
+		}
+	}
+
+	if bootstrapInProgress && cycleSuccessful {
+		// Bootstrap can be marked complete only after both base and token historical
+		// updates finished successfully in this cycle.
+		if err := fr.db.FiatRatesSetHistoricalBootstrapComplete(true); err != nil {
+			cycleSuccessful = false
+			glog.Error("FiatRatesDownloader: setting bootstrap completion failed ", err)
+		} else if err := resetHistoricalBootstrapAttempts(fr.db); err != nil {
+			cycleSuccessful = false
+			glog.Error("FiatRatesDownloader: resetting bootstrap attempt counter failed ", err)
+		}
+	}
+
+	if bootstrapInProgress && !cycleSuccessful {
+		// Token/bootstrap-finalization failures count as a failed bootstrap cycle too.
+		attempts, exhausted, attemptsErr := registerHistoricalBootstrapAttemptFailure(fr.db)
+		if attemptsErr != nil {
+			glog.Error("FiatRatesDownloader: recording bootstrap attempt failure failed ", attemptsErr)
+		} else if exhausted {
+			cycleSuccessful = true
+			glog.Warningf("FiatRatesDownloader: bootstrap failed %d/%d times, stopping bootstrap retries", attempts, maxHistoricalBootstrapAttempts)
+		} else {
+			glog.Warningf("FiatRatesDownloader: bootstrap attempt %d/%d failed", attempts, maxHistoricalBootstrapAttempts)
+		}
+	}
+
+	return cycleSuccessful, banned
 }

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -35,7 +36,7 @@ type RatesDownloaderInterface interface {
 	FiveMinutesTickers() (*[]common.CurrencyRatesTicker, error)
 	UpdateHistoricalTickers() error
 	UpdateHistoricalTokenTickers() error
-	ReconcileHistoricalRates(windowDays int, maxGapDays int) (int, error)
+	ReconcileHistoricalRates(windowDays int, maxGapDays int, stop <-chan os.Signal) (int, error)
 }
 
 const (
@@ -495,8 +496,10 @@ const historicalBanBackoff = 30 * time.Minute
 // missing historical fiat rates (interior holes and trailing gaps) within the reconcile
 // window. It is meant to run once, before the periodic downloader loops start, so the DB is
 // consistent and there is no concurrent Free-tier throttling. Honors the per-coin config
-// toggle and is a no-op when fiat rates are disabled.
-func (fr *FiatRates) ReconcileHistoricalRatesAtStartup() {
+// toggle and is a no-op when fiat rates are disabled. The stop channel (blockbook's
+// chanOsSignal, closed on shutdown) lets a SIGTERM mid-repair abort the pass promptly so
+// shutdown is not delayed by a long backfill.
+func (fr *FiatRates) ReconcileHistoricalRatesAtStartup(stop <-chan os.Signal) {
 	if !fr.Enabled || fr.downloader == nil {
 		return
 	}
@@ -512,7 +515,7 @@ func (fr *FiatRates) ReconcileHistoricalRatesAtStartup() {
 	}()
 	start := time.Now()
 	glog.Info("FiatRatesDownloader: starting historical rates reconciliation (startup self-healing)")
-	filled, err := fr.downloader.ReconcileHistoricalRates(reconcileWindowDays, reconcileMaxGapDays)
+	filled, err := fr.downloader.ReconcileHistoricalRates(reconcileWindowDays, reconcileMaxGapDays, stop)
 	if err != nil {
 		fr.observeUpdateDuration("reconcile", "error", start)
 		logFiatRatesDownloaderError("FiatRatesDownloader: reconciliation error ", err)

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -1,6 +1,7 @@
 package fiat
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,7 +37,7 @@ type RatesDownloaderInterface interface {
 	FiveMinutesTickers() (*[]common.CurrencyRatesTicker, error)
 	UpdateHistoricalTickers() error
 	UpdateHistoricalTokenTickers() error
-	ReconcileHistoricalRates(windowDays int, maxGapDays int, stop <-chan os.Signal) (int, error)
+	ReconcileHistoricalRates(ctx context.Context, windowDays int, maxGapDays int) (int, error)
 }
 
 const (
@@ -45,6 +46,10 @@ const (
 	// treated as a probable bug and reported instead of refetched.
 	reconcileWindowDays = 365
 	reconcileMaxGapDays = 90
+	// defaultReconcileMaxDuration is the wall-clock budget for the blocking startup
+	// reconciliation; once it elapses the pass aborts (persisting what it fetched) so a slow or
+	// throttling CDN can never stall startup. Overridable via reconcileHistoricalMaxMinutes.
+	defaultReconcileMaxDuration = 5 * time.Minute
 )
 
 // FiatRates is used to fetch and refresh fiat rates
@@ -58,6 +63,7 @@ type FiatRates struct {
 	downloader             RatesDownloaderInterface
 	downloadTokens         bool
 	reconcileAtStartup     bool
+	reconcileMaxDuration   time.Duration
 	provider               string
 	allowedVsCurrencies    string
 	mux                    sync.RWMutex
@@ -101,6 +107,9 @@ func NewFiatRates(db *db.RocksDB, config *common.Config, metrics *common.Metrics
 		// ReconcileHistoricalAtStartup toggles the blocking startup self-healing pass that
 		// repairs missing historical rates. Absent (nil) means enabled; set false to disable.
 		ReconcileHistoricalAtStartup *bool `json:"reconcileHistoricalAtStartup"`
+		// ReconcileHistoricalMaxMinutes caps the wall-clock time of that pass. Absent (nil) or
+		// <= 0 uses defaultReconcileMaxDuration.
+		ReconcileHistoricalMaxMinutes *int `json:"reconcileHistoricalMaxMinutes"`
 	}
 	rdParams := &fiatRatesParams{}
 	err := json.Unmarshal([]byte(config.FiatRatesParams), &rdParams)
@@ -120,6 +129,10 @@ func NewFiatRates(db *db.RocksDB, config *common.Config, metrics *common.Metrics
 	fr.callbackOnNewTicker = callback
 	fr.downloadTokens = rdParams.PlatformIdentifier != "" && rdParams.PlatformVsCurrency != ""
 	fr.reconcileAtStartup = rdParams.ReconcileHistoricalAtStartup == nil || *rdParams.ReconcileHistoricalAtStartup
+	fr.reconcileMaxDuration = defaultReconcileMaxDuration
+	if rdParams.ReconcileHistoricalMaxMinutes != nil && *rdParams.ReconcileHistoricalMaxMinutes > 0 {
+		fr.reconcileMaxDuration = time.Duration(*rdParams.ReconcileHistoricalMaxMinutes) * time.Minute
+	}
 	if fr.downloadTokens {
 		common.TickerRecalculateTokenRate = strings.ToLower(db.GetInternalState().CoinShortcut) != rdParams.PlatformVsCurrency
 		common.TickerTokenVsCurrency = rdParams.PlatformVsCurrency
@@ -514,8 +527,21 @@ func (fr *FiatRates) ReconcileHistoricalRatesAtStartup(stop <-chan os.Signal) {
 		}
 	}()
 	start := time.Now()
-	glog.Info("FiatRatesDownloader: starting historical rates reconciliation (startup self-healing)")
-	filled, err := fr.downloader.ReconcileHistoricalRates(reconcileWindowDays, reconcileMaxGapDays, stop)
+	// Bound the pass by both a wall-clock budget and the shutdown signal so a slow/throttling
+	// CDN can never stall startup and a SIGTERM aborts the repair promptly.
+	ctx, cancel := context.WithTimeout(context.Background(), fr.reconcileMaxDuration)
+	defer cancel()
+	if stop != nil {
+		go func() {
+			select {
+			case <-stop:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+	}
+	glog.Infof("FiatRatesDownloader: starting historical rates reconciliation (startup self-healing), budget %v", fr.reconcileMaxDuration)
+	filled, err := fr.downloader.ReconcileHistoricalRates(ctx, reconcileWindowDays, reconcileMaxGapDays)
 	if err != nil {
 		fr.observeUpdateDuration("reconcile", "error", start)
 		logFiatRatesDownloaderError("FiatRatesDownloader: reconciliation error ", err)

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -342,10 +342,18 @@ func (fr *FiatRates) GetTickersForTimestamps(timestamps []int64, vsCurrency stri
 	return &tickers, nil
 }
 func (fr *FiatRates) logTickersInfo() {
+	// Snapshot the cache fields under the lock: this runs on the historical goroutine while the
+	// current goroutine concurrently replaces the hourly/5-minute maps and their bounds under
+	// fr.mux. Read them all atomically, then format the log line outside the lock.
+	fr.mux.RLock()
+	dailyLen, dailyFrom, dailyTo := len(fr.dailyTickers), fr.dailyTickersFrom, fr.dailyTickersTo
+	hourlyLen, hourlyFrom, hourlyTo := len(fr.hourlyTickers), fr.hourlyTickersFrom, fr.hourlyTickersTo
+	fiveMinLen, fiveMinFrom, fiveMinTo := len(fr.fiveMinutesTickers), fr.fiveMinutesTickersFrom, fr.fiveMinutesTickersTo
+	fr.mux.RUnlock()
 	glog.Infof("fiat rates %s handler, %d (%s - %s) daily tickers, %d (%s - %s) hourly tickers, %d (%s - %s) 5 minute tickers", fr.provider,
-		len(fr.dailyTickers), time.Unix(fr.dailyTickersFrom, 0).Format("2006-01-02"), time.Unix(fr.dailyTickersTo, 0).Format("2006-01-02"),
-		len(fr.hourlyTickers), time.Unix(fr.hourlyTickersFrom, 0).Format("2006-01-02 15:04"), time.Unix(fr.hourlyTickersTo, 0).Format("2006-01-02 15:04"),
-		len(fr.fiveMinutesTickers), time.Unix(fr.fiveMinutesTickersFrom, 0).Format("2006-01-02 15:04"), time.Unix(fr.fiveMinutesTickersTo, 0).Format("2006-01-02 15:04"))
+		dailyLen, time.Unix(dailyFrom, 0).Format("2006-01-02"), time.Unix(dailyTo, 0).Format("2006-01-02"),
+		hourlyLen, time.Unix(hourlyFrom, 0).Format("2006-01-02 15:04"), time.Unix(hourlyTo, 0).Format("2006-01-02 15:04"),
+		fiveMinLen, time.Unix(fiveMinFrom, 0).Format("2006-01-02 15:04"), time.Unix(fiveMinTo, 0).Format("2006-01-02 15:04"))
 }
 
 func roundTimeUnix(t time.Time, granularity int64) int64 {
@@ -700,7 +708,9 @@ func (fr *FiatRates) runHistoricalCycle(is *common.InternalState) (done bool, ba
 		glog.Error("FiatRatesDownloader: loadDailyTickers error ", err)
 	} else {
 		fr.observeUpdateDuration("load_daily_tickers", "success", loadDailyTickersStart)
+		fr.mux.RLock()
 		ticker, found := fr.dailyTickers[fr.dailyTickersTo]
+		fr.mux.RUnlock()
 		if !found || ticker == nil {
 			glog.Error("FiatRatesDownloader: dailyTickers not loaded")
 		} else {

--- a/fiat/fiat_rates.go
+++ b/fiat/fiat_rates.go
@@ -470,10 +470,6 @@ func logFiatRatesDownloaderError(message string, err error) {
 		glog.Errorf("%sno data from provider", message)
 		return
 	}
-	if isCoingeckoThrottleRetriesExhaustedError(err) {
-		glog.Warning(message, err)
-		return
-	}
 	glog.Error(message, err)
 }
 

--- a/fiat/fiat_rates_test.go
+++ b/fiat/fiat_rates_test.go
@@ -569,6 +569,95 @@ func TestGetTickersForTimestamps_ConcurrentReadersAndWriters(t *testing.T) {
 	}
 }
 
+// TestLogTickersInfo_ConcurrentWithCacheWriters reproduces the data race between the historical
+// goroutine (which calls logTickersInfo after a daily cycle) and the current goroutine (which
+// replaces the hourly/5-minute ticker maps and their bounds under fr.mux). Before logTickersInfo
+// took the read lock this failed under -race. It mirrors the production split introduced by
+// RunDownloader starting runHistoricalLoop and runCurrentLoop concurrently.
+func TestLogTickersInfo_ConcurrentWithCacheWriters(t *testing.T) {
+	fr := &FiatRates{Enabled: true, provider: "coingecko"}
+
+	const (
+		writers      = 2
+		loggers      = 4
+		testDuration = 300 * time.Millisecond
+		waitTimeout  = 3 * time.Second
+	)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// writeCacheState mimics the locked sections of setHourlyTickers/setFiveMinutesTickers/
+	// setCurrentTicker: it replaces the map headers and the int64 bounds under fr.mux.
+	writeCacheState := func(counter int64) {
+		fr.mux.Lock()
+		fr.hourlyTickers = map[int64]*common.CurrencyRatesTicker{
+			3600 + counter: {Timestamp: time.Unix(3600+counter, 0).UTC()},
+		}
+		fr.hourlyTickersFrom = 3600 + counter
+		fr.hourlyTickersTo = 7200 + counter
+		fr.fiveMinutesTickers = map[int64]*common.CurrencyRatesTicker{
+			600 + counter: {Timestamp: time.Unix(600+counter, 0).UTC()},
+		}
+		fr.fiveMinutesTickersFrom = 600 + counter
+		fr.fiveMinutesTickersTo = 900 + counter
+		fr.dailyTickers = map[int64]*common.CurrencyRatesTicker{
+			86400 + counter: {Timestamp: time.Unix(86400+counter, 0).UTC()},
+		}
+		fr.dailyTickersFrom = 86400 + counter
+		fr.dailyTickersTo = 172800 + counter
+		fr.mux.Unlock()
+	}
+
+	writeCacheState(0)
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			counter := int64(seed)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				writeCacheState(counter)
+				counter++
+			}
+		}(w)
+	}
+
+	for l := 0; l < loggers; l++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				fr.logTickersInfo()
+			}
+		}()
+	}
+
+	time.Sleep(testDuration)
+	close(stop)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(waitTimeout):
+		t.Fatal("concurrent logTickersInfo/writers did not finish in time")
+	}
+}
+
 func TestGetTokenTickersForTimestamps_QueriesUniqueSortedTimestamps(t *testing.T) {
 	originalFindTickers := fiatRatesFindTickers
 	defer func() {

--- a/fiat/fiat_rates_test.go
+++ b/fiat/fiat_rates_test.go
@@ -89,16 +89,7 @@ func getFiatRatesMockData(name string) (string, error) {
 	return string(b), nil
 }
 
-func resetCoingeckoTestCaches() {
-	vsCurrencies = nil
-	platformIds = nil
-	platformIdsToTokens = nil
-}
-
 func TestFiatRates(t *testing.T) {
-	resetCoingeckoTestCaches()
-	t.Cleanup(resetCoingeckoTestCaches)
-
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
 		var mockData string
@@ -306,9 +297,6 @@ func TestFiatRates(t *testing.T) {
 }
 
 func TestFiatRatesTronCurrentTickers_PreserveBase58TokenAddress(t *testing.T) {
-	resetCoingeckoTestCaches()
-	t.Cleanup(resetCoingeckoTestCaches)
-
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
 		var mockData string


### PR DESCRIPTION
### Summary

Reworks CoinGecko fiat-rate fetching to be resilient and self-healing. Two problems motivated this: the Free tier is heavily rate-limited, and a blockbook instance can start with gaps in its historical rates (a long trailing gap after downtime, or interior holes). Previously the Trezor CDN was used only for from-scratch bootstrap, so any later gap was refetched through the Free tier — slowly, and competing with the chain-tip updates.

The branch (a) makes throttled fetching wait-and-retry instead of giving up, (b) routes all high-volume historical backfill to the no-rate-limit CDN while leaving only the chain tip (≤1 day) on the Free tier, and (c) adds a blocking, at-startup self-healing pass that detects and repairs missing daily rates before the periodic downloader loops start.

### Free-plan throttling resilience

- Detect throttling by HTTP 429 / `Retry-After` and Cloudflare 1015 HTML ban bodies.
- Pace free/keyless requests at 10 req/min; keep bootstrap CDN requests on the faster local interval.
- Replace capped retries with retry-until-success backoff honoring `Retry-After`, behind a shared throttle window across all downloader requests.
- Prioritize current/high-granularity requests over historical/token backfill while throttled.
- Run current-rate and historical-rate fetching in separate goroutines.
- Move list/token caches onto the downloader instance behind a mutex; make token-update state race-safe.

### CDN routing (Free tier only for the chain tip)

- Resolve a per-series fetch range from the gap: `1 day` → tip (Free tier), `2..365 days` → backfill, `> 365` → capped at 365.
- Route tip fetches to the Free/Pro endpoint and everything larger to the CDN, so bulk backfill never touches the rate-limited path.

### Startup self-healing reconciliation

A blocking pass that runs once RocksDB is initialized, before the periodic loops, so the DB is consistent and there is no Free-tier contention.

- **Stage 1 (cheap, key-only scan):** compute which whole days are missing within the 365-day window. Zero missing → returns immediately with no network requests (the healthy common case). `≥ 90` missing → reported as `gap_too_large` and skipped (a months-long gap signals a bug/misconfig, not routine catch-up).
- **Stage 2 (bounded fetch):** fetch only the missing-day span from the CDN and fill only those days (interior holes and trailing gaps), leaving existing records untouched. Write set is bounded by the missing-day count regardless of series count.
- Repairs the base coin across every vs-currency plus every token.
- Crash-safe and idempotent: partial progress is persisted, so an interrupted run resumes from the remaining gap on the next startup.
- A panic in reconciliation can never brick startup (recovered and logged).

### Cancellation and wall-clock budget

- The pass is bounded by a `context.Context` carrying both the shutdown signal (`chanOsSignal`) and a wall-clock budget, threaded through the whole fetch path.
- A `SIGTERM` mid-repair aborts promptly — even while a single request is stuck retrying a 429.
- A persistently slow/throttling CDN can no longer stall startup: once the budget elapses the pass aborts, persists what it fetched, and lets blockbook come up.
- Steady-state loops pass `context.Background()` and keep their retry-forever behavior unchanged.

### Configuration

- `reconcileHistoricalAtStartup` (bool, default enabled) — toggle the startup pass per coin.
- `reconcileHistoricalMaxMinutes` (int, default 5) — wall-clock budget for the pass.

### Observability

- New counters: `fiat_rates_fetched_units_total` and `fiat_rates_fetched_tokens_total` (by phase: tip / backfill / bootstrap / reconcile), and `fiat_rates_unable_total` (by phase and reason: `gap_too_large`, `fetch_failed`, `provider_banned`, `no_base_ticker`, `budget_exhausted`).
- New Grafana "Fiat Rates" dashboard section: chain-tip fetches, backfill fetches, reconciliation, and unable-to-fetch by reason.

### Tests

- Expanded `fiat/coingecko_test.go`: 429/Retry-After detection, request pacing, shared throttle window, priority yielding, retry-until-success historical/token updates, and bootstrap CDN pacing.
- CDN routing: range resolution and per-range source-URL selection.
- Reconciliation: interior-hole repair (base + token, present days untouched), healthy DB / young DB make no requests, `gap_too_large` skips fetching, no-CDN no-op, cancelled-context aborts before any fetch, and budget timeout aborts mid-backfill without error.
