### PR TITLE
1581 add upper cap limits to chosen websocket endpoints to increase resilliency

### DIFF
--- a/api/fiat_balance_history.go
+++ b/api/fiat_balance_history.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -13,14 +12,6 @@ func normalizeBalanceHistoryPathLabel(pathLabel string) string {
 		return "unknown"
 	}
 	return pathLabel
-}
-
-func normalizeCurrenciesToLowercase(currencies []string) []string {
-	currenciesLowercase := make([]string, len(currencies))
-	for i := range currencies {
-		currenciesLowercase[i] = strings.ToLower(currencies[i])
-	}
-	return currenciesLowercase
 }
 
 func buildBalanceHistoryTimestamps(histories BalanceHistories) []int64 {
@@ -180,7 +171,10 @@ func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, curre
 		return nil
 	}
 	pathLabel = normalizeBalanceHistoryPathLabel(pathLabel)
-	currenciesLowercase := normalizeCurrenciesToLowercase(currencies)
+	currenciesLowercase, err := normalizeFiatCurrencies(currencies)
+	if err != nil {
+		return err
+	}
 	timestamps := buildBalanceHistoryTimestamps(histories)
 	tickers, batchFetchValid, reason, returnedTickers, err := w.lookupBalanceHistoryBatchTickers(timestamps, pathLabel, len(histories))
 	if batchFetchValid {

--- a/api/fiat_balance_history.go
+++ b/api/fiat_balance_history.go
@@ -166,23 +166,21 @@ func (w *Worker) applyFallbackTickersToBalanceHistories(histories BalanceHistori
 	w.observeBalanceHistoryFiatDuration(pathLabel, "fallback", stats.status(), fallbackStarted)
 }
 
-func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, currencies []string, pathLabel string) error {
+// setFiatRateToBalanceHistories fills FiatRates of the passed histories.
+// currenciesLowercase must already be normalized by normalizeFiatCurrencies;
+// both entry points (GetBalanceHistory, GetXpubBalanceHistory) do so.
+func (w *Worker) setFiatRateToBalanceHistories(histories BalanceHistories, currenciesLowercase []string, pathLabel string) {
 	if len(histories) == 0 || w.fiatRates == nil || !w.fiatRates.Enabled {
-		return nil
+		return
 	}
 	pathLabel = normalizeBalanceHistoryPathLabel(pathLabel)
-	currenciesLowercase, err := normalizeFiatCurrencies(currencies)
-	if err != nil {
-		return err
-	}
 	timestamps := buildBalanceHistoryTimestamps(histories)
 	tickers, batchFetchValid, reason, returnedTickers, err := w.lookupBalanceHistoryBatchTickers(timestamps, pathLabel, len(histories))
 	if batchFetchValid {
 		applyBatchTickersToBalanceHistories(histories, tickers, currenciesLowercase)
-		return nil
+		return
 	}
 	glog.Errorf("Error finding tickers for %d timestamps (returned %d, reason %s). Error: %v", len(timestamps), returnedTickers, reason, err)
 	w.incrementBalanceHistoryFiatFallback(pathLabel, reason)
 	w.applyFallbackTickersToBalanceHistories(histories, currenciesLowercase, pathLabel)
-	return nil
 }

--- a/api/fiat_balance_history_test.go
+++ b/api/fiat_balance_history_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -202,6 +203,38 @@ func TestSetFiatRateToBalanceHistories_SkipsLookupWhenFiatRatesDisabled(t *testi
 	}
 	if calls != 0 {
 		t.Fatalf("expected 0 ticker lookup calls when fiat rates are disabled, got %d", calls)
+	}
+}
+
+func TestSetFiatRateToBalanceHistories_RejectsTooManyCurrenciesBeforeLookup(t *testing.T) {
+	histories := BalanceHistories{{Time: 100}}
+	w := &Worker{
+		fiatRates: &fiat.FiatRates{Enabled: true},
+	}
+	originalGetter := getTickersForTimestamps
+	defer func() {
+		getTickersForTimestamps = originalGetter
+	}()
+
+	calls := 0
+	getTickersForTimestamps = func(_ *fiat.FiatRates, _ []int64, _, _ string) (*[]*common.CurrencyRatesTicker, error) {
+		calls++
+		tickers := []*common.CurrencyRatesTicker{}
+		return &tickers, nil
+	}
+
+	currencies := make([]string, MaxFiatRatesCurrencies+1)
+	for i := range currencies {
+		currencies[i] = fmt.Sprintf("c%03d", i)
+	}
+	err := w.setFiatRateToBalanceHistories(histories, currencies, "address")
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
+	}
+	if calls != 0 {
+		t.Fatalf("expected ticker lookup not to be called, got %d calls", calls)
 	}
 }
 

--- a/api/fiat_balance_history_test.go
+++ b/api/fiat_balance_history_test.go
@@ -3,7 +3,6 @@
 package api
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -38,10 +37,7 @@ func TestSetFiatRateToBalanceHistories_BatchesTickerLookup(t *testing.T) {
 		return &tickers, nil
 	}
 
-	err := w.setFiatRateToBalanceHistories(histories, []string{"USD", "eur", "cad"}, "address")
-	if err != nil {
-		t.Fatalf("setFiatRateToBalanceHistories returned error: %v", err)
-	}
+	w.setFiatRateToBalanceHistories(histories, []string{"usd", "eur", "cad"}, "address")
 	if calls != 1 {
 		t.Fatalf("expected 1 ticker lookup call, got %d", calls)
 	}
@@ -78,10 +74,7 @@ func TestSetFiatRateToBalanceHistories_AllRatesWhenCurrenciesNotSpecified(t *tes
 		return &tickers, nil
 	}
 
-	err := w.setFiatRateToBalanceHistories(histories, nil, "address")
-	if err != nil {
-		t.Fatalf("setFiatRateToBalanceHistories returned error: %v", err)
-	}
+	w.setFiatRateToBalanceHistories(histories, nil, "address")
 	if !reflect.DeepEqual(histories[0].FiatRates, map[string]float32{"usd": 11, "eur": 22}) {
 		t.Fatalf("unexpected rates for histories[0]: %v", histories[0].FiatRates)
 	}
@@ -128,10 +121,7 @@ func TestSetFiatRateToBalanceHistories_BatchFailureFallsBackToPerPoint(t *testin
 		}
 	}
 
-	err := w.setFiatRateToBalanceHistories(histories, []string{"usd"}, "address")
-	if err != nil {
-		t.Fatalf("setFiatRateToBalanceHistories returned error: %v", err)
-	}
+	w.setFiatRateToBalanceHistories(histories, []string{"usd"}, "address")
 	if calls != 4 {
 		t.Fatalf("expected 4 ticker lookup calls (1 batch + 3 point), got %d", calls)
 	}
@@ -171,10 +161,7 @@ func TestSetFiatRateToBalanceHistories_SkipsLookupForEmptyHistory(t *testing.T) 
 		return &tickers, nil
 	}
 
-	err := w.setFiatRateToBalanceHistories(BalanceHistories{}, []string{"usd"}, "address")
-	if err != nil {
-		t.Fatalf("setFiatRateToBalanceHistories returned error: %v", err)
-	}
+	w.setFiatRateToBalanceHistories(BalanceHistories{}, []string{"usd"}, "address")
 	if calls != 0 {
 		t.Fatalf("expected 0 ticker lookup calls, got %d", calls)
 	}
