### PR TITLE
perf(api): resolve tx inputs without unpacking whole prev-tx records

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -361,12 +361,13 @@ func (w *Worker) GetTransactionFromBchainTx(bchainTx *bchain.Tx, height int, spe
 		if w.chainType == bchain.ChainBitcoinType {
 			//  bchainVin.Txid=="" is coinbase transaction
 			if bchainVin.Txid != "" {
-				// load spending addresses from TxAddresses
-				tas, err := w.db.GetTxAddresses(bchainVin.Txid)
+				// load the spending address from TxAddresses; only the spent output
+				// is needed, so avoid unpacking the whole previous-tx record
+				output, err := w.db.GetTxAddressesOutput(bchainVin.Txid, vin.Vout)
 				if err != nil {
-					return nil, errors.Annotatef(err, "GetTxAddresses %v", bchainVin.Txid)
+					return nil, errors.Annotatef(err, "GetTxAddressesOutput %v", bchainVin.Txid)
 				}
-				if tas == nil {
+				if output == nil {
 					// try to load from backend
 					otx, _, err := w.txCache.GetTransaction(bchainVin.Txid)
 					if err != nil {
@@ -397,16 +398,13 @@ func (w *Worker) GetTransactionFromBchainTx(bchainTx *bchain.Tx, height int, spe
 						aggregateAddresses(addresses, vin.Addresses, vin.IsAddress)
 					}
 				} else {
-					if len(tas.Outputs) > int(vin.Vout) {
-						output := &tas.Outputs[vin.Vout]
-						vin.ValueSat = (*Amount)(&output.ValueSat)
-						vin.AddrDesc = output.AddrDesc
-						vin.Addresses, vin.IsAddress, err = output.Addresses(w.chainParser)
-						if err != nil {
-							glog.Errorf("output.Addresses error %v, tx %v, output %v", err, bchainVin.Txid, i)
-						}
-						aggregateAddresses(addresses, vin.Addresses, vin.IsAddress)
+					vin.ValueSat = (*Amount)(&output.ValueSat)
+					vin.AddrDesc = output.AddrDesc
+					vin.Addresses, vin.IsAddress, err = output.Addresses(w.chainParser)
+					if err != nil {
+						glog.Errorf("output.Addresses error %v, tx %v, output %v", err, bchainVin.Txid, i)
 					}
+					aggregateAddresses(addresses, vin.Addresses, vin.IsAddress)
 				}
 				if vin.ValueSat != nil {
 					valInSat.Add(&valInSat, (*big.Int)(vin.ValueSat))

--- a/api/worker_test.go
+++ b/api/worker_test.go
@@ -4,13 +4,20 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
 	"github.com/trezor/blockbook/common"
+	"github.com/trezor/blockbook/db"
 	"github.com/trezor/blockbook/fiat"
+	"github.com/trezor/blockbook/tests/dbtestdata"
 )
 
 func TestSystemInfoInSync(t *testing.T) {
@@ -304,3 +311,105 @@ func TestTronBalanceHistoryOverrides(t *testing.T) {
 		})
 	}
 }
+
+// BenchmarkTxInputResolution measures GetTransactionFromBchainTx as a function of
+// a transaction's input fan-in, using the plain Bitcoin-testnet parser. Each input's
+// previous output is resolved from the database, so this tracks how per-transaction
+// allocation and time scale with the input count. The fan-in values span a wide range
+// to make that scaling visible and to guard against regressions in input resolution.
+//
+//	go test -tags unittest -run x -bench TxInputResolution -benchmem ./api/
+func BenchmarkTxInputResolution(b *testing.B) {
+	for _, fanIn := range []int{8, 32, 128, 512, 2048} {
+		b.Run("fanIn="+strconv.Itoa(fanIn), func(b *testing.B) {
+			worker, subjectTx, cleanup := buildHighFanInWorker(b, fanIn)
+			defer cleanup()
+			addresses := make(map[string]struct{})
+
+			tx, err := worker.GetTransactionFromBchainTx(subjectTx, 2, false, false, addresses)
+			require.NoError(b, err)
+			require.Len(b, tx.Vin, fanIn)
+			require.True(b, tx.Vin[fanIn-1].IsAddress && tx.Vin[fanIn-1].ValueSat != nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := worker.GetTransactionFromBchainTx(subjectTx, 2, false, false, addresses); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// buildHighFanInWorker indexes a previous transaction with fanIn outputs and a
+// subject transaction whose fanIn inputs each spend one of them (all referencing the
+// same previous tx, concentrating resolution on a single large record), and returns
+// a Worker plus the subject tx. Only db + parser are needed: GetTransactionFromBchainTx
+// for a confirmed Bitcoin-type tx (specificJSON=false) does not touch the chain.
+func buildHighFanInWorker(tb testing.TB, fanIn int) (*Worker, *bchain.Tx, func()) {
+	tb.Helper()
+	parser := btc.NewBitcoinParser(btc.GetChainParams("test"), &btc.Configuration{BlockAddressesToKeep: 1})
+	script := dbtestdata.AddressToPubKeyHex(dbtestdata.Addr1, parser)
+
+	prevTxid := fanInHash(1)
+	prevOuts := make([]bchain.Vout, fanIn)
+	subjectIns := make([]bchain.Vin, fanIn)
+	for j := 0; j < fanIn; j++ {
+		prevOuts[j] = fanInVout(uint32(j), script)
+		subjectIns[j] = bchain.Vin{Txid: prevTxid, Vout: uint32(j), Sequence: 0xffffffff}
+	}
+	prevTx := fanInTx(prevTxid, 1, []bchain.Vin{{Coinbase: "01", Sequence: 0xffffffff}}, prevOuts)
+	subjectTx := fanInTx(fanInHash(2), 2, subjectIns, []bchain.Vout{fanInVout(0, script), fanInVout(1, script)})
+
+	blocks := []*bchain.Block{
+		{BlockHeader: bchain.BlockHeader{Hash: fanInHash(1_000_001), Height: 1, Time: 1_700_000_001}, Txs: []bchain.Tx{*prevTx}},
+		{BlockHeader: bchain.BlockHeader{Hash: fanInHash(1_000_002), Height: 2, Time: 1_700_000_002}, Txs: []bchain.Tx{*subjectTx}},
+	}
+
+	tmp, err := os.MkdirTemp("", "vin-resolution")
+	require.NoError(tb, err)
+	database, err := db.NewRocksDB(tmp, 100000, -1, parser, nil, false)
+	require.NoError(tb, err)
+	cleanup := func() {
+		require.NoError(tb, database.Close())
+		require.NoError(tb, os.RemoveAll(tmp))
+	}
+
+	is, err := database.LoadInternalState(&common.Config{CoinName: "coin-unittest"})
+	require.NoError(tb, err)
+	database.SetInternalState(is)
+
+	bulk, err := database.InitBulkConnect()
+	require.NoError(tb, err)
+	for i, block := range blocks {
+		require.NoError(tb, bulk.ConnectBlock(block, i == len(blocks)-1))
+	}
+	require.NoError(tb, bulk.Close())
+	is.FinishedSync(uint32(len(blocks)))
+
+	return &Worker{db: database, chainParser: parser, chainType: bchain.ChainBitcoinType, is: is}, subjectTx, cleanup
+}
+
+func fanInTx(txid string, height uint32, vin []bchain.Vin, vout []bchain.Vout) *bchain.Tx {
+	return &bchain.Tx{
+		Txid:          txid,
+		Version:       1,
+		Vin:           vin,
+		Vout:          vout,
+		BlockHeight:   height,
+		Confirmations: 1,
+		Time:          int64(1_700_000_000 + height),
+		Blocktime:     int64(1_700_000_000 + height),
+	}
+}
+
+func fanInVout(n uint32, scriptHex string) bchain.Vout {
+	return bchain.Vout{
+		ValueSat:     *big.NewInt(100000),
+		N:            n,
+		ScriptPubKey: bchain.ScriptPubKey{Hex: scriptHex, Addresses: []string{dbtestdata.Addr1}},
+	}
+}
+
+func fanInHash(n uint64) string { return fmt.Sprintf("%064x", n) }

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -1117,6 +1117,49 @@ func (d *RocksDB) GetTxAddresses(txid string) (*TxAddresses, error) {
 	return d.getTxAddresses(btxID)
 }
 
+// GetTxAddressesOutput returns Outputs[vout] of the transaction's TxAddresses
+// record, or nil if the record or that output is not present. Unlike
+// GetTxAddresses it does not unpack the whole record: inputs and preceding
+// outputs are skipped without allocating, so resolving a single previous output
+// costs O(1) allocations regardless of the referenced transaction's size.
+func (d *RocksDB) GetTxAddressesOutput(txid string, vout uint32) (*TxOutput, error) {
+	btxID, err := d.chainParser.PackTxid(txid)
+	if err != nil {
+		return nil, err
+	}
+	val, err := d.db.GetCF(d.ro, d.cfh[cfTxAddresses], btxID)
+	if err != nil {
+		return nil, err
+	}
+	defer val.Free()
+	buf := val.Data()
+	// 3 is minimum length of a txAddresses record - 1 byte height, 1 byte inputs len, 1 byte outputs len
+	if len(buf) < 3 {
+		return nil, nil
+	}
+	_, l := unpackVaruint(buf) // height
+	if d.extendedIndex {
+		_, n := unpackVaruint(buf[l:]) // vsize
+		l += n
+	}
+	inputs, n := unpackVaruint(buf[l:])
+	l += n
+	for i := uint(0); i < inputs; i++ {
+		l += d.packedTxInputLen(buf[l:])
+	}
+	outputs, n := unpackVaruint(buf[l:])
+	l += n
+	if uint(vout) >= outputs {
+		return nil, nil
+	}
+	for i := uint(0); i < uint(vout); i++ {
+		l += d.packedTxOutputLen(buf[l:])
+	}
+	var output TxOutput
+	d.unpackTxOutput(&output, buf[l:])
+	return &output, nil
+}
+
 // AddrDescForOutpoint is a function that returns address descriptor and value for given outpoint or nil if outpoint not found
 func (d *RocksDB) AddrDescForOutpoint(outpoint bchain.Outpoint) (bchain.AddressDescriptor, *big.Int) {
 	ta, err := d.GetTxAddresses(outpoint.Txid)
@@ -1359,6 +1402,50 @@ func (d *RocksDB) unpackTxOutput(to *TxOutput, buf []byte) int {
 		al += l
 	}
 	return al
+}
+
+// packedTxInputLen returns the byte length of the packed input at the start of buf
+// without allocating. Keep in sync with appendTxInput/unpackTxInput.
+func (d *RocksDB) packedTxInputLen(buf []byte) int {
+	if d.extendedIndex {
+		al, pos := unpackVarint(buf)
+		coinbase := al < 0
+		if coinbase {
+			al = ^al
+		}
+		pos += al                // addrDesc
+		pos += int(buf[pos]) + 1 // value (1-byte length prefix + bytes)
+		if !coinbase {
+			pos += d.chainParser.PackedTxidLen() // prev txid
+			_, n := unpackVaruint(buf[pos:])     // prev vout
+			pos += n
+		}
+		return pos
+	}
+	al, pos := unpackVaruint(buf)
+	pos += int(al)           // addrDesc
+	pos += int(buf[pos]) + 1 // value
+	return pos
+}
+
+// packedTxOutputLen returns the byte length of the packed output at the start of buf
+// without allocating. Keep in sync with appendTxOutput/unpackTxOutput.
+func (d *RocksDB) packedTxOutputLen(buf []byte) int {
+	al, pos := unpackVarint(buf)
+	spent := al < 0
+	if spent {
+		al = ^al
+	}
+	pos += al                // addrDesc
+	pos += int(buf[pos]) + 1 // value
+	if d.extendedIndex && spent {
+		pos += d.chainParser.PackedTxidLen() // spent txid
+		_, n := unpackVaruint(buf[pos:])     // spent index
+		pos += n
+		_, n = unpackVaruint(buf[pos:]) // spent height
+		pos += n
+	}
+	return pos
 }
 
 func (d *RocksDB) packTxIndexes(txi []txIndexes) []byte {

--- a/db/rocksdb_test.go
+++ b/db/rocksdb_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/linxGnu/grocksdb"
 	"github.com/martinboehm/btcutil/chaincfg"
+	"github.com/stretchr/testify/require"
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/bchain/coins/btc"
 	"github.com/trezor/blockbook/common"
@@ -1744,6 +1745,84 @@ func TestRocksDB_packTxIndexes_unpackTxIndexes(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.data) {
 				t.Errorf("unpackTxIndexes() = %+v, want %+v", got, tt.data)
 			}
+		})
+	}
+}
+
+// setupRocksDBWithExtendedIndex is like setupRocksDB but lets the caller choose
+// the extendedIndex layout; used by TestGetTxAddressesOutput to cover both forms.
+func setupRocksDBWithExtendedIndex(t *testing.T, p bchain.BlockChainParser, extendedIndex bool) *RocksDB {
+	t.Helper()
+	tmp, err := os.MkdirTemp("", "testdb")
+	require.NoError(t, err)
+	d, err := NewRocksDB(tmp, 100000, -1, p, nil, extendedIndex)
+	require.NoError(t, err)
+	is, err := d.LoadInternalState(&common.Config{CoinName: "coin-unittest"})
+	require.NoError(t, err)
+	d.SetInternalState(is)
+	return d
+}
+
+// TestGetTxAddressesOutput checks that GetTxAddressesOutput(txid, vout) returns the
+// same TxOutput as GetTxAddresses(txid).Outputs[vout]: the former skips over the
+// height, inputs and preceding outputs by length and unpacks only the target output,
+// while the latter unpacks the whole record. It runs with extendedIndex off and on
+// and uses a record with a coinbase input and both spent and unspent outputs, so
+// every length-skip case in packedTxInputLen/packedTxOutputLen is covered.
+func TestGetTxAddressesOutput(t *testing.T) {
+	for _, extendedIndex := range []bool{false, true} {
+		name := "basic"
+		if extendedIndex {
+			name = "extendedIndex"
+		}
+		t.Run(name, func(t *testing.T) {
+			d := setupRocksDBWithExtendedIndex(t, &testBitcoinParser{
+				BitcoinParser: bitcoinTestnetParser(),
+			}, extendedIndex)
+			defer closeAndDestroyRocksDB(t, d)
+
+			ta := &TxAddresses{
+				Height: 12345,
+				Inputs: []TxInput{
+					{ValueSat: *big.NewInt(0)}, // coinbase: empty AddrDesc, no Txid
+					{AddrDesc: addressToAddrDesc(dbtestdata.Addr1, d.chainParser), ValueSat: *big.NewInt(1000), Txid: strings.Repeat("b2", 32), Vout: 0},
+					{AddrDesc: addressToAddrDesc(dbtestdata.Addr2, d.chainParser), ValueSat: *big.NewInt(2000), Txid: strings.Repeat("c3", 32), Vout: 3},
+				},
+				Outputs: []TxOutput{
+					{AddrDesc: addressToAddrDesc(dbtestdata.Addr3, d.chainParser), ValueSat: *big.NewInt(3000)},
+					{AddrDesc: addressToAddrDesc(dbtestdata.Addr4, d.chainParser), ValueSat: *big.NewInt(4000), Spent: true, SpentTxid: strings.Repeat("d4", 32), SpentIndex: 5, SpentHeight: 12346},
+					{AddrDesc: addressToAddrDesc(dbtestdata.Addr5, d.chainParser), ValueSat: *big.NewInt(5000)},
+				},
+			}
+			txid := strings.Repeat("a1", 32)
+
+			btxID, err := d.chainParser.PackTxid(txid)
+			require.NoError(t, err)
+			wb := grocksdb.NewWriteBatch()
+			defer wb.Destroy()
+			require.NoError(t, d.storeTxAddresses(wb, map[string]*TxAddresses{string(btxID): ta}))
+			require.NoError(t, d.db.Write(d.wo, wb))
+
+			full, err := d.GetTxAddresses(txid)
+			require.NoError(t, err)
+			require.NotNil(t, full)
+
+			// Each output read singly must equal the full-record unpack.
+			for vout := range full.Outputs {
+				got, err := d.GetTxAddressesOutput(txid, uint32(vout))
+				require.NoErrorf(t, err, "vout %d", vout)
+				require.NotNilf(t, got, "vout %d", vout)
+				require.Equalf(t, full.Outputs[vout], *got, "vout %d", vout)
+			}
+
+			// Out-of-range vout and missing txid both return nil.
+			got, err := d.GetTxAddressesOutput(txid, uint32(len(full.Outputs)))
+			require.NoError(t, err)
+			require.Nil(t, got, "out-of-range vout")
+
+			got, err = d.GetTxAddressesOutput(strings.Repeat("ee", 32), 0)
+			require.NoError(t, err)
+			require.Nil(t, got, "missing txid")
 		})
 	}
 }


### PR DESCRIPTION
### Summary
`GetTransactionFromBchainTx` — the path behind `GET /api/v2/tx/<txid>` and address
queries with `details=txs` — resolves each input's previous output by calling
`db.GetTxAddresses(prevTxid)`, which **unpacks the entire `TxAddresses` record**
(every input and every output of the referenced transaction) just to read a single
`Outputs[vout]`. For transactions with many inputs that reference large previous
transactions, this allocates on the order of `inputs × record size`, so a single API
response can allocate **hundreds of MB** of transient heap. On high-fan-in addresses
(pools, treasuries, consolidation/sweep wallets) this drives severe memory
amplification.

This PR makes input resolution read **only the one output it needs**, taking
allocations from quadratic to linear with no change in behavior or on-disk format.

### Root cause
- The vin loop calls `GetTxAddresses(prevTxid)` once per input.
- `GetTxAddresses` fully deserializes the record: slices + `big.Int`s for *all* inputs
  and *all* outputs of the previous tx — only to read one output.
- When `K` inputs reference the same `K`-output previous tx, cost ≈ `K × unpack(K)` =
  **O(K²)** allocations. In general the amplification per input is the number of
  outputs in the previous tx it spends.

### Fix
- Add `db.GetTxAddressesOutput(txid, vout)`: returns just `Outputs[vout]`. It walks the
  packed record computing the byte length of the height, inputs, and preceding outputs
  (`packedTxInputLen` / `packedTxOutputLen`) and **skips them without allocating**, then
  unpacks only the target output — O(1) allocations regardless of the referenced tx's
  size.
- Use it in the vin-resolution loop. Resolved value/addresses are identical, and the
  `txCache` fallback for not-yet-indexed transactions is preserved.
- Works unchanged with and without `-extendedindex`.

### Benchmark
`BenchmarkTxInputResolution` (added in this PR) resolves a transaction whose inputs all
spend outputs of one large previous tx, sweeping the input fan-in. Machine:
Apple M4 Pro, `darwin/arm64`, Go default `-benchtime`.

**Allocated bytes per call (`B/op`)**

| fan-in (inputs) | before | after | reduction |
|---:|---:|---:|---:|
| 8 | 25,888 | 17,120 | 1.5× |
| 32 | 196,705 | 57,184 | 3.4× |
| 128 | 2,445,679 | 216,418 | 11× |
| 512 | 36,507,509 (≈34.8 MB) | 851,698 (≈0.8 MB) | 43× |
| 2048 | 540,268,338 (≈515 MB) | 3,379,106 (≈3.2 MB) | **160×** |

**Allocations per call (`allocs/op`)**

| fan-in | before | after | reduction |
|---:|---:|---:|---:|
| 8 | 321 | 193 | 1.7× |
| 32 | 2,673 | 625 | 4.3× |
| 128 | 35,121 | 2,353 | 15× |
| 512 | 533,553 | 9,265 | 58× |
| 2048 | 8,425,529 | 36,913 | **228×** |

**Time per call (`ns/op`)**

| fan-in | before | after | speedup |
|---:|---:|---:|---:|
| 8 | 10,258 | 8,385 | 1.2× |
| 32 | 57,981 | 30,730 | 1.9× |
| 128 | 565,081 | 136,454 | 4.1× |
| 512 | 7,896,200 | 884,482 | 8.9× |
| 2048 | 121,848,819 (≈122 ms) | 11,650,475 (≈12 ms) | **10×** |

### Reproducing the numbers

```bash
# After (this PR):
go test -tags unittest -run x -bench TxInputResolution -benchmem ./api/

# Before (pre-fix): restore the previous input-resolution path, run, then put the fix back.
# api/worker.go is the only production file changed, so reverting it to master recreates
# the old behavior while keeping the benchmark this PR adds.
git checkout master -- api/worker.go     # or: git checkout HEAD~1 -- api/worker.go
go test -tags unittest -run x -bench TxInputResolution -benchmem ./api/
git checkout HEAD -- api/worker.go        # restore the fix
```

> If your environment's RocksDB build isn't linked with a compression library, append
> `-args -noCompression` to the `go test` commands.

### Tests
- `TestGetTxAddressesOutput` (both index modes): asserts the single-output read equals
  `GetTxAddresses().Outputs[vout]` for a record containing a coinbase input and a mix of
  spent/unspent outputs (covers every `packedTxInputLen`/`packedTxOutputLen` branch),
  plus out-of-range `vout` and missing-txid cases.
- `BenchmarkTxInputResolution`: input fan-in scaling (above).

### Scope / risk
- Additive and contained: one new exported method + two small non-allocating length
  helpers in `db/rocksdb.go`, one call site changed in `api/worker.go`. No on-disk format
  change; no behavioral change to API responses.