### PR TITLE
fix(api): always serialize token decimals, default unresolved to coin convention

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -235,7 +235,7 @@ type Token struct {
 	Contract         string                   `json:"contract,omitempty" ts_doc:"Contract address on-chain."`
 	Transfers        int                      `json:"transfers" ts_doc:"Total number of token transfers for this address."`
 	Symbol           string                   `json:"symbol,omitempty" ts_doc:"Symbol for the token (e.g., 'ETH', 'USDT')."`
-	Decimals         int                      `json:"decimals,omitempty" ts_doc:"Number of decimals for this token."`
+	Decimals         int                      `json:"decimals" ts_doc:"Number of decimals for this token. Always present; defaults to the coin convention (18 for ERC-20) when the contract value is unavailable."`
 	BalanceSat       *Amount                  `json:"balance,omitempty" ts_doc:"Current token balance (in minimal base units)."`
 	BaseValue        float64                  `json:"baseValue,omitempty" ts_doc:"Value in the base currency (e.g. ETH for ERC20 tokens)."`
 	SecondaryValue   float64                  `json:"secondaryValue,omitempty" ts_doc:"Value in a secondary currency (e.g. fiat), if available."`
@@ -284,7 +284,7 @@ type TokenTransfer struct {
 	Contract         string                   `json:"contract" ts_doc:"Contract address of the token."`
 	Name             string                   `json:"name,omitempty" ts_doc:"Token name."`
 	Symbol           string                   `json:"symbol,omitempty" ts_doc:"Token symbol."`
-	Decimals         int                      `json:"decimals,omitempty" ts_doc:"Number of decimals for this token (if applicable)."`
+	Decimals         int                      `json:"decimals" ts_doc:"Number of decimals for this token. Always present; defaults to the coin convention (18 for ERC-20) when the contract value is unavailable."`
 	Value            *Amount                  `json:"value,omitempty" ts_doc:"Amount (in base units) of tokens transferred."`
 	MultiTokenValues []MultiTokenValue        `json:"multiTokenValues,omitempty" ts_doc:"List of multiple ID-value pairs for ERC1155 transfers."`
 }

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -330,3 +330,42 @@ func TestTokens_Sort(t *testing.T) {
 		})
 	}
 }