@@ -197,44 +184,9 @@ func TestSetFiatRateToBalanceHistories_SkipsLookupWhenFiatRatesDisabled(t *testi
 		return &tickers, nil
 	}
 
-	err := w.setFiatRateToBalanceHistories(histories, []string{"usd"}, "address")
-	if err != nil {
-		t.Fatalf("setFiatRateToBalanceHistories returned error: %v", err)
-	}
+	w.setFiatRateToBalanceHistories(histories, []string{"usd"}, "address")
 	if calls != 0 {
 		t.Fatalf("expected 0 ticker lookup calls when fiat rates are disabled, got %d", calls)
-	}
-}
-
-func TestSetFiatRateToBalanceHistories_RejectsTooManyCurrenciesBeforeLookup(t *testing.T) {
-	histories := BalanceHistories{{Time: 100}}
-	w := &Worker{
-		fiatRates: &fiat.FiatRates{Enabled: true},
-	}
-	originalGetter := getTickersForTimestamps
-	defer func() {
-		getTickersForTimestamps = originalGetter
-	}()
-
-	calls := 0
-	getTickersForTimestamps = func(_ *fiat.FiatRates, _ []int64, _, _ string) (*[]*common.CurrencyRatesTicker, error) {
-		calls++
-		tickers := []*common.CurrencyRatesTicker{}
-		return &tickers, nil
-	}
-
-	currencies := make([]string, MaxFiatRatesCurrencies+1)
-	for i := range currencies {
-		currencies[i] = fmt.Sprintf("c%03d", i)
-	}
-	err := w.setFiatRateToBalanceHistories(histories, currencies, "address")
-	apiErr := requireAPIError(t, err, true)
-	want := fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies)
-	if apiErr.Text != want {
-		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
-	}
-	if calls != 0 {
-		t.Fatalf("expected ticker lookup not to be called, got %d calls", calls)
 	}
 }
 

