### PR TITLE
fix(L2-config): disable mempool sync on OP Stack and Arbitrum chains

### DIFF
--- a/configs/coins/arbitrum.json
+++ b/configs/coins/arbitrum.json
@@ -55,6 +55,7 @@
                 "averageBlockTimeMs": 250,
                 "mempoolTxTimeoutHours": 12,
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"arbitrum-one\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}"

--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -67,6 +67,7 @@
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"arbitrum-one\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",

--- a/configs/coins/arbitrum_nova.json
+++ b/configs/coins/arbitrum_nova.json
@@ -54,6 +54,7 @@
                 "averageBlockTimeMs": 250,
                 "mempoolTxTimeoutHours": 12,
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}"

--- a/configs/coins/arbitrum_nova_archive.json
+++ b/configs/coins/arbitrum_nova_archive.json
@@ -57,6 +57,7 @@
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",

--- a/configs/coins/base.json
+++ b/configs/coins/base.json
@@ -56,6 +56,7 @@
                 "averageBlockTimeMs": 2000,
                 "mempoolTxTimeoutHours": 12,
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"base\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}"

--- a/configs/coins/optimism.json
+++ b/configs/coins/optimism.json
@@ -56,6 +56,7 @@
                 "averageBlockTimeMs": 2000,
                 "mempoolTxTimeoutHours": 12,
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"optimistic-ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}"

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -69,6 +69,7 @@
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,
+                "disableMempoolSync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"optimistic-ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",


### PR DESCRIPTION
## Problem

On restart, optimism_archive logs:

```
initializeMempool EthSubscribe newPendingTransactions: invalid subscription type for subscribe
```

op-geth and arbitrum-nitro do not implement the `newPendingTransactions` subscription filter. Without `disableMempoolSync: true`, Blockbook logs this error on startup and repeatedly attempts to resubscribe, wasting resources.

This was already fixed for `bsc_archive`, `polygon_archive`, and `base_archive` but was missing on the remaining L2 coin configs.

## Changes

Add `"disableMempoolSync": true` to 7 L2 coin configs:

| Config | Chain | Node |
|---|---|---|
| `optimism.json` | Optimism (full) | op-geth |
| `optimism_archive.json` | Optimism (archive) | op-geth |
| `base.json` | Base (full) | op-geth |
| `arbitrum.json` | Arbitrum One (full) | nitro |
| `arbitrum_archive.json` | Arbitrum One (archive) | nitro |
| `arbitrum_nova.json` | Arbitrum Nova (full) | nitro |
| `arbitrum_nova_archive.json` | Arbitrum Nova (archive) | nitro |

All 7 are L2 rollups whose node software does not expose the `newPendingTransactions` EthSubscribe filter.