### PR TITLE
fix(eth): keep alt-mempool txs a private relay stops surfacing until timeout

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,16 +25,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Python dependencies
-        run: |
-          rm -rf .python-deps
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --disable-pip-version-check --quiet --target .python-deps -r .github/requirements.txt
-
-      - name: Validate Grafana dashboard sources
-        run: |
-          PYTHONPATH=.python-deps python3 contrib/scripts/render_grafana_test.py
-          PYTHONPATH=.python-deps python3 contrib/scripts/render_grafana.py --check
-
       - name: Run unit tests
         env:
           BB_BUILD_ENV: dev
@@ -84,10 +74,14 @@ jobs:
           BB_BUILD_ENV: dev
         run: make test-integration ARGS="-v"
 
-  backend-artifact-lint:
-    name: Backend Artifact Lint
-    # Pure static analysis of configs/coins/*.json: no secrets, no backend
-    # access, safe to run for fork PRs on an ephemeral GitHub-hosted runner.
+  lint:
+    name: Lint
+    # Pure static analysis of configs/ (Grafana dashboards + coin backend
+    # artifacts): no secrets, no backend access, safe to run for fork PRs on an
+    # ephemeral GitHub-hosted runner. Unlike unit-tests (self-hosted, skipped for
+    # fork PRs), this job runs for forks too, so dashboard/artifact regressions
+    # are caught on every PR. The only third-party dependency is the pinned
+    # PyYAML used by the Grafana renderer.
     runs-on: ubuntu-latest
 
     steps:
@@ -95,6 +89,16 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      - name: Install Python dependencies
+        run: |
+          rm -rf .python-deps
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --disable-pip-version-check --quiet --target .python-deps -r .github/requirements.txt
+
+      - name: Validate Grafana dashboard sources
+        run: |
+          PYTHONPATH=.python-deps python3 contrib/scripts/render_grafana_test.py
+          PYTHONPATH=.python-deps python3 contrib/scripts/render_grafana.py --check
 
       - name: Validate backend artifact sources
         run: python3 ./.github/scripts/validate_backend_artifacts.py

--- a/bchain/coins/eth/alternativesendtx.go
+++ b/bchain/coins/eth/alternativesendtx.go
@@ -223,25 +223,40 @@ func (p *AlternativeSendTxProvider) reconcileMempoolTxs() {
 			}
 			p.observeMempoolReconciliation("provider_error")
 			continue
-		} else if !known {
-			p.observeMempoolReconciliation("provider_missing")
-			// Blink-style private providers return empty once a tx is no longer retained.
-			p.removeMempoolTx(tx.txid)
-			continue
-		} else if mined {
+		}
+		if mined {
 			p.observeMempoolReconciliation("mined")
 			p.removeMempoolTx(tx.txid)
 			continue
 		}
 
-		// The provider still reports the transaction as pending. If a different transaction has
-		// already consumed its nonce (e.g. a replacement submitted outside Blockbook), it can never
-		// be mined, so evict it deterministically instead of waiting for the timeout. Only nonces
-		// strictly below the confirmed account nonce are treated as superseded; equal or higher
-		// nonces are still mineable (the next tx, or a gap waiting to be filled) and are left intact.
+		// The provider answered without error and the tx is not mined: it is either still reported as
+		// pending (known) or no longer surfaced by eth_getTransactionByHash (!known). If a different
+		// transaction has already consumed its nonce (e.g. a replacement submitted outside Blockbook),
+		// it can never be mined, so evict it deterministically instead of waiting for the timeout -
+		// regardless of whether the provider still surfaces it, because a spent nonce is a positive,
+		// irreversible on-chain fact. Only nonces strictly below the confirmed account nonce are
+		// treated as superseded; equal or higher nonces are still mineable (the next tx, or a gap
+		// waiting to be filled) and are left intact.
 		if p.transactionSupersededByNonce(tx.tx.tx, confirmedNonces, confirmedNonceFailed) {
 			p.observeMempoolReconciliation("nonce_superseded")
 			p.removeMempoolTx(tx.txid)
+			continue
+		}
+
+		if !known {
+			// A null/empty eth_getTransactionByHash is NOT authoritative proof the tx is gone:
+			// Blink-style private/MEV relays stop surfacing a still-pending, still-mineable tx via
+			// eth_getTransactionByHash while it stays broadcast. Evicting on a single empty probe
+			// deleted the tx from both sender and recipient ~1-2 minutes after send, even though it
+			// could still be mined. Defer eviction to the absolute cache timeout instead; mined and
+			// nonce_superseded above remain the only deterministic early evictions.
+			if timedOut {
+				p.observeMempoolReconciliation("provider_missing")
+				p.removeMempoolTx(tx.txid)
+				continue
+			}
+			p.observeMempoolReconciliation("provider_missing_pending")
 			continue
 		}
 