--- a/api/fiat_rates_api.go
+++ b/api/fiat_rates_api.go
@@ -13,15 +13,42 @@ import (
 // MaxFiatRatesTimestamps limits batch fiat-rate lookups to bounded request work.
 const MaxFiatRatesTimestamps = 1000
 
-// removeEmpty removes empty strings from a slice.
-func removeEmpty(stringSlice []string) []string {
-	ret := make([]string, 0, len(stringSlice))
-	for _, str := range stringSlice {
-		if str != "" {
-			ret = append(ret, str)
+// MaxFiatRatesCurrencies limits explicit currency selectors. An empty list still
+// means "all available currencies", so legitimate callers do not need a large
+// explicit list.
+const MaxFiatRatesCurrencies = 128
+
+// MaxFiatRatesCurrencyCodeLength bounds each selector before it is copied into
+// per-result response maps.
+const MaxFiatRatesCurrencyCodeLength = 16
+
+// normalizeFiatCurrencies trims, lowercases, deduplicates, and bounds explicit
+// fiat currency selectors before any per-result response maps are allocated.
+func normalizeFiatCurrencies(currencies []string) ([]string, error) {
+	capacity := len(currencies)
+	if capacity > MaxFiatRatesCurrencies {
+		capacity = MaxFiatRatesCurrencies + 1
+	}
+	seen := make(map[string]struct{}, capacity)
+	normalized := make([]string, 0, capacity)
+	for _, currency := range currencies {
+		currency = strings.ToLower(strings.TrimSpace(currency))
+		if currency == "" {
+			continue
+		}
+		if len(currency) > MaxFiatRatesCurrencyCodeLength {
+			return nil, NewAPIError(fmt.Sprintf("currency code too long, max %d", MaxFiatRatesCurrencyCodeLength), true)
+		}
+		if _, found := seen[currency]; found {
+			continue
+		}
+		seen[currency] = struct{}{}
+		normalized = append(normalized, currency)
+		if len(normalized) > MaxFiatRatesCurrencies {
+			return nil, NewAPIError(fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies), true)
 		}
 	}
-	return ret
+	return normalized, nil
 }
 
 func copyTickerRates(rates map[string]float32) map[string]float32 {
@@ -90,12 +117,15 @@ func (w *Worker) getFiatRatesResult(currencies []string, ticker *common.Currency
 // GetCurrentFiatRates returns last available fiat rates.
 func (w *Worker) GetCurrentFiatRates(currencies []string, token string) (*FiatTicker, error) {
 	vsCurrency := ""
-	currencies = removeEmpty(currencies)
+	var err error
+	currencies, err = normalizeFiatCurrencies(currencies)
+	if err != nil {
+		return nil, err
+	}
 	if len(currencies) == 1 {
 		vsCurrency = currencies[0]
 	}
 	ticker := getCurrentTicker(w.fiatRates, vsCurrency, token)
-	var err error
 	if ticker == nil {
 		if token == "" {
 			// fallback - get last fiat rate from db if not in current ticker
@@ -135,7 +165,10 @@ func (w *Worker) GetFiatRatesForTimestamps(timestamps []int64, currencies []stri
 		return nil, NewAPIError(fmt.Sprintf("too many timestamps, max %d", MaxFiatRatesTimestamps), true)
 	}
 	vsCurrency := ""
-	currencies = removeEmpty(currencies)
+	currencies, err := normalizeFiatCurrencies(currencies)
+	if err != nil {
+		return nil, err
+	}
 	if len(currencies) == 1 {
 		vsCurrency = currencies[0]
 	}

--- a/api/fiat_rates_api.go
+++ b/api/fiat_rates_api.go
@@ -24,13 +24,14 @@ const MaxFiatRatesCurrencyCodeLength = 16
 
 // normalizeFiatCurrencies trims, lowercases, deduplicates, and bounds explicit
 // fiat currency selectors before any per-result response maps are allocated.
+// The count limit applies to the raw input length so the work done here is
+// bounded by it as well.
 func normalizeFiatCurrencies(currencies []string) ([]string, error) {
-	capacity := len(currencies)
-	if capacity > MaxFiatRatesCurrencies {
-		capacity = MaxFiatRatesCurrencies + 1
+	if len(currencies) > MaxFiatRatesCurrencies {
+		return nil, NewAPIError(fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies), true)
 	}
-	seen := make(map[string]struct{}, capacity)
-	normalized := make([]string, 0, capacity)
+	seen := make(map[string]struct{}, len(currencies))
+	normalized := make([]string, 0, len(currencies))
 	for _, currency := range currencies {
 		currency = strings.ToLower(strings.TrimSpace(currency))
 		if currency == "" {
@@ -44,9 +45,6 @@ func normalizeFiatCurrencies(currencies []string) ([]string, error) {
 		}
 		seen[currency] = struct{}{}
 		normalized = append(normalized, currency)
-		if len(normalized) > MaxFiatRatesCurrencies {
-			return nil, NewAPIError(fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies), true)
-		}
 	}
 	return normalized, nil
 }

--- a/api/fiat_rates_api.go
+++ b/api/fiat_rates_api.go
@@ -58,6 +58,7 @@ func copyTickerRates(rates map[string]float32) map[string]float32 {
 }
 
 // getFiatRatesResult checks if CurrencyRatesTicker contains all necessary data and returns formatted result.
+// currencies must already be normalized by normalizeFiatCurrencies.
 func (w *Worker) getFiatRatesResult(currencies []string, ticker *common.CurrencyRatesTicker, token string) (*FiatTicker, error) {
 	if token != "" {
 		capacity := len(currencies)
@@ -76,7 +77,6 @@ func (w *Worker) getFiatRatesResult(currencies []string, ticker *common.Currency
 			}
 		} else {
 			for _, currency := range currencies {
-				currency = strings.ToLower(currency)
 				rate := ticker.TokenRateInCurrency(token, currency)
 				if rate <= 0 {
 					rate = -1
@@ -99,7 +99,6 @@ func (w *Worker) getFiatRatesResult(currencies []string, ticker *common.Currency
 	// Check if currencies from the list are available in the ticker rates.
 	rates := make(map[string]float32, len(currencies))
 	for _, currency := range currencies {
-		currency = strings.ToLower(currency)
 		if rate, found := ticker.Rates[currency]; found {
 			rates[currency] = rate
 		} else {

--- a/api/fiat_rates_api_test.go
+++ b/api/fiat_rates_api_test.go
@@ -28,11 +28,50 @@ func requireAPIError(t *testing.T, err error, wantPublic bool) *APIError {
 	return apiErr
 }
 
-func TestRemoveEmpty(t *testing.T) {
-	got := removeEmpty([]string{"usd", "", "eur", "", ""})
+func TestNormalizeFiatCurrencies(t *testing.T) {
+	got, err := normalizeFiatCurrencies([]string{" usd ", "", "USD", "eur", " Eur "})
+	if err != nil {
+		t.Fatalf("normalizeFiatCurrencies returned error: %v", err)
+	}
 	want := []string{"usd", "eur"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("unexpected filtered currencies: got %v, want %v", got, want)
+		t.Fatalf("unexpected normalized currencies: got %v, want %v", got, want)
+	}
+}
+
+func TestNormalizeFiatCurrencies_LimitsUniqueCurrencies(t *testing.T) {
+	currencies := make([]string, MaxFiatRatesCurrencies+1)
+	for i := range currencies {
+		currencies[i] = fmt.Sprintf("c%03d", i)
+	}
+	_, err := normalizeFiatCurrencies(currencies)
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
+	}
+}
+
+func TestNormalizeFiatCurrencies_DeduplicatesBeforeLimit(t *testing.T) {
+	currencies := make([]string, MaxFiatRatesCurrencies+1)
+	for i := range currencies {
+		currencies[i] = "USD"
+	}
+	got, err := normalizeFiatCurrencies(currencies)
+	if err != nil {
+		t.Fatalf("normalizeFiatCurrencies returned error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"usd"}) {
+		t.Fatalf("unexpected normalized currencies: got %v", got)
+	}
+}
+
+func TestNormalizeFiatCurrencies_RejectsLongCode(t *testing.T) {
+	_, err := normalizeFiatCurrencies([]string{strings.Repeat("a", MaxFiatRatesCurrencyCodeLength+1)})
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("currency code too long, max %d", MaxFiatRatesCurrencyCodeLength)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
 	}
 }
 
@@ -153,8 +192,8 @@ func TestGetCurrentFiatRates_UsesGetterAndCurrencyFilter(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("expected one ticker call, got %d", calls)
 	}
-	if gotVsCurrency != "USD" {
-		t.Fatalf("unexpected vsCurrency: got %q, want %q", gotVsCurrency, "USD")
+	if gotVsCurrency != "usd" {
+		t.Fatalf("unexpected vsCurrency: got %q, want %q", gotVsCurrency, "usd")
 	}
 	if gotToken != "" {
 		t.Fatalf("unexpected token: got %q, want empty", gotToken)
@@ -200,6 +239,60 @@ func TestGetFiatRatesForTimestamps_LimitsInput(t *testing.T) {
 	want := fmt.Sprintf("too many timestamps, max %d", MaxFiatRatesTimestamps)
 	if apiErr.Text != want {
 		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
+	}
+}
+
+func TestGetFiatRatesForTimestamps_LimitsCurrenciesBeforeLookup(t *testing.T) {
+	w := &Worker{fiatRates: &fiat.FiatRates{}}
+	originalGetter := getTickersForTimestamps
+	defer func() {
+		getTickersForTimestamps = originalGetter
+	}()
+
+	calls := 0
+	getTickersForTimestamps = func(_ *fiat.FiatRates, _ []int64, _, _ string) (*[]*common.CurrencyRatesTicker, error) {
+		calls++
+		tickers := []*common.CurrencyRatesTicker{}
+		return &tickers, nil
+	}
+
+	currencies := make([]string, MaxFiatRatesCurrencies+1)
+	for i := range currencies {
+		currencies[i] = fmt.Sprintf("c%03d", i)
+	}
+	_, err := w.GetFiatRatesForTimestamps([]int64{1}, currencies, "")
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
+	}
+	if calls != 0 {
+		t.Fatalf("expected ticker lookup not to be called, got %d calls", calls)
+	}
+}
+
+func TestGetFiatRatesForTimestamps_RejectsLongCurrencyBeforeLookup(t *testing.T) {
+	w := &Worker{fiatRates: &fiat.FiatRates{}}
+	originalGetter := getTickersForTimestamps
+	defer func() {
+		getTickersForTimestamps = originalGetter
+	}()
+
+	calls := 0
+	getTickersForTimestamps = func(_ *fiat.FiatRates, _ []int64, _, _ string) (*[]*common.CurrencyRatesTicker, error) {
+		calls++
+		tickers := []*common.CurrencyRatesTicker{}
+		return &tickers, nil
+	}
+
+	_, err := w.GetFiatRatesForTimestamps([]int64{1}, []string{strings.Repeat("a", MaxFiatRatesCurrencyCodeLength+1)}, "")
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("currency code too long, max %d", MaxFiatRatesCurrencyCodeLength)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
+	}
+	if calls != 0 {
+		t.Fatalf("expected ticker lookup not to be called, got %d calls", calls)
 	}
 }
 

--- a/api/fiat_rates_api_test.go
+++ b/api/fiat_rates_api_test.go
@@ -39,7 +39,7 @@ func TestNormalizeFiatCurrencies(t *testing.T) {
 	}
 }
 
-func TestNormalizeFiatCurrencies_LimitsUniqueCurrencies(t *testing.T) {
+func TestNormalizeFiatCurrencies_LimitsCurrencyCount(t *testing.T) {
 	currencies := make([]string, MaxFiatRatesCurrencies+1)
 	for i := range currencies {
 		currencies[i] = fmt.Sprintf("c%03d", i)
@@ -52,8 +52,8 @@ func TestNormalizeFiatCurrencies_LimitsUniqueCurrencies(t *testing.T) {
 	}
 }
 
-func TestNormalizeFiatCurrencies_DeduplicatesBeforeLimit(t *testing.T) {
-	currencies := make([]string, MaxFiatRatesCurrencies+1)
+func TestNormalizeFiatCurrencies_DeduplicatesWithinLimit(t *testing.T) {
+	currencies := make([]string, MaxFiatRatesCurrencies)
 	for i := range currencies {
 		currencies[i] = "USD"
 	}
@@ -63,6 +63,21 @@ func TestNormalizeFiatCurrencies_DeduplicatesBeforeLimit(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, []string{"usd"}) {
 		t.Fatalf("unexpected normalized currencies: got %v", got)
+	}
+}
+
+func TestNormalizeFiatCurrencies_LimitAppliesToRawInputLength(t *testing.T) {
+	// The count cap bounds the raw input length, so even a list that would
+	// deduplicate to a single entry is rejected when it is too long.
+	currencies := make([]string, MaxFiatRatesCurrencies+1)
+	for i := range currencies {
+		currencies[i] = "USD"
+	}
+	_, err := normalizeFiatCurrencies(currencies)
+	apiErr := requireAPIError(t, err, true)
+	want := fmt.Sprintf("too many currencies, max %d", MaxFiatRatesCurrencies)
+	if apiErr.Text != want {
+		t.Fatalf("unexpected error text: got %q, want %q", apiErr.Text, want)
 	}
 }
 

--- a/api/fiat_rates_api_test.go
+++ b/api/fiat_rates_api_test.go
@@ -111,7 +111,7 @@ func TestGetFiatRatesResult_NonTokenSelectedCurrencies(t *testing.T) {
 		},
 	}
 
-	got, err := w.getFiatRatesResult([]string{"USD", "gbp"}, ticker, "")
+	got, err := w.getFiatRatesResult([]string{"usd", "gbp"}, ticker, "")
 	if err != nil {
 		t.Fatalf("getFiatRatesResult returned error: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestGetFiatRatesResult_TokenRates(t *testing.T) {
 		},
 	}
 
-	got, err := w.getFiatRatesResult([]string{"USD", "EUR", "JPY"}, ticker, "0xToken")
+	got, err := w.getFiatRatesResult([]string{"usd", "eur", "jpy"}, ticker, "0xToken")
 	if err != nil {
 		t.Fatalf("getFiatRatesResult returned error: %v", err)
 	}

--- a/api/worker.go
+++ b/api/worker.go
@@ -2044,7 +2044,11 @@ const (
 // the caller supplies the transport-specific cap (WS vs REST). transport labels
 // the emitted metrics with the serving surface.
 func (w *Worker) GetBalanceHistory(address string, fromTimestamp, toTimestamp int64, currencies []string, groupBy uint32, maxTxs int, transport string) (BalanceHistories, error) {
-	currencies = removeEmpty(currencies)
+	var err error
+	currencies, err = normalizeFiatCurrencies(currencies)
+	if err != nil {
+		return nil, err
+	}
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
 	addrDesc, _, err := w.getAddrDescAndNormalizeAddress(address)

--- a/api/worker.go
+++ b/api/worker.go
@@ -2105,10 +2105,7 @@ func (w *Worker) GetBalanceHistory(address string, fromTimestamp, toTimestamp in
 	if w.metrics != nil {
 		w.metrics.BalanceHistoryPoints.With(common.Labels{"path": "address"}).Observe(float64(len(bha)))
 	}
-	err = w.setFiatRateToBalanceHistories(bha, currencies, "address")
-	if err != nil {
-		return nil, err
-	}
+	w.setFiatRateToBalanceHistories(bha, currencies, "address")
 	glog.V(1).Info("GetBalanceHistory ", address, ", blocks ", fromHeight, "-", toHeight, ", count ", len(bha), ", ", time.Since(start))
 	return bha, nil
 }

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -774,6 +774,11 @@ func (w *Worker) GetXpubUtxo(xpub string, onlyConfirmed bool, gap int) (Utxos, e
 // transport-specific cap (WS vs REST). transport labels the emitted metrics with
 // the serving surface.
 func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp int64, currencies []string, gap int, groupBy uint32, maxTxs int, transport string) (BalanceHistories, error) {
+	var err error
+	currencies, err = normalizeFiatCurrencies(currencies)
+	if err != nil {
+		return nil, err
+	}
 	bhs := make(BalanceHistories, 0)
 	start := time.Now()
 	fromUnix, fromHeight, toUnix, toHeight := w.balanceHistoryHeightsFromTo(fromTimestamp, toTimestamp)

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -870,10 +870,7 @@ func (w *Worker) GetXpubBalanceHistory(xpub string, fromTimestamp, toTimestamp i
 	if w.metrics != nil {
 		w.metrics.BalanceHistoryPoints.With(common.Labels{"path": "xpub"}).Observe(float64(len(bha)))
 	}
-	err = w.setFiatRateToBalanceHistories(bha, currencies, "xpub")
-	if err != nil {
-		return nil, err
-	}
+	w.setFiatRateToBalanceHistories(bha, currencies, "xpub")
 	glog.V(1).Info("GetUtxoBalanceHistory ", xpub[:xpubLogPrefix], ", cache ", inCache, ", blocks ", fromHeight, "-", toHeight, ", count ", len(bha), ",  ", time.Since(start))
 	return bha, nil
 }

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -33,6 +33,11 @@ const contractBalanceOfSignature = "0x70a08231"
 
 const ENSRegistryAddress = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" // ENSRegistryAddress is the mainnet ENS registry contract address
 
+const (
+	evmWordBytes = 32
+	evmWordHex   = evmWordBytes * 2
+)
+
 func addressFromPaddedHex(s string) (string, error) {
 	var t big.Int
 	var ok bool
@@ -131,6 +136,44 @@ func processERC1155TransferSingleEvent(l *bchain.RpcLog) (transfer *bchain.Token
 	}, nil
 }
 
+func parseEVMLogWordUint64(data string, offset int) (uint64, error) {
+	if offset < 0 || offset > len(data) || len(data)-offset < evmWordHex {
+		return 0, errors.New("ERC1155 TransferBatch, invalid data length")
+	}
+	var b big.Int
+	_, ok := b.SetString(data[offset:offset+evmWordHex], 16)
+	if !ok || !b.IsUint64() {
+		return 0, errors.New("ERC1155 TransferBatch, not a number")
+	}
+	return b.Uint64(), nil
+}
+
+func erc1155BatchOffsetHex(offsetBytes uint64) (int, error) {
+	if offsetBytes < 2*evmWordBytes {
+		return 0, errors.New("ERC1155 TransferBatch, invalid offset")
+	}
+	if offsetBytes%evmWordBytes != 0 {
+		return 0, errors.New("ERC1155 TransferBatch, invalid offset")
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	if offsetBytes > maxInt/2 {
+		return 0, errors.New("ERC1155 TransferBatch, invalid offset")
+	}
+	return int(offsetBytes * 2), nil
+}
+
+func erc1155BatchArrayEnd(offset int, count uint64) (int, error) {
+	if offset < 0 {
+		return 0, errors.New("ERC1155 TransferBatch, invalid offset")
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	base := uint64(offset) + evmWordHex
+	if base > maxInt || count > (maxInt-base)/evmWordHex {
+		return 0, errors.New("ERC1155 TransferBatch, invalid data length")
+	}
+	return int(base + count*evmWordHex), nil
+}
+
 func processERC1155TransferBatchEvent(l *bchain.RpcLog) (transfer *bchain.TokenTransfer, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -154,40 +197,65 @@ func processERC1155TransferBatchEvent(l *bchain.RpcLog) (transfer *bchain.TokenT
 	if has0xPrefix(l.Data) {
 		data = data[2:]
 	}
-	var b big.Int
-	_, ok := b.SetString(data[:64], 16)
-	if !ok || !b.IsInt64() {
-		return nil, errors.New("ERC1155 TransferBatch, not a number")
+	if len(data) < 2*evmWordHex || len(data)%evmWordHex != 0 {
+		return nil, errors.New("ERC1155 TransferBatch, invalid data length")
 	}
-	offsetIds := int(b.Int64()) * 2
-	_, ok = b.SetString(data[64:128], 16)
-	if !ok || !b.IsInt64() {
-		return nil, errors.New("ERC1155 TransferBatch, not a number")
+	offsetIdsBytes, err := parseEVMLogWordUint64(data, 0)
+	if err != nil {
+		return nil, err
 	}
-	offsetValues := int(b.Int64()) * 2
-	_, ok = b.SetString(data[offsetIds:offsetIds+64], 16)
-	if !ok || !b.IsInt64() {
-		return nil, errors.New("ERC1155 TransferBatch, not a number")
+	offsetIds, err := erc1155BatchOffsetHex(offsetIdsBytes)
+	if err != nil {
+		return nil, err
 	}
-	countIds := int(b.Int64())
-	_, ok = b.SetString(data[offsetValues:offsetValues+64], 16)
-	if !ok || !b.IsInt64() {
-		return nil, errors.New("ERC1155 TransferBatch, not a number")
+	offsetValuesBytes, err := parseEVMLogWordUint64(data, evmWordHex)
+	if err != nil {
+		return nil, err
 	}
-	countValues := int(b.Int64())
+	offsetValues, err := erc1155BatchOffsetHex(offsetValuesBytes)
+	if err != nil {
+		return nil, err
+	}
+	countIds, err := parseEVMLogWordUint64(data, offsetIds)
+	if err != nil {
+		return nil, err
+	}
+	countValues, err := parseEVMLogWordUint64(data, offsetValues)
+	if err != nil {
+		return nil, err
+	}
 	if countIds != countValues {
 		return nil, errors.New("ERC1155 TransferBatch, count values and ids does not match")
 	}
-	idValues := make([]bchain.MultiTokenValue, countValues)
-	for i := 0; i < countValues; i++ {
+	endIds, err := erc1155BatchArrayEnd(offsetIds, countValues)
+	if err != nil {
+		return nil, err
+	}
+	if endIds > len(data) {
+		return nil, errors.New("ERC1155 TransferBatch, invalid ids data length")
+	}
+	endValues, err := erc1155BatchArrayEnd(offsetValues, countValues)
+	if err != nil {
+		return nil, err
+	}
+	if endValues > len(data) {
+		return nil, errors.New("ERC1155 TransferBatch, invalid values data length")
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	if countValues > maxInt {
+		return nil, errors.New("ERC1155 TransferBatch, invalid data length")
+	}
+	count := int(countValues)
+	idValues := make([]bchain.MultiTokenValue, count)
+	for i := 0; i < count; i++ {
 		var id, value big.Int
-		o := offsetIds + 64 + 64*i
-		_, ok := id.SetString(data[o:o+64], 16)
+		o := offsetIds + evmWordHex + evmWordHex*i
+		_, ok := id.SetString(data[o:o+evmWordHex], 16)
 		if !ok {
 			return nil, errors.New("ERC1155 log Data id is not a number")
 		}
-		o = offsetValues + 64 + 64*i
-		_, ok = value.SetString(data[o:o+64], 16)
+		o = offsetValues + evmWordHex + evmWordHex*i
+		_, ok = value.SetString(data[o:o+evmWordHex], 16)
 		if !ok {
 			return nil, errors.New("ERC1155 log Data value is not a number")
 		}

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -268,14 +268,17 @@ func processERC1155TransferBatchEvent(l *bchain.RpcLog) (transfer *bchain.TokenT
 	}, nil
 }
 
-func contractGetTransfersFromLog(logs []*bchain.RpcLog) (bchain.TokenTransfers, error) {
+// contractGetTransfersFromLog extracts token transfers from receipt logs.
+// An unparseable log is skipped with a warning so that one malformed event
+// does not discard the valid transfers of the transaction.
+func contractGetTransfersFromLog(logs []*bchain.RpcLog, txid string) bchain.TokenTransfers {
 	var r bchain.TokenTransfers
-	var tt *bchain.TokenTransfer
-	var err error
 	for _, l := range logs {
 		tl := len(l.Topics)
 		if tl > 0 {
 			signature := l.Topics[0]
+			var tt *bchain.TokenTransfer
+			var err error
 			if signature == tokenTransferEventSignature {
 				tt, err = processTransferEvent(l)
 			} else if signature == tokenERC1155TransferSingleEventSignature {
@@ -286,14 +289,15 @@ func contractGetTransfersFromLog(logs []*bchain.RpcLog) (bchain.TokenTransfers, 
 				continue
 			}
 			if err != nil {
-				return nil, err
+				glog.Warningf("contractGetTransfersFromLog: skipping unparseable log of contract %s, tx %s: %v", l.Address, txid, err)
+				continue
 			}
 			if tt != nil {
 				r = append(r, tt)
 			}
 		}
 	}
-	return r, nil
+	return r
 }
 
 func contractGetTransfersFromTx(tx *bchain.RpcTransaction) (bchain.TokenTransfers, error) {

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -241,10 +241,8 @@ func processERC1155TransferBatchEvent(l *bchain.RpcLog) (transfer *bchain.TokenT
 	if endValues > len(data) {
 		return nil, errors.New("ERC1155 TransferBatch, invalid values data length")
 	}
-	maxInt := uint64(^uint(0) >> 1)
-	if countValues > maxInt {
-		return nil, errors.New("ERC1155 TransferBatch, invalid data length")
-	}
+	// countValues cannot truncate: the endValues <= len(data) check above bounds
+	// it to len(data)/evmWordHex.
 	count := int(countValues)
 	idValues := make([]bchain.MultiTokenValue, count)
 	for i := 0; i < count; i++ {

--- a/bchain/coins/eth/contract_test.go
+++ b/bchain/coins/eth/contract_test.go
@@ -5,6 +5,7 @@ package eth
 import (
 	"fmt"
 	"math/big"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -224,6 +225,48 @@ func Test_contractGetTransfersFromLog(t *testing.T) {
 
 			}
 		})
+	}
+}
+
+func erc1155BatchWord(n uint64) string {
+	return fmt.Sprintf("%064x", n)
+}
+
+func malformedERC1155TransferBatchLog(count uint64) *bchain.RpcLog {
+	return &bchain.RpcLog{
+		Address: "0x1111111111111111111111111111111111111111",
+		Topics: []string{
+			tokenERC1155TransferBatchEventSignature,
+			"0x0000000000000000000000002222222222222222222222222222222222222222",
+			"0x0000000000000000000000003333333333333333333333333333333333333333",
+			"0x0000000000000000000000004444444444444444444444444444444444444444",
+		},
+		Data: "0x" +
+			erc1155BatchWord(0x40) +
+			erc1155BatchWord(0x60) +
+			erc1155BatchWord(count) +
+			erc1155BatchWord(count),
+	}
+}
+
+func Test_contractGetTransfersFromLogRejectsMalformedERC1155TransferBatchBeforeAllocation(t *testing.T) {
+	const count = 200000
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	transfers, err := contractGetTransfersFromLog([]*bchain.RpcLog{malformedERC1155TransferBatchLog(count)})
+	runtime.ReadMemStats(&after)
+	if err == nil {
+		t.Fatal("contractGetTransfersFromLog returned nil error for malformed ERC1155 TransferBatch")
+	}
+	if transfers != nil {
+		t.Fatalf("contractGetTransfersFromLog transfers = %+v, want nil", transfers)
+	}
+	if strings.Contains(err.Error(), "recovered from panic") {
+		t.Fatalf("contractGetTransfersFromLog recovered from panic instead of validating input: %v", err)
+	}
+	if delta := after.TotalAlloc - before.TotalAlloc; delta > 1_000_000 {
+		t.Fatalf("contractGetTransfersFromLog allocated %d bytes for malformed ERC1155 TransferBatch count %d", delta, count)
 	}
 }
 

--- a/bchain/coins/eth/contract_test.go
+++ b/bchain/coins/eth/contract_test.go
@@ -15,10 +15,9 @@ import (
 
 func Test_contractGetTransfersFromLog(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []*bchain.RpcLog
-		want    bchain.TokenTransfers
-		wantErr bool
+		name string
+		args []*bchain.RpcLog
+		want bchain.TokenTransfers
 	}{
 		{
 			name: "ERC20 transfer 1",
@@ -209,11 +208,7 @@ func Test_contractGetTransfersFromLog(t *testing.T) {
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := contractGetTransfersFromLog(tt.args)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("contractGetTransfersFromLog error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := contractGetTransfersFromLog(tt.args, "0xtxid")
 			if len(got) != len(tt.want) {
 				t.Errorf("contractGetTransfersFromLog len not same, %+v, want %+v", got, tt.want)
 			}
@@ -249,24 +244,47 @@ func malformedERC1155TransferBatchLog(count uint64) *bchain.RpcLog {
 	}
 }
 
-func Test_contractGetTransfersFromLogRejectsMalformedERC1155TransferBatchBeforeAllocation(t *testing.T) {
+func Test_processERC1155TransferBatchEventRejectsMalformedLogBeforeAllocation(t *testing.T) {
 	const count = 200000
 	runtime.GC()
 	var before, after runtime.MemStats
 	runtime.ReadMemStats(&before)
-	transfers, err := contractGetTransfersFromLog([]*bchain.RpcLog{malformedERC1155TransferBatchLog(count)})
+	transfer, err := processERC1155TransferBatchEvent(malformedERC1155TransferBatchLog(count))
 	runtime.ReadMemStats(&after)
 	if err == nil {
-		t.Fatal("contractGetTransfersFromLog returned nil error for malformed ERC1155 TransferBatch")
+		t.Fatal("processERC1155TransferBatchEvent returned nil error for malformed ERC1155 TransferBatch")
 	}
-	if transfers != nil {
-		t.Fatalf("contractGetTransfersFromLog transfers = %+v, want nil", transfers)
+	if transfer != nil {
+		t.Fatalf("processERC1155TransferBatchEvent transfer = %+v, want nil", transfer)
 	}
 	if strings.Contains(err.Error(), "recovered from panic") {
-		t.Fatalf("contractGetTransfersFromLog recovered from panic instead of validating input: %v", err)
+		t.Fatalf("processERC1155TransferBatchEvent recovered from panic instead of validating input: %v", err)
 	}
 	if delta := after.TotalAlloc - before.TotalAlloc; delta > 1_000_000 {
-		t.Fatalf("contractGetTransfersFromLog allocated %d bytes for malformed ERC1155 TransferBatch count %d", delta, count)
+		t.Fatalf("processERC1155TransferBatchEvent allocated %d bytes for malformed ERC1155 TransferBatch count %d", delta, count)
+	}
+}
+
+func Test_contractGetTransfersFromLogSkipsMalformedERC1155TransferBatch(t *testing.T) {
+	logs := []*bchain.RpcLog{
+		malformedERC1155TransferBatchLog(200000),
+		{ // valid ERC20 Transfer in the same receipt
+			Address: "0x76a45e8976499ab9ae223cc584019341d5a84e96",
+			Topics: []string{
+				tokenTransferEventSignature,
+				"0x0000000000000000000000002aacf811ac1a60081ea39f7783c0d26c500871a8",
+				"0x000000000000000000000000e9a5216ff992cfa01594d43501a56e12769eb9d2",
+			},
+			Data: "0x0000000000000000000000000000000000000000000000000000000000000123",
+		},
+	}
+	transfers := contractGetTransfersFromLog(logs, "0xtxid")
+	if len(transfers) != 1 {
+		t.Fatalf("contractGetTransfersFromLog transfers = %+v, want the valid transfer kept", transfers)
+	}
+	// the address could have different case
+	if strings.ToLower(transfers[0].Contract) != "0x76a45e8976499ab9ae223cc584019341d5a84e96" {
+		t.Fatalf("contractGetTransfersFromLog kept transfer of contract %s, want the valid ERC20 transfer", transfers[0].Contract)
 	}
 }
 

--- a/bchain/coins/eth/ethparser.go
+++ b/bchain/coins/eth/ethparser.go
@@ -571,12 +571,12 @@ func (p *EthereumParser) EthereumTypeGetTokenTransfersFromTx(tx *bchain.Tx) (bch
 	csd, ok := tx.CoinSpecificData.(bchain.EthereumSpecificData)
 	if ok {
 		if csd.Receipt != nil {
-			r, err = contractGetTransfersFromLog(csd.Receipt.Logs)
+			r = contractGetTransfersFromLog(csd.Receipt.Logs, tx.Txid)
 		} else {
 			r, err = contractGetTransfersFromTx(csd.Tx)
-		}
-		if err != nil {
-			return nil, err
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return r, nil

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -31,6 +31,10 @@ const defaultTimeout = 60 * time.Second
 const unknownMethodLabel = "unknown"
 const maxWebsocketMessageBytes int64 = 4 * 1024 * 1024
 const maxWebsocketPendingRequests = 48
+
+// maxWebsocketMempoolFiltersResponses caps getMempoolFilters responses accepted
+// by one connection but not yet written to the websocket.
+const maxWebsocketMempoolFiltersResponses = 4
 const maxWebsocketActiveRequests = 2048
 const maxWebsocketEstimateFeeBlocks = 32
 const maxWebsocketSubscribeAddresses = 1000
@@ -58,6 +62,7 @@ type websocketChannel struct {
 	conn                         *websocket.Conn
 	out                          chan *WsRes
 	pendingRequests              chan struct{}
+	mempoolFiltersSlots          chan struct{} // semaphore capping in-flight getMempoolFilters responses, see maxWebsocketMempoolFiltersResponses
 	ip                           string
 	ipKey                        string
 	blockKey                     string
@@ -338,16 +343,17 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	conn.SetReadLimit(maxWebsocketMessageBytes)
 	c := &websocketChannel{
-		id:              atomic.AddUint64(&connectionCounter, 1),
-		conn:            conn,
-		out:             make(chan *WsRes, outChannelSize),
-		pendingRequests: make(chan struct{}, maxWebsocketPendingRequests),
-		ip:              ip,
-		ipKey:           ipKey,
-		blockKey:        bKey,
-		blockable:       blockable,
-		requestHeader:   r.Header,
-		alive:           true,
+		id:                  atomic.AddUint64(&connectionCounter, 1),
+		conn:                conn,
+		out:                 make(chan *WsRes, outChannelSize),
+		pendingRequests:     make(chan struct{}, maxWebsocketPendingRequests),
+		mempoolFiltersSlots: make(chan struct{}, maxWebsocketMempoolFiltersResponses),
+		ip:                  ip,
+		ipKey:               ipKey,
+		blockKey:            bKey,
+		blockable:           blockable,
+		requestHeader:       r.Header,
+		alive:               true,
 	}
 	if s.messageRateLimit > 0 {
 		c.messageRate = newConnMessageRate(s.messageRateWindow)
@@ -484,7 +490,7 @@ func (c *websocketChannel) CloseOut(reason string) (bool, string) {
 		//clean out
 		close(c.out)
 		for len(c.out) > 0 {
-			<-c.out
+			c.finalize(<-c.out)
 		}
 		return true, closeReason
 	}
@@ -496,17 +502,22 @@ func (c *websocketChannel) DataOut(data *WsRes) {
 	defer c.aliveLock.Unlock()
 	if c.alive {
 		if len(c.out) < outChannelSize-1 {
+			// Enqueued: ownership passes to the out pipeline, which finalizes it
+			// once written (outputLoop) or drained (CloseOut).
 			c.out <- data
-		} else {
-			glog.Warning("Channel ", c.id, " overflow, closing")
-			if c.closeReason == "" {
-				c.closeReason = "overflow"
-			}
-			// close the connection but do not call CloseOut - would call duplicate c.aliveLock.Lock
-			// CloseOut will be called because the closed connection will cause break in the inputLoop
-			c.conn.Close()
+			return
 		}
+		glog.Warning("Channel ", c.id, " overflow, closing")
+		if c.closeReason == "" {
+			c.closeReason = "overflow"
+		}
+		// close the connection but do not call CloseOut - would call duplicate c.aliveLock.Lock
+		// CloseOut will be called because the closed connection will cause break in the inputLoop
+		c.conn.Close()
 	}
+	// Not enqueued (overflow or dead connection): the response never reaches the
+	// out pipeline, so release any slot it held here.
+	c.finalize(data)
 }
 
 func (c *websocketChannel) acquireRequestSlot() bool {
@@ -520,6 +531,27 @@ func (c *websocketChannel) acquireRequestSlot() bool {
 
 func (c *websocketChannel) releaseRequestSlot() {
 	<-c.pendingRequests
+}
+
+func (c *websocketChannel) acquireMempoolFiltersSlot() bool {
+	select {
+	case c.mempoolFiltersSlots <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *websocketChannel) releaseMempoolFiltersSlot() {
+	<-c.mempoolFiltersSlots
+}
+
+// finalize releases any resources a response held, exactly once
+func (c *websocketChannel) finalize(res *WsRes) {
+	if res != nil && res.release != nil {
+		res.release()
+		res.release = nil
+	}
 }
 
 func (s *WebsocketServer) inputLoop(c *websocketChannel) {
@@ -601,6 +633,7 @@ func (s *WebsocketServer) outputLoop(c *websocketChannel) {
 	for m := range c.out {
 		c.conn.SetWriteDeadline(time.Now().Add(defaultTimeout))
 		err := c.conn.WriteJSON(m)
+		c.finalize(m)
 		if err != nil {
 			glog.Error("Error sending message to ", c.id, ", ", err)
 			s.closeChannel(c, "write_error")
@@ -843,6 +876,8 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *WsRe
 func (s *WebsocketServer) onRequest(c *websocketChannel, req *WsReq) {
 	var err error
 	var data interface{}
+	// release is non-nil while this request holds a rate-capped endpoint slot.
+	var release func()
 	f, ok := requestHandlers[req.Method]
 	methodLabel := req.Method
 	if !ok {
@@ -859,9 +894,14 @@ func (s *WebsocketServer) onRequest(c *websocketChannel, req *WsReq) {
 		// nil data means no response
 		if data != nil {
 			c.DataOut(&WsRes{
-				ID:   req.ID,
-				Data: data,
+				ID:      req.ID,
+				Data:    data,
+				release: release,
 			})
+			release = nil // ownership handed to the response
+		}
+		if release != nil {
+			release() // no response was produced — free the slot now
 		}
 		s.metrics.WebsocketPendingRequests.With(common.Labels{"method": methodLabel}).Dec()
 	}()
@@ -871,6 +911,17 @@ func (s *WebsocketServer) onRequest(c *websocketChannel, req *WsReq) {
 		s.metrics.WebsocketReqDuration.With(common.Labels{"method": methodLabel}).Observe(float64(time.Since(t)) / 1e3) // in microseconds
 	}()
 	if ok {
+		if req.Method == "getMempoolFilters" {
+			if !c.acquireMempoolFiltersSlot() {
+				e := resultError{}
+				e.Error.Message = "mempool_filters_limit"
+				data = e
+				s.metrics.WebsocketRequests.With(common.Labels{"method": methodLabel, "status": "failure"}).Inc()
+				glog.Warning("Client ", c.id, " exceeded getMempoolFilters response limit, ", c.ip)
+				return
+			}
+			release = c.releaseMempoolFiltersSlot
+		}
 		data, err = f(s, c, req)
 		if err == nil {
 			glog.V(1).Info("Client ", c.id, " onRequest ", req.Method, " success")

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -32,8 +32,14 @@ const unknownMethodLabel = "unknown"
 const maxWebsocketMessageBytes int64 = 4 * 1024 * 1024
 const maxWebsocketPendingRequests = 48
 
-// maxWebsocketMempoolFiltersResponses caps getMempoolFilters responses accepted
-// by one connection but not yet written to the websocket.
+// maxWebsocketMempoolFiltersResponses caps per-connection getMempoolFilters
+// requests over their whole lifecycle: the slot is acquired before the handler
+// computes the (potentially large) response and released only after the
+// response is written to the websocket (or drained on close). The point is to
+// bound the peak memory held in computed-but-unwritten filter responses, so the
+// cap deliberately covers compute, queueing, and write together; a client that
+// pipelines more than this many requests, or reads slower than it requests,
+// gets a mempool_filters_limit error instead of queueing further responses.
 const maxWebsocketMempoolFiltersResponses = 4
 const maxWebsocketActiveRequests = 2048
 const maxWebsocketEstimateFeeBlocks = 32

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/trezor/blockbook/api"
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/bchain/coins/eth"
@@ -1380,6 +1382,64 @@ func TestWebsocketCloseOutReleasesQueuedMempoolFilterResponses(t *testing.T) {
 	}
 	if got := len(c.mempoolFiltersSlots); got != 0 {
 		t.Fatalf("held mempool filter slots = %d after CloseOut, want 0", got)
+	}
+}
+
+// TestWebsocketOutputLoopReleasesMempoolFilterSlotAfterWrite exercises the
+// primary slot-release path for a live connection: outputLoop's c.finalize(m)
+// after a successful WriteJSON. Neither TestWebsocketMempoolFilterResponseSlots
+// (raw semaphore) nor TestWebsocketCloseOutReleasesQueuedMempoolFilterResponses
+// (drain-on-close) touch this line, so without this test a removal of the
+// finalize call would leak a slot on every successful response and go undetected.
+func TestWebsocketOutputLoopReleasesMempoolFilterSlotAfterWrite(t *testing.T) {
+	// Stand up a real websocket connection pair so outputLoop's WriteJSON and
+	// finalize run against a live *websocket.Conn.
+	upgrader := websocket.Upgrader{}
+	serverConnCh := make(chan *websocket.Conn, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		serverConnCh <- conn
+	}))
+	defer ts.Close()
+
+	clientConn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+	serverConn := <-serverConnCh
+	defer serverConn.Close()
+
+	c := &websocketChannel{
+		conn:                serverConn,
+		out:                 make(chan *WsRes, outChannelSize),
+		mempoolFiltersSlots: make(chan struct{}, maxWebsocketMempoolFiltersResponses),
+		alive:               true,
+	}
+	if !c.acquireMempoolFiltersSlot() {
+		t.Fatal("acquireMempoolFiltersSlot() = false")
+	}
+	c.out <- &WsRes{ID: "mempool", Data: struct{}{}, release: c.releaseMempoolFiltersSlot}
+	close(c.out) // outputLoop returns once the single queued response is written
+
+	s := &WebsocketServer{}
+	done := make(chan struct{})
+	go func() {
+		s.outputLoop(c)
+		close(done)
+	}()
+
+	if _, _, err := clientConn.ReadMessage(); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	<-done
+
+	if got := len(c.mempoolFiltersSlots); got != 0 {
+		t.Fatalf("held mempool filter slots = %d after successful write, want 0", got)
 	}
 }
 

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1344,6 +1344,45 @@ func TestWebsocketTrackWorkAppliesGlobalLimit(t *testing.T) {
 	}
 }
 
+func TestWebsocketMempoolFilterResponseSlots(t *testing.T) {
+	c := &websocketChannel{
+		mempoolFiltersSlots: make(chan struct{}, maxWebsocketMempoolFiltersResponses),
+	}
+	for i := 0; i < maxWebsocketMempoolFiltersResponses; i++ {
+		if !c.acquireMempoolFiltersSlot() {
+			t.Fatalf("acquireMempoolFiltersSlot() = false at slot %d", i)
+		}
+	}
+	if c.acquireMempoolFiltersSlot() {
+		t.Fatal("acquireMempoolFiltersSlot() = true at limit")
+	}
+	c.releaseMempoolFiltersSlot()
+	if !c.acquireMempoolFiltersSlot() {
+		t.Fatal("acquireMempoolFiltersSlot() = false after release")
+	}
+}
+
+func TestWebsocketCloseOutReleasesQueuedMempoolFilterResponses(t *testing.T) {
+	c := &websocketChannel{
+		out:                 make(chan *WsRes, outChannelSize),
+		mempoolFiltersSlots: make(chan struct{}, maxWebsocketMempoolFiltersResponses),
+		alive:               true,
+	}
+	if !c.acquireMempoolFiltersSlot() {
+		t.Fatal("acquireMempoolFiltersSlot() = false")
+	}
+	c.DataOut(&WsRes{ID: "mempool", Data: struct{}{}, release: c.releaseMempoolFiltersSlot})
+	if got := len(c.mempoolFiltersSlots); got != 1 {
+		t.Fatalf("held mempool filter slots = %d before CloseOut, want 1", got)
+	}
+	if closed, reason := c.CloseOut("test"); !closed || reason != "test" {
+		t.Fatalf("CloseOut() = %v, %q, want true, test", closed, reason)
+	}
+	if got := len(c.mempoolFiltersSlots); got != 0 {
+		t.Fatalf("held mempool filter slots = %d after CloseOut, want 0", got)
+	}
+}
+
 func TestWebsocketShutdownIsIdempotent(t *testing.T) {
 	s := newShutdownTestServer()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/server/ws_types.go
+++ b/server/ws_types.go
@@ -17,6 +17,8 @@ type WsReq struct {
 type WsRes struct {
 	ID   string      `json:"id" ts_doc:"Corresponding request identifier."`
 	Data interface{} `json:"data" ts_doc:"Payload of the response, structure depends on the request."`
+	// release, if non-nil, is invoked exactly once when this response leaves the out pipeline
+	release func()
 }
 
 type resultError struct {


### PR DESCRIPTION
## Summary

Adds upper-cap / bound-checking limits to several server endpoints to improve resilience against unbounded memory growth and abusive request patterns (closes #1581). Each cap is covered by unit tests.

## Changes

**WebSocket — cap in-flight `getMempoolFilters` responses**
Per-connection semaphore (`maxWebsocketMempoolFiltersResponses = 4`) bounds each request from acceptance until its response is written (or drained on close), capping the peak memory held in large filter responses; excess requests are rejected with a `mempool_filters_limit` error. Adds a `release`/`finalize` hook on `WsRes` so the slot is freed exactly once across write, drain-on-close, and overflow paths.

**Fiat rates — bound and normalize currency selectors**
Replaces `removeEmpty` with `normalizeFiatCurrencies` (trim, lowercase, dedupe, bound) applied once at the entry points (`GetCurrentFiatRates`, `GetFiatRatesForTimestamps`, `GetBalanceHistory`, `GetXpubBalanceHistory`) before any per-result maps are allocated; downstream helpers rely on the pre-normalized slice. New limits `MaxFiatRatesCurrencies = 128` (applied to the raw selector list length) and `MaxFiatRatesCurrencyCodeLength = 16` return a client-facing error when exceeded.

**EVM — harden ERC-1155 `TransferBatch` log parsing**
Rewrites offset/length handling with explicit bounds and overflow checks to avoid possible OOM / out-of-range slicing from malformed log data, validating total data length before allocating the result slice.

## Behavior changes

- A currency selector longer than 16 characters is now rejected with a public `APIError` (HTTP 400 on REST). The REST tickers endpoint never splits `?currency=` on commas — it passes the whole value as a single selector — so a comma-joined value is only rejected once it exceeds 16 chars. `?currency=usd,eur,gbp,jpy` (15 chars) therefore still returns `200` with `{"usd,eur,gbp,jpy": -1}` exactly as before; only a longer value such as `?currency=usd,eur,gbp,cad,jpy` (19 chars) now returns `400 "currency code too long, max 16"`.
- The currency-count cap (128) applies to the raw selector list length before deduplication, so the validation work itself is bounded by the cap; a longer list is rejected even if it would deduplicate to fewer entries. This cap only bites on the array-accepting WS methods (`getCurrentFiatRates`, `getFiatRatesForTimestamps`) and the balance-history paths; the single-param REST tickers endpoint always passes 0 or 1 selector, so it can never trip the count cap.
- More than 4 getMempoolFilters requests in flight on one websocket connection (accepted but not yet written back) are rejected with a `mempool_filters_limit` error.

## Tests
- `server/websocket_test.go` — mempool filters slot capping, including release after a successful write (via `outputLoop` over a live connection) and drain-on-close
- `api/fiat_rates_api_test.go`, `api/fiat_balance_history_test.go` — currency normalization/limits
- `bchain/coins/eth/contract_test.go` — malformed ERC-1155 batch logs