+
+// TestTokenDecimals_AlwaysSerialized guards trezor/blockbook#1577: the decimals
+// field must always be present on Token and TokenTransfer, including when it is
+// 0. Previously the field carried `,omitempty`, so a 0 was dropped entirely and
+// clients could not tell a genuine 0-decimal token apart from missing metadata.
+func TestTokenDecimals_AlwaysSerialized(t *testing.T) {
+	tests := []struct {
+		name string
+		v    interface{}
+		want string
+	}{
+		{
+			name: "TokenTransfer zero decimals is present",
+			v:    TokenTransfer{Standard: "ERC20", From: "0xfrom", To: "0xto", Contract: "0xc"},
+			want: `{"type":"","standard":"ERC20","from":"0xfrom","to":"0xto","contract":"0xc","decimals":0}`,
+		},
+		{
+			name: "TokenTransfer non-zero decimals is present",
+			v:    TokenTransfer{Standard: "ERC20", From: "0xfrom", To: "0xto", Contract: "0xc", Decimals: 18},
+			want: `{"type":"","standard":"ERC20","from":"0xfrom","to":"0xto","contract":"0xc","decimals":18}`,
+		},
+		{
+			name: "Token zero decimals is present",
+			v:    Token{Standard: "ERC20", Name: "n", Contract: "0xc"},
+			want: `{"type":"","standard":"ERC20","name":"n","contract":"0xc","transfers":0,"decimals":0}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.v)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if string(b) != tt.want {
+				t.Errorf("json.Marshal() = %v, want %v", string(b), tt.want)
+			}
+		})
+	}
+}

--- a/api/worker.go
+++ b/api/worker.go
@@ -743,6 +743,11 @@ func (w *Worker) getContractDescriptorInfo(cd bchain.AddressDescriptor, standard
 			}
 			if blockchainContractInfo != nil {
 				contractInfo.Decimals = blockchainContractInfo.Decimals
+			} else if contractInfo.Decimals == 0 && contractInfo.Standard == bchain.UnhandledTokenStandard {
+				// contract metadata could not be read on-chain; fall back to the coin's
+				// default decimals (18 for ERC-20) instead of persisting an ambiguous 0
+				// for a token whose true precision is simply unknown (trezor/blockbook#1577)
+				contractInfo.Decimals = w.chainParser.AmountDecimals()
 			}
 			if contractInfo.Standard == bchain.UnhandledTokenStandard {
 				glog.Infof("Contract %v %v [%s] handled", cd, standardFromContext, contractInfo.Name)
@@ -753,6 +758,13 @@ func (w *Worker) getContractDescriptorInfo(cd bchain.AddressDescriptor, standard
 				glog.Errorf("StoreContractInfo error %v, contract %v", err, cd)
 			}
 		}
+	}
+	// never surface an unresolved contract (still Unhandled because its metadata
+	// could not be fetched, e.g. a transient RPC error above) with a bare 0
+	// decimals; use the coin default instead. Genuinely 0-decimal tokens always
+	// carry a resolved (handled) standard, so they are unaffected (trezor/blockbook#1577)
+	if contractInfo.Decimals == 0 && contractInfo.Standard == bchain.UnhandledTokenStandard {
+		contractInfo.Decimals = w.chainParser.AmountDecimals()
 	}
 	return contractInfo, validContract, nil
 }

--- a/blockbook-api.ts
+++ b/blockbook-api.ts
@@ -152,8 +152,8 @@ export interface TokenTransfer {
     name?: string;
     /** Token symbol. */
     symbol?: string;
-    /** Number of decimals for this token (if applicable). */
-    decimals?: number;
+    /** Number of decimals for this token. Always present; defaults to the coin convention (18 for ERC-20) when the contract value is unavailable. */
+    decimals: number;
     /** Amount (in base units) of tokens transferred. */
     value?: string;
     /** List of multiple ID-value pairs for ERC1155 transfers. */
@@ -329,8 +329,8 @@ export interface Token {
     transfers: number;
     /** Symbol for the token (e.g., 'ETH', 'USDT'). */
     symbol?: string;
-    /** Number of decimals for this token. */
-    decimals?: number;
+    /** Number of decimals for this token. Always present; defaults to the coin convention (18 for ERC-20) when the contract value is unavailable. */
+    decimals: number;
     /** Current token balance (in minimal base units). */
     balance?: string;
     /** Value in the base currency (e.g. ETH for ERC20 tokens). */

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1869,7 +1869,7 @@ components:
 
     TokenTransfer:
       type: object
-      required: [type, standard, from, to, contract]
+      required: [type, standard, from, to, contract, decimals]
       properties:
         type:
           deprecated: true
@@ -2223,7 +2223,7 @@ components:
 
     Token:
       type: object
-      required: [type, standard, name, transfers]
+      required: [type, standard, name, transfers, decimals]
       properties:
         type:
           deprecated: true

--- a/tests/openapi/src/support.ts
+++ b/tests/openapi/src/support.ts
@@ -189,6 +189,20 @@ export function assertEVMTokenListContractsMatch(tokens: TokenResponse[], contra
   });
 }
 
+// assertTokenDecimals enforces trezor/blockbook#1577: `decimals` must always be present on
+// Token and TokenTransfer payloads (it used to be dropped when 0, leaving clients unable to
+// tell a genuine 0-decimal token from missing metadata) and must be a non-negative integer.
+// This makes the expectation explicit on top of the schema's `required: decimals`, so it still
+// holds if the schema is ever relaxed, and adds the non-negativity check the schema does not.
+export function assertTokenDecimals(decimals: number | undefined, context: string) {
+  if (decimals === undefined) {
+    throw new Error(`${context}.decimals is missing; it must always be present (trezor/blockbook#1577)`);
+  }
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(`${context}.decimals must be a non-negative integer, got ${String(decimals)}`);
+  }
+}
+
 export function assertErc4626Payload(context: string, shareContract: string, payload: NonNullable<ContractInfoResponse["protocols"]>["erc4626"]) {
   if (!payload) {
     throw new Error(`${context} missing payload`);

--- a/tests/openapi/src/tests/evm.ts
+++ b/tests/openapi/src/tests/evm.ts
@@ -13,6 +13,7 @@ import {
   assertNonEmptyString,
   assertPageMeta,
   assertPageSizeUpperBound,
+  assertTokenDecimals,
   buildAddressDetailsPath,
   encodePathSegment,
   equalFold,
@@ -120,6 +121,7 @@ async function testGetAddressTokensEVM(ctx: TestContext) {
   resp.tokens?.forEach((token, index) => {
     assertNonEmptyString(token.type, `GetAddressTokensEVM.tokens[${index}].type`);
     assertNonEmptyString(token.contract, `GetAddressTokensEVM.tokens[${index}].contract`);
+    assertTokenDecimals(token.decimals, `GetAddressTokensEVM.tokens[${index}]`);
   });
 }
 
@@ -268,6 +270,10 @@ async function testGetTransactionEVMShape(ctx: TestContext) {
   if (!isObject(tx.ethereumSpecific) || Object.keys(tx.ethereumSpecific).length === 0) {
     throw new Error(`GetTransactionEVMShape missing ethereumSpecific object for ${txid}`);
   }
+  // when the sampled tx carries token transfers, each must report decimals (trezor/blockbook#1577)
+  tx.tokenTransfers?.forEach((transfer, index) =>
+    assertTokenDecimals(transfer.decimals, `GetTransactionEVMShape.tokenTransfers[${index}]`),
+  );
 }
 
 export async function assertErc4626FixturesInAccountInfo(


### PR DESCRIPTION
## Problem

Closes #1577.

Blockbook's token-transfer and token-balance responses declared `decimals`
with `,omitempty`, so a value of `0` was dropped from the JSON entirely.
Clients (e.g. Trezor Suite) could not tell a genuine 0-decimal token apart
from missing metadata and had to assume a default — which is unsafe (`0`
underflows the amount, `18` overflows it). Trezor Suite worked around this
client-side in trezor/trezor-suite#28697 by defaulting missing decimals to 18.

This implements the issue's preferred fix: **always populate `decimals`,
defaulting to the coin convention (18 for ERC-20) when the on-chain value is
unavailable.**

## Changes

- Remove `,omitempty` from `api.Token.Decimals` and `api.TokenTransfer.Decimals`
  so the field is always present (consistent with `ContractInfoResult.Decimals`,
  which already is).
- `getContractDescriptorInfo`: when a contract's metadata cannot be read
  on-chain (a transient RPC error, or a token that does not expose
  `name`/`symbol`/`decimals`), fall back to `chainParser.AmountDecimals()`
  instead of surfacing — and persisting — an ambiguous `0`. The fallback is
  guarded on `UnhandledTokenStandard` (the sync-time sentinel), so genuinely
  0-decimal tokens, which always carry a resolved (handled) standard, keep
  their `0`.
- Keep `blockbook-api.ts` and `openapi.yaml` in parity: `decimals` is now
  required on the `Token` and `TokenTransfer` schemas. The OpenAPI parity
  typecheck (`tests/openapi`) passes.
- Add a regression test asserting `decimals` is serialized even when `0`.

### Why the second bullet matters

Removing `,omitempty` alone would have been a subtle regression: in the
unresolved-metadata path the sync-time `Decimals` is `0`, which `omitempty`
currently hides. Serving it as an authoritative `"decimals":0` would make
strict clients render amounts off by 10^18. The fallback ensures `0` only ever
appears for tokens whose precision is genuinely 0.

## Notes for clients

`decimals` is now authoritative and always present, so consumers no longer need
to guess. Note that genuine 0-decimal tokens now correctly arrive as
`"decimals":0` instead of being coerced to a default — clients using
`value || 18`-style fallbacks should prefer `value ?? 18` (or just trust the
wire value) to avoid mis-rendering them.

## Testing

- `go test -tags unittest ./api/ ./server/ ./db/ ./bchain/coins/eth/ ./bchain/coins/tron/` — all pass.
- `cd tests/openapi && npm run lint:spec && npm run generate && npm run typecheck` — all pass.