--- a/bchain/coins/eth/alternativesendtx.go
+++ b/bchain/coins/eth/alternativesendtx.go
@@ -117,9 +117,11 @@ func (p *AlternativeSendTxProvider) handleMempoolTransaction(txid string) (strin
 	p.mempoolTxsMux.Lock()
 	// remove potential RBF transactions - with equal from and nonce
 	var rbfTxid string
+	var rbfTime uint32
 	for rbf, storedTx := range p.mempoolTxs {
 		if storedTx.tx.From == tx.From && storedTx.tx.AccountNonce == tx.AccountNonce {
 			rbfTxid = rbf
+			rbfTime = storedTx.time
 			break
 		}
 	}
@@ -128,6 +130,10 @@ func (p *AlternativeSendTxProvider) handleMempoolTransaction(txid string) (strin
 
 	if rbfTxid != "" {
 		glog.Infof("eth_sendRawTransaction replacing txid %s by %s", rbfTxid, txid)
+		// the replaced entry leaves the cache by fee-replacement rather than reconciliation; record the
+		// exit reason and its residence so the lifecycle metrics account for every way an entry leaves.
+		p.observeMempoolReconciliation("rbf_replaced")
+		p.observeMempoolTxResidence("rbf_replaced", rbfTime)
 		if p.removeTransactionFromMempool != nil {
 			p.removeTransactionFromMempool(rbfTxid)
 		}
@@ -158,6 +164,11 @@ func (p *AlternativeSendTxProvider) GetTransaction(txid string) (*bchain.RpcTran
 			p.mempoolTxsMux.Lock()
 			delete(p.mempoolTxs, txid)
 			p.mempoolTxsMux.Unlock()
+			// the same staleness timeout the reconcile loop applies, just reached on the read path
+			// first; record it so the timeout counter and residence histogram do not undercount
+			// entries read after expiry but before the next reconcile cycle evicts them.
+			p.observeMempoolReconciliation("timeout")
+			p.observeMempoolTxResidence("timeout", storedTx.time)
 			return nil, false
 		}
 		return storedTx.tx, true
@@ -217,16 +228,14 @@ func (p *AlternativeSendTxProvider) reconcileMempoolTxs() {
 		if err != nil {
 			glog.Warningf("eth_getTransactionByHash from alternative provider failed for %s: %v", tx.txid, err)
 			if timedOut {
-				p.observeMempoolReconciliation("timeout")
-				p.removeMempoolTx(tx.txid)
+				p.evictMempoolTx("timeout", tx.txid, tx.tx.time)
 				continue
 			}
 			p.observeMempoolReconciliation("provider_error")
 			continue
 		}
 		if mined {
-			p.observeMempoolReconciliation("mined")
-			p.removeMempoolTx(tx.txid)
+			p.evictMempoolTx("mined", tx.txid, tx.tx.time)
 			continue
 		}
 
@@ -239,8 +248,7 @@ func (p *AlternativeSendTxProvider) reconcileMempoolTxs() {
 		// treated as superseded; equal or higher nonces are still mineable (the next tx, or a gap
 		// waiting to be filled) and are left intact.
 		if p.transactionSupersededByNonce(tx.tx.tx, confirmedNonces, confirmedNonceFailed) {
-			p.observeMempoolReconciliation("nonce_superseded")
-			p.removeMempoolTx(tx.txid)
+			p.evictMempoolTx("nonce_superseded", tx.txid, tx.tx.time)
 			continue
 		}
 
@@ -252,8 +260,7 @@ func (p *AlternativeSendTxProvider) reconcileMempoolTxs() {
 			// could still be mined. Defer eviction to the absolute cache timeout instead; mined and
 			// nonce_superseded above remain the only deterministic early evictions.
 			if timedOut {
-				p.observeMempoolReconciliation("provider_missing")
-				p.removeMempoolTx(tx.txid)
+				p.evictMempoolTx("provider_missing", tx.txid, tx.tx.time)
 				continue
 			}
 			p.observeMempoolReconciliation("provider_missing_pending")
@@ -261,12 +268,16 @@ func (p *AlternativeSendTxProvider) reconcileMempoolTxs() {
 		}
 
 		if timedOut {
-			p.observeMempoolReconciliation("timeout")
-			p.removeMempoolTx(tx.txid)
+			p.evictMempoolTx("timeout", tx.txid, tx.tx.time)
 			continue
 		}
 		p.observeMempoolReconciliation("kept")
 	}
+
+	p.mempoolTxsMux.Lock()
+	size := len(p.mempoolTxs)
+	p.mempoolTxsMux.Unlock()
+	p.setMempoolCacheSize(size)
 }
 
 func (p *AlternativeSendTxProvider) observeMempoolReconciliation(action string) {
@@ -274,6 +285,39 @@ func (p *AlternativeSendTxProvider) observeMempoolReconciliation(action string) 
 		return
 	}
 	p.metrics.EthAlternativeMempoolEvents.With(common.Labels{"action": action}).Inc()
+}
+
+// evictMempoolTx records a terminal reconcile decision and removes the cache entry. It counts the
+// decision and observes the entry's residence (how long it lived before this eviction reason fired),
+// so the eviction rate and the per-reason lifetime distribution stay consistent. Decisions that keep
+// an entry for a later cycle use observeMempoolReconciliation directly instead.
+func (p *AlternativeSendTxProvider) evictMempoolTx(action, txid string, addedUnix uint32) {
+	p.observeMempoolReconciliation(action)
+	p.observeMempoolTxResidence(action, addedUnix)
+	p.removeMempoolTx(txid)
+}
+
+// observeMempoolTxResidence records the age of a cache entry (seconds since it was broadcast) at the
+// moment it is evicted, labeled by the deciding action. This makes the non-deterministic lifetime of
+// an unconfirmed tx visible per eviction reason - e.g. provider_missing clustering near the timeout
+// rather than at ~1-2 min would show a premature-eviction regression like the one #1573 describes.
+func (p *AlternativeSendTxProvider) observeMempoolTxResidence(action string, addedUnix uint32) {
+	if p.metrics == nil || p.metrics.EthAlternativeMempoolTxResidence == nil {
+		return
+	}
+	residence := time.Since(time.Unix(int64(addedUnix), 0)).Seconds()
+	if residence < 0 {
+		residence = 0
+	}
+	p.metrics.EthAlternativeMempoolTxResidence.With(common.Labels{"action": action}).Observe(residence)
+}
+
+// setMempoolCacheSize records the current depth of the alternative send-tx mempool cache.
+func (p *AlternativeSendTxProvider) setMempoolCacheSize(size int) {
+	if p.metrics == nil || p.metrics.EthAlternativeMempoolCacheSize == nil {
+		return
+	}
+	p.metrics.EthAlternativeMempoolCacheSize.Set(float64(size))
 }
 
 // transactionSupersededByNonce reports whether a different transaction has already consumed the

--- a/bchain/coins/eth/alternativesendtx_test.go
+++ b/bchain/coins/eth/alternativesendtx_test.go
@@ -91,7 +91,10 @@ func TestAlternativeSendTxProviderReconcileLivenessOutcomes(t *testing.T) {
 		response    string
 		wantRemoved bool
 	}{
-		{"dropped tx (provider returns empty) is removed", `{"jsonrpc":"2.0","id":1,"result":null}`, true},
+		// A provider that returns empty is NOT authoritative proof the tx is gone (Blink-style
+		// private/MEV relays stop surfacing a still-pending tx via eth_getTransactionByHash). The tx
+		// is kept until the cache timeout - here mempoolTxsTimeout is time.Hour, so it stays.
+		{"empty provider result is kept until timeout", `{"jsonrpc":"2.0","id":1,"result":null}`, false},
 		{"mined tx is removed", minedTxResponse, true},
 		{"known pending tx is kept", testAlternativeKnownTxResponse, false},
 		{"tx is kept on provider error", `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"temporary failure"}}`, false},
@@ -122,6 +125,14 @@ func TestAlternativeSendTxProviderReconcileTimeoutEviction(t *testing.T) {
 			name: "provider error and timed out is removed",
 			serverURL: func(t *testing.T) string {
 				return newAlternativeTxProviderTestServer(t, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"temporary failure"}}`).URL
+			},
+		},
+		{
+			// an empty provider result is kept while fresh (see ReconcileLivenessOutcomes) but the
+			// timeout safety net still evicts it once mempoolTxsTimeout has elapsed
+			name: "empty provider result and timed out is removed",
+			serverURL: func(t *testing.T) string {
+				return newAlternativeTxProviderTestServer(t, `{"jsonrpc":"2.0","id":1,"result":null}`).URL
 			},
 		},
 		{
@@ -304,6 +315,23 @@ func TestAlternativeSendTxProviderReconcileNonceOutcomes(t *testing.T) {
 			assertReconcileOutcome(t, provider, removed, tt.wantRemoved)
 		})
 	}
+}
+
+func TestAlternativeSendTxProviderReconcileEvictsSupersededMissingTx(t *testing.T) {
+	// The provider no longer surfaces the tx via eth_getTransactionByHash (returns empty), so it is
+	// not evicted on the "missing" path alone. But the confirmed account nonce (0x2) is strictly
+	// above the cached tx nonce (0x1): the nonce is spent on-chain, so the tx can never be mined and
+	// is evicted deterministically even though it is well within the (1h) cache timeout.
+	server := newMethodAwareTxProviderTestServer(t, map[string]string{
+		"eth_getTransactionByHash": `{"jsonrpc":"2.0","id":1,"result":null}`,
+		"eth_getTransactionCount":  nonceCountResponse("0x2"),
+	})
+	var removed string
+	provider := newTestAlternativeSendTxProvider(server.URL, &removed)
+
+	provider.reconcileMempoolTxs()
+
+	assertReconcileOutcome(t, provider, removed, true)
 }
 
 func TestAlternativeSendTxProviderReconcileUsesLowestConfirmedNonce(t *testing.T) {

--- a/bchain/coins/eth/alternativesendtx_test.go
+++ b/bchain/coins/eth/alternativesendtx_test.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/common"
 )
 
 const testAlternativeTxID = "0x1111111111111111111111111111111111111111111111111111111111111111"
@@ -429,6 +431,212 @@ func TestAlternativeSendTxProviderReconcileMemoizesConfirmedNoncePerSender(t *te
 	}
 	if _, found := provider.mempoolTxs[testAlternativeSecondTxID]; !found {
 		t.Fatal("transaction ahead of the confirmed nonce was incorrectly evicted")
+	}
+}
+
+// newReconcileTestMetrics builds a common.Metrics holding only the collectors reconcileMempoolTxs
+// touches, left unregistered so each test owns fresh collectors and testutil can read them directly.
+func newReconcileTestMetrics() *common.Metrics {
+	return &common.Metrics{
+		EthAlternativeMempoolEvents: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_alt_mempool_events_total"}, []string{"action"}),
+		EthAlternativeMempoolTxResidence: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Name: "test_alt_mempool_tx_residence_seconds", Buckets: []float64{30, 60, 120, 300, 600}}, []string{"action"}),
+		EthAlternativeMempoolCacheSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{Name: "test_alt_mempool_cache_size"}),
+	}
+}
+
+// The readers below register a collector in a throwaway registry and gather it, so a test can read
+// metric values without pulling in the prometheus/testutil dependency (and its transitive modules).
+
+// gaugeValue reads the current value of a single gauge.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(g); err != nil {
+		t.Fatalf("register gauge: %v", err)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather gauge: %v", err)
+	}
+	for _, mf := range families {
+		for _, m := range mf.GetMetric() {
+			return m.GetGauge().GetValue()
+		}
+	}
+	return 0
+}
+
+// counterValue reads the value of the counter series carrying action=action.
+func counterValue(t *testing.T, cv *prometheus.CounterVec, action string) float64 {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(cv); err != nil {
+		t.Fatalf("register counter: %v", err)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather counter: %v", err)
+	}
+	for _, mf := range families {
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "action" && lp.GetValue() == action {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// residenceSampleCount reports how many residence observations were recorded under action=action.
+func residenceSampleCount(t *testing.T, h *prometheus.HistogramVec, action string) uint64 {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(h); err != nil {
+		t.Fatalf("register residence histogram: %v", err)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather residence histogram: %v", err)
+	}
+	for _, mf := range families {
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "action" && lp.GetValue() == action {
+					return m.GetHistogram().GetSampleCount()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// TestAlternativeSendTxProviderReconcileObservesMetrics asserts the reconcile flow feeds the two
+// metrics added to make it transparent: the per-action tx-lifetime histogram (observed only on
+// eviction, under the same action label as the decision counter) and the cache-depth gauge.
+func TestAlternativeSendTxProviderReconcileObservesMetrics(t *testing.T) {
+	const minedTxResponse = `{"jsonrpc":"2.0","id":1,"result":{"hash":"` + testAlternativeTxID + `","from":"0x2222222222222222222222222222222222222222","nonce":"0x1","gas":"0x5208","value":"0x0","input":"0x","to":"0x3333333333333333333333333333333333333333","blockNumber":"0x1"}}`
+
+	t.Run("eviction records residence and zeroes the cache-depth gauge", func(t *testing.T) {
+		server := newAlternativeTxProviderTestServer(t, minedTxResponse)
+		var removed string
+		provider := newTestAlternativeSendTxProvider(server.URL, &removed)
+		provider.metrics = newReconcileTestMetrics()
+
+		provider.reconcileMempoolTxs()
+
+		if got := counterValue(t, provider.metrics.EthAlternativeMempoolEvents, "mined"); got != 1 {
+			t.Errorf("mined reconciliation events = %v, want 1", got)
+		}
+		// the lifetime histogram records exactly one sample, under the same action label as the counter
+		if got := residenceSampleCount(t, provider.metrics.EthAlternativeMempoolTxResidence, "mined"); got != 1 {
+			t.Errorf("mined residence sample count = %d, want 1", got)
+		}
+		// the only cached tx was evicted, so the depth gauge settles at 0
+		if got := gaugeValue(t, provider.metrics.EthAlternativeMempoolCacheSize); got != 0 {
+			t.Errorf("cache depth gauge = %v, want 0 after eviction", got)
+		}
+	})
+
+	t.Run("a kept tx records no residence and keeps the gauge at one", func(t *testing.T) {
+		server := newAlternativeTxProviderTestServer(t, testAlternativeKnownTxResponse)
+		var removed string
+		provider := newTestAlternativeSendTxProvider(server.URL, &removed)
+		provider.metrics = newReconcileTestMetrics()
+
+		provider.reconcileMempoolTxs()
+
+		if got := counterValue(t, provider.metrics.EthAlternativeMempoolEvents, "kept"); got != 1 {
+			t.Errorf("kept reconciliation events = %v, want 1", got)
+		}
+		// nothing was evicted, so no lifetime sample must be recorded for any terminal action
+		for _, action := range []string{"mined", "nonce_superseded", "provider_missing", "timeout"} {
+			if got := residenceSampleCount(t, provider.metrics.EthAlternativeMempoolTxResidence, action); got != 0 {
+				t.Errorf("residence sample count for %q = %d, want 0 when nothing is evicted", action, got)
+			}
+		}
+		if got := gaugeValue(t, provider.metrics.EthAlternativeMempoolCacheSize); got != 1 {
+			t.Errorf("cache depth gauge = %v, want 1 with one tx retained", got)
+		}
+	})
+}
+
+func TestAlternativeSendTxProviderGetTransactionTimeoutObservesMetrics(t *testing.T) {
+	// a cached entry past mempoolTxsTimeout, read before the reconcile loop reaches it, is evicted on
+	// the read path - and that eviction must be counted and have its residence observed just like the
+	// reconcile-loop timeout, otherwise the timeout series is undercounted.
+	provider := &AlternativeSendTxProvider{
+		fetchMempoolTx:    true,
+		mempoolTxsTimeout: time.Minute,
+		mempoolTxs: map[string]storedTx{
+			testAlternativeTxID: {
+				tx:   &bchain.RpcTransaction{Hash: testAlternativeTxID},
+				time: uint32(time.Now().Add(-2 * time.Minute).Unix()),
+			},
+		},
+		metrics: newReconcileTestMetrics(),
+	}
+
+	if tx, found := provider.GetTransaction(testAlternativeTxID); found || tx != nil {
+		t.Fatalf("timed-out tx: got (tx=%v found=%v), want (nil false)", tx, found)
+	}
+	if _, stillCached := provider.mempoolTxs[testAlternativeTxID]; stillCached {
+		t.Fatal("timed-out tx was not evicted from the cache")
+	}
+	if got := counterValue(t, provider.metrics.EthAlternativeMempoolEvents, "timeout"); got != 1 {
+		t.Errorf("timeout reconciliation events = %v, want 1", got)
+	}
+	if got := residenceSampleCount(t, provider.metrics.EthAlternativeMempoolTxResidence, "timeout"); got != 1 {
+		t.Errorf("timeout residence sample count = %d, want 1", got)
+	}
+}
+
+func TestAlternativeSendTxProviderRBFReplacementObservesMetrics(t *testing.T) {
+	// handleMempoolTransaction replaces a cached entry sharing the incoming tx's sender+nonce. The
+	// replaced entry leaves the cache by fee-replacement, so that exit must be counted and its residence
+	// observed, not silently dropped.
+	server := newAlternativeTxProviderTestServer(t, testAlternativeKnownTxResponse)
+	provider := &AlternativeSendTxProvider{
+		urls:              []string{server.URL},
+		fetchMempoolTx:    true,
+		onlyAlternative:   true,
+		rpcTimeout:        time.Second,
+		mempoolTxsTimeout: time.Hour,
+		mempoolTxs: map[string]storedTx{
+			// the older tx that the incoming testAlternativeTxID (same sender 0x2222, nonce 0x1) replaces
+			testAlternativeSecondTxID: {
+				tx: &bchain.RpcTransaction{
+					Hash:         testAlternativeSecondTxID,
+					From:         "0x2222222222222222222222222222222222222222",
+					AccountNonce: "0x1",
+				},
+				time: uint32(time.Now().Add(-3 * time.Minute).Unix()),
+			},
+		},
+		metrics: newReconcileTestMetrics(),
+	}
+	var removed string
+	provider.removeTransactionFromMempool = func(txid string) {
+		removed = txid
+		provider.RemoveTransaction(txid)
+	}
+
+	if _, err := provider.handleMempoolTransaction(testAlternativeTxID); err != nil {
+		t.Fatalf("handleMempoolTransaction: %v", err)
+	}
+
+	if removed != testAlternativeSecondTxID {
+		t.Fatalf("replaced txid = %q, want %q", removed, testAlternativeSecondTxID)
+	}
+	if got := counterValue(t, provider.metrics.EthAlternativeMempoolEvents, "rbf_replaced"); got != 1 {
+		t.Errorf("rbf_replaced events = %v, want 1", got)
+	}
+	if got := residenceSampleCount(t, provider.metrics.EthAlternativeMempoolTxResidence, "rbf_replaced"); got != 1 {
+		t.Errorf("rbf_replaced residence sample count = %d, want 1", got)
 	}
 }
 

--- a/common/metrics.go
+++ b/common/metrics.go
@@ -65,6 +65,8 @@ type Metrics struct {
 	ExplorerViews                     *prometheus.CounterVec   `metric:"explorer_views"`
 	MempoolSize                       prometheus.Gauge         `metric:"mempool_size"`
 	EthAlternativeMempoolEvents       *prometheus.CounterVec   `metric:"eth_alternative_mempool_reconciliation_events_total"`
+	EthAlternativeMempoolTxResidence  *prometheus.HistogramVec `metric:"eth_alternative_mempool_tx_residence_seconds"`
+	EthAlternativeMempoolCacheSize    prometheus.Gauge         `metric:"eth_alternative_mempool_cache_size"`
 	EstimatedFee                      *prometheus.GaugeVec     `metric:"estimated_fee"`
 	AvgBlockPeriod                    prometheus.Gauge         `metric:"avg_block_period"`
 	SyncBlockStats                    *prometheus.GaugeVec     `metric:"sync_block_stats"`

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -69,6 +69,7 @@
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"base\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",

--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -175,11 +175,28 @@ panels:
         legend: '{{coin}} - {{instance}}'
   sync.eth_alternative_mempool_reconciliation:
     title: Alternative mempool reconciliation
-    description: Decisions made while reconciling alternative-provider-only send-tx cache entries; provider_missing, mined, nonce_superseded and timeout remove entries, while provider_error keeps them for retry.
+    description: Decisions over the alternative-provider-only send-tx cache lifecycle (events/min by action). mined, nonce_superseded, provider_missing, timeout (reconcile loop or read-path expiry) and rbf_replaced remove an entry; provider_error and provider_missing_pending keep an unconfirmed entry for a later cycle (a private/MEV relay no longer surfacing a still-mineable tx); skipped_fresh and kept retain a still-young or still-pending entry.
     queries:
       actions:
         promql: sum(rate({{name:eth_alternative_mempool_reconciliation_events_total}}{job="blockbook", coin="$coin"}[$__rate_interval])) by (action) * 60
         legend: '{{action}}/min'
+  sync.eth_alternative_mempool_cache_size:
+    title: Alternative mempool cache depth
+    description: Transactions currently held in the alternative-provider-only send-tx cache, sampled at the end of each reconcile cycle. It should track the number of in-flight unconfirmed sends; a steady climb means entries are added faster than they are mined or evicted.
+    queries:
+      size:
+        promql: '{{name:eth_alternative_mempool_cache_size}}{job="blockbook", coin="$coin"}'
+        legend: '{{coin}} - {{instance}}'
+  sync.eth_alternative_mempool_tx_residence:
+    title: Alternative mempool tx lifetime by eviction reason
+    description: p50/p95 of how long an alternative send-tx cache entry survives before each eviction reason fires. provider_missing and timeout sitting near the cache timeout is healthy; provider_missing collapsing toward ~1-2 min would surface the premature-eviction regression from #1573, while mined shows how quickly relays actually confirm.
+    queries:
+      p50:
+        promql: histogram_quantile(0.5, sum(rate({{name:eth_alternative_mempool_tx_residence_seconds}}_bucket{job="blockbook", coin="$coin"}[$__rate_interval])) by (action, le))
+        legend: '{{action}} p50'
+      p95:
+        promql: histogram_quantile(0.95, sum(rate({{name:eth_alternative_mempool_tx_residence_seconds}}_bucket{job="blockbook", coin="$coin"}[$__rate_interval])) by (action, le))
+        legend: '{{action}} p95'
   sync.mempool_resync_throughput_p95:
     title: 95% quantile of mempool resync throughput
     description: Transactions returned by a mempool reload divided by reload duration; low values mean the backend or parser is feeding the mempool slowly.

--- a/configs/grafana/template.json
+++ b/configs/grafana/template.json
@@ -1570,7 +1570,7 @@
         },
         "overrides": []
       },
-      "id": 321,
+      "id": 332,
       "options": {
         "legend": {
           "calcs": [
@@ -5160,7 +5160,7 @@
     },
     {
       "collapsed": false,
-      "id": 321,
+      "id": 333,
       "panels": [],
       "type": "row",
       "x-panel-key": "row.fiat_rates"
@@ -5196,7 +5196,7 @@
         },
         "overrides": []
       },
-      "id": 322,
+      "id": 334,
       "options": {
         "legend": {
           "calcs": [
@@ -5256,7 +5256,7 @@
         },
         "overrides": []
       },
-      "id": 323,
+      "id": 335,
       "options": {
         "legend": {
           "calcs": [
@@ -5322,7 +5322,7 @@
         },
         "overrides": []
       },
-      "id": 324,
+      "id": 336,
       "options": {
         "legend": {
           "calcs": [
@@ -5388,7 +5388,7 @@
         },
         "overrides": []
       },
-      "id": 325,
+      "id": 337,
       "options": {
         "legend": {
           "calcs": [

--- a/configs/grafana/template.json
+++ b/configs/grafana/template.json
@@ -1607,6 +1607,132 @@
           },
           "custom": {
             "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 338,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "size"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "sync.eth_alternative_mempool_cache_size"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "id": 339,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "p50"
+        },
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "B",
+          "x-query-key": "p95"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "sync.eth_alternative_mempool_tx_residence"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
             "lineWidth": 1,

--- a/configs/metrics.yaml
+++ b/configs/metrics.yaml
@@ -227,8 +227,18 @@ metrics:
   eth_alternative_mempool_reconciliation_events_total:
     name: blockbook_eth_alternative_mempool_reconciliation_events_total
     type: counter_vec
-    help: Alternative send-transaction mempool cache reconciliation decisions, labeled by action such as skipped_fresh, kept, provider_error, provider_missing, mined, nonce_superseded or timeout
+    help: Alternative send-transaction mempool cache lifecycle decisions, labeled by action - skipped_fresh and kept retain an entry for the next cycle, provider_error and provider_missing_pending keep an unconfirmed entry pending retry, and mined, nonce_superseded, provider_missing, timeout (from the reconcile loop or a read-path expiry) and rbf_replaced (fee replacement) remove it
     labels: [action]
+  eth_alternative_mempool_tx_residence_seconds:
+    name: blockbook_eth_alternative_mempool_tx_residence_seconds
+    type: histogram_vec
+    help: Age in seconds (time since broadcast) of an alternative send-transaction cache entry at the moment it leaves the cache, labeled by the removing action (mined, nonce_superseded, provider_missing, timeout or rbf_replaced) - reveals how long unconfirmed txs actually survive before each exit reason fires
+    labels: [action]
+    buckets: [30, 60, 120, 180, 300, 450, 600, 900, 1200, 1800, 3600]
+  eth_alternative_mempool_cache_size:
+    name: blockbook_eth_alternative_mempool_cache_size
+    type: gauge
+    help: Transactions currently held in the alternative send-transaction mempool cache, sampled at the end of every reconcile cycle
   estimated_fee:
     name: blockbook_estimated_fee
     type: gauge_vec


### PR DESCRIPTION
Follow-up hot-fix for #1562 (alternative-provider EVM send-tx mempool reconciliation).

### Symptom
On a Blink-relay Ethereum deployment, a sent tx showed **Unconfirmed** on both sender and recipient, then **disappeared from both ~1–2 min later** (nonce unchanged). Pre-#1562 it stayed visible until mined or timed out.

### Cause
The new 1-minute reconcile loop evicted a tx the moment a single `eth_getTransactionByHash` returned empty (`provider_missing`, `alternativesendtx.go`). But a **Blink-style private/MEV relay stops surfacing a still-pending, still-mineable tx** via `getTransactionByHash` while it remains broadcast — so "empty" is not proof the tx is gone. The eviction deletes from both `b.Mempool` and the alt cache, removing it from sender (Vin) and recipient (Vout) at once. The disappearance is a display/cache effect; the tx not mining is upstream relay behavior (with `*_SENDTX_ONLY=TRUE` the tx only ever goes to the private relay).

### Fix
- Treat empty `eth_getTransactionByHash` as **non-authoritative**: defer eviction to the absolute cache timeout (`mempoolTxsTimeout`), restoring the pre-#1562 visibility window.
- Keep `mined` and `nonce_superseded` as the only **deterministic early evictions** — both are positive, irreversible on-chain facts.
- Also run the nonce-superseded check when the provider no longer surfaces the tx, so a provably spent nonce is still cleaned up promptly (not just at timeout).
- New metric label `provider_missing_pending` marks the kept-not-evicted case (the `by (action)` Grafana panel picks it up automatically).

### Scope
Bites deployments combining `*_ALTERNATIVE_FETCH_MEMPOOL_TX=TRUE` + a private relay + effectively `disableMempoolSync=true` (the dev/Blink setup). Prod ethereum (no alt provider / mempool sync on) is unaffected.

### Tests
`bchain/coins/eth` reconcile tests updated + added (empty-result-kept-until-timeout, empty-and-timed-out-removed, superseded-missing-tx-evicted); full package green under `-race`.