### PR TITLE
ci: fixes and improvements from CI/CD pipeline review

### DIFF
--- a/.github/scripts/build_plan.py
+++ b/.github/scripts/build_plan.py
@@ -13,6 +13,7 @@ from runner import (
     log,
     parse_json_object,
     resolve_build_selection,
+    write_step_summary,
 )
 
 
@@ -66,6 +67,22 @@ def main() -> None:
             f"Runner {item['runner']} labels={item['labels_json']}: "
             + ", ".join(item["coins"])
         )
+
+    summary_lines = [
+        f"### Build plan ({build_env})",
+        "",
+        "| Runner | Coins |",
+        "| --- | --- |",
+    ]
+    for item in runner_matrix:
+        summary_lines.append(f"| {item['runner']} | {', '.join(item['coins'])} |")
+    if selection.skipped_prod_only and selection.requested_all:
+        summary_lines += [
+            "",
+            "Skipped prod-only coins for env=dev: "
+            + ", ".join(selection.skipped_prod_only),
+        ]
+    write_step_summary("\n".join(summary_lines))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/deploy_plan.py
+++ b/.github/scripts/deploy_plan.py
@@ -14,6 +14,7 @@ from runner import (
     parse_json_object,
     require_coin_config,
     resolve_deploy_selection,
+    write_step_summary,
 )
 
 
@@ -89,6 +90,20 @@ def main() -> None:
 
     log("Selected coins: " + ", ".join(requested))
     log("Connectivity regex: " + connectivity_regex)
+
+    summary_lines = [
+        "### Deploy plan",
+        "",
+        "| Coin | Runner |",
+        "| --- | --- |",
+    ]
+    for item in runner_matrix:
+        summary_lines.append(f"| {item['coin']} | {item['runner']} |")
+    summary_lines += [
+        "",
+        "E2E test coins: " + ", ".join(unique_test_coins),
+    ]
+    write_step_summary("\n".join(summary_lines))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/runner.py
+++ b/.github/scripts/runner.py
@@ -41,6 +41,15 @@ def log(message: str) -> None:
     print(f"{LOG_PREFIX} {message}", flush=True)
 
 
+def write_step_summary(markdown: str) -> None:
+    # Renders on the workflow run's summary page; a no-op outside Actions.
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write(markdown.rstrip("\n") + "\n")
+
+
 def parse_json_object(raw: str, description: str) -> dict:
     try:
         payload = json.loads(raw)

--- a/.github/scripts/validate_branch_or_tag.py
+++ b/.github/scripts/validate_branch_or_tag.py
@@ -23,8 +23,8 @@ def fail(message: str) -> None:
 def ref_exists(repo: str, ref: str, kind: str) -> bool:
     remote = f"https://github.com/{repo}.git"
     try:
-        subprocess.run(
-            ["git", "ls-remote", "--exit-code", f"--{kind}", remote, ref],
+        result = subprocess.run(
+            ["git", "ls-remote", "--exit-code", f"--{kind}", remote, "--", ref],
             check=True,
             capture_output=True,
             text=True,
@@ -34,7 +34,15 @@ def ref_exists(repo: str, ref: str, kind: str) -> bool:
         raise AssertionError("unreachable") from exc
     except subprocess.CalledProcessError:
         return False
-    return True
+    # ls-remote patterns are tail-matching globs, so e.g. 'mas*' or 'master'
+    # can match a different ref than the one actions/checkout will later use;
+    # accept only an exact ref-name match.
+    expected = f"refs/{kind}/{ref}"
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1] == expected:
+            return True
+    return False
 
 
 def validate_branch_or_tag(repo: str, ref: str) -> str:

--- a/.github/scripts/validate_branch_or_tag_test.py
+++ b/.github/scripts/validate_branch_or_tag_test.py
@@ -1,7 +1,8 @@
+import subprocess
 import unittest
 from unittest.mock import patch
 
-from validate_branch_or_tag import validate_branch_or_tag
+from validate_branch_or_tag import ref_exists, validate_branch_or_tag
 
 
 class ValidateBranchOrTagTest(unittest.TestCase):
@@ -19,6 +20,35 @@ class ValidateBranchOrTagTest(unittest.TestCase):
         with patch("validate_branch_or_tag.ref_exists", return_value=False):
             with self.assertRaisesRegex(SystemExit, "1"):
                 validate_branch_or_tag("trezor/blockbook", "missing-ref")
+
+
+class RefExistsTest(unittest.TestCase):
+    @staticmethod
+    def _ls_remote(stdout: str) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def test_accepts_exact_ref_name(self) -> None:
+        with patch(
+            "validate_branch_or_tag.subprocess.run",
+            return_value=self._ls_remote("abc123\trefs/heads/master\n"),
+        ):
+            self.assertTrue(ref_exists("trezor/blockbook", "master", "heads"))
+
+    def test_rejects_glob_pattern_matching_another_ref(self) -> None:
+        with patch(
+            "validate_branch_or_tag.subprocess.run",
+            return_value=self._ls_remote("abc123\trefs/heads/master\n"),
+        ):
+            self.assertFalse(ref_exists("trezor/blockbook", "mas*", "heads"))
+
+    def test_rejects_tail_match_of_longer_ref(self) -> None:
+        # ls-remote patterns tail-match, so 'master' would match
+        # 'feature/master' even when no branch named 'master' exists.
+        with patch(
+            "validate_branch_or_tag.subprocess.run",
+            return_value=self._ls_remote("abc123\trefs/heads/feature/master\n"),
+        ):
+            self.assertFalse(ref_exists("trezor/blockbook", "master", "heads"))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/wait_for_sync.py
+++ b/.github/scripts/wait_for_sync.py
@@ -21,6 +21,15 @@ def log(message: str) -> None:
     print(f"{LOG_PREFIX} {message}", flush=True)
 
 
+def read_error_body(exc: urllib.error.HTTPError) -> bytes:
+    # The connection can be reset while reading the error body (e.g. a proxy
+    # 502); that must degrade to an empty body, not kill the retry loop.
+    try:
+        return exc.read()
+    except Exception:
+        return b""
+
+
 def parse_requested_coins(raw: str) -> list[str]:
     text = raw.strip()
     if not text:
@@ -192,7 +201,7 @@ def main() -> None:
                 status, body = fetch_status(base_url, request_timeout, ssl_context)
             except urllib.error.HTTPError as exc:
                 status = exc.code
-                body = exc.read()
+                body = read_error_body(exc)
             except Exception as exc:
                 last_seen[coin] = f"{base_url}/api/status request failed: {exc}"
                 continue
@@ -204,7 +213,7 @@ def main() -> None:
                     status, body = fetch_status(base_url, request_timeout, ssl_context)
                 except urllib.error.HTTPError as exc:
                     status = exc.code
-                    body = exc.read()
+                    body = read_error_body(exc)
                 except Exception as exc:
                     last_seen[coin] = f"{base_url}/api/status request failed: {exc}"
                     continue
@@ -224,14 +233,16 @@ def main() -> None:
         if not pending:
             break
 
-        remaining_seconds = int(max(0, deadline - time.monotonic()))
-        if remaining_seconds == 0:
+        # Keep sub-second remainders: int() truncation used to declare a
+        # timeout with up to a second of budget (and one last poll) unused.
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
             break
 
         details = "; ".join(
             f"{coin}: {last_seen[coin]}" for coin in sorted(pending)
         )
-        log(f"Still waiting for Blockbook sync ({remaining_seconds}s left): {details}")
+        log(f"Still waiting for Blockbook sync ({remaining_seconds:.0f}s left): {details}")
         time.sleep(min(poll_seconds, remaining_seconds))
 
     if pending:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,9 @@ jobs:
     name: Build (${{ matrix.runner }})
     needs: prepare_build
     if: ${{ inputs.mode == 'build' }}
+    # Generous ceilings so a hung step can't hold a self-hosted runner for
+    # the 360-minute default; sized well above normal runtimes.
+    timeout-minutes: 240
     env:
       RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
     strategy:
@@ -139,6 +142,7 @@ jobs:
     name: Deploy (${{ matrix.coin }})
     needs: prepare_deploy
     if: ${{ inputs.mode == 'deploy' }}
+    timeout-minutes: 45
     env:
       RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
     strategy:
@@ -213,6 +217,7 @@ jobs:
     # for the coins that deployed, as long as they reached sync.
     if: ${{ !cancelled() && (needs.deploy.result == 'success' || needs.deploy.result == 'failure') && needs.wait-for-sync.result == 'success' }}
     runs-on: [self-hosted, bb-dev-selfhosted]
+    timeout-minutes: 60
     env:
       RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
       CONNECTIVITY_REGEX: ${{ needs.prepare_deploy.outputs.connectivity_regex }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout workflow code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Validate branch or tag
         env:
@@ -62,6 +64,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.RESOLVED_BRANCH_OR_TAG }}
+          persist-credentials: false
 
       - name: Build build plan
         id: plan
@@ -85,6 +88,8 @@ jobs:
     steps:
       - name: Checkout workflow code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Validate branch or tag
         env:
@@ -95,6 +100,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.RESOLVED_BRANCH_OR_TAG }}
+          persist-credentials: false
 
       - name: Build deploy/e2e plan
         id: plan
@@ -122,6 +128,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.RESOLVED_BRANCH_OR_TAG }}
+          persist-credentials: false
 
       - name: Export repository variables
         uses: ./.github/actions/export-env-vars
@@ -155,6 +162,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.RESOLVED_BRANCH_OR_TAG }}
+          persist-credentials: false
 
       - name: Export repository variables
         uses: ./.github/actions/export-env-vars
@@ -179,7 +187,8 @@ jobs:
         env:
           BRANCH_OR_TAG: ${{ env.RESOLVED_BRANCH_OR_TAG }}
           BB_BUILD_ENV: dev
-        run: ./contrib/scripts/deploy-bb-and-backend.sh "${{ matrix.coin }}" --force-confnew
+          DEPLOY_COIN: ${{ matrix.coin }}
+        run: ./contrib/scripts/deploy-bb-and-backend.sh "$DEPLOY_COIN" --force-confnew
 
   wait-for-sync:
     name: Wait For Sync
@@ -199,6 +208,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.RESOLVED_BRANCH_OR_TAG }}
+          persist-credentials: false
 
       - name: Export repository variables
         uses: ./.github/actions/export-env-vars
@@ -226,6 +236,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.RESOLVED_BRANCH_OR_TAG }}
+          persist-credentials: false
 
       - name: Export repository variables
         uses: ./.github/actions/export-env-vars

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,10 @@
 name: Build / Deploy
 
+# Surface what the run actually does in the run list; without this every
+# dispatch shows only the generic workflow name. env context is not
+# available in run-name, so the ref fallback is inlined.
+run-name: "${{ inputs.mode }} ${{ inputs.coins }} (${{ inputs.mode == 'build' && inputs.env || 'dev' }}) @ ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}"
+
 on:
   workflow_dispatch:
     inputs:
@@ -107,7 +112,7 @@ jobs:
         run: python3 ./.github/scripts/deploy_plan.py
 
   build:
-    name: Build (${{ matrix.runner }})
+    name: "Build (${{ matrix.runner }}: ${{ matrix.coins_csv }})"
     needs: prepare_build
     if: ${{ inputs.mode == 'build' }}
     # Generous ceilings so a hung step can't hold a self-hosted runner for

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,7 +180,10 @@ jobs:
   wait-for-sync:
     name: Wait For Sync
     needs: [prepare_deploy, deploy]
-    if: ${{ needs.deploy.result == 'success' }}
+    # deploy is a fail-fast:false matrix: one failed coin must not skip sync
+    # verification for the coins that did deploy, so run on partial failure
+    # too. Only 'skipped' (mode=build) and cancellation keep this job off.
+    if: ${{ !cancelled() && (needs.deploy.result == 'success' || needs.deploy.result == 'failure') }}
     runs-on: [self-hosted, bb-dev-selfhosted]
     timeout-minutes: 31
     env:
@@ -206,7 +209,9 @@ jobs:
   e2e-tests:
     name: E2E Tests (post-deploy)
     needs: [prepare_deploy, deploy, wait-for-sync]
-    if: ${{ needs.deploy.result == 'success' && needs.wait-for-sync.result == 'success' }}
+    # Mirror wait-for-sync: partially failed deploys still get e2e coverage
+    # for the coins that deployed, as long as they reached sync.
+    if: ${{ !cancelled() && (needs.deploy.result == 'success' || needs.deploy.result == 'failure') && needs.wait-for-sync.result == 'success' }}
     runs-on: [self-hosted, bb-dev-selfhosted]
     env:
       RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,16 +39,16 @@ on:
 permissions:
   contents: read
 
+env:
+  RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
+
 jobs:
   prepare_build:
     name: Prepare Build Plan
     runs-on: ubuntu-latest
     if: ${{ inputs.mode == 'build' }}
-    env:
-      RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
     outputs:
       runner_matrix: ${{ steps.plan.outputs.runner_matrix }}
-      coins_csv: ${{ steps.plan.outputs.coins_csv }}
     steps:
       - name: Checkout workflow code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -78,12 +78,9 @@ jobs:
     name: Prepare Deploy Plan
     runs-on: ubuntu-latest
     if: ${{ inputs.mode == 'deploy' }}
-    env:
-      RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
     outputs:
       runner_matrix: ${{ steps.plan.outputs.runner_matrix }}
       connectivity_regex: ${{ steps.plan.outputs.connectivity_regex }}
-      coins_csv: ${{ steps.plan.outputs.coins_csv }}
       test_coins_csv: ${{ steps.plan.outputs.test_coins_csv }}
     steps:
       - name: Checkout workflow code
@@ -116,8 +113,6 @@ jobs:
     # Generous ceilings so a hung step can't hold a self-hosted runner for
     # the 360-minute default; sized well above normal runtimes.
     timeout-minutes: 240
-    env:
-      RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -150,8 +145,6 @@ jobs:
     needs: prepare_deploy
     if: ${{ inputs.mode == 'deploy' }}
     timeout-minutes: 45
-    env:
-      RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -200,7 +193,6 @@ jobs:
     runs-on: [self-hosted, bb-dev-selfhosted]
     timeout-minutes: 6
     env:
-      RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
       COINS_INPUT: ${{ needs.prepare_deploy.outputs.test_coins_csv }}
       SYNC_TIMEOUT_SECONDS: "300"
     steps:
@@ -229,7 +221,6 @@ jobs:
     runs-on: [self-hosted, bb-dev-selfhosted]
     timeout-minutes: 60
     env:
-      RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
       CONNECTIVITY_REGEX: ${{ needs.prepare_deploy.outputs.connectivity_regex }}
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,11 +185,11 @@ jobs:
     # too. Only 'skipped' (mode=build) and cancellation keep this job off.
     if: ${{ !cancelled() && (needs.deploy.result == 'success' || needs.deploy.result == 'failure') }}
     runs-on: [self-hosted, bb-dev-selfhosted]
-    timeout-minutes: 31
+    timeout-minutes: 6
     env:
       RESOLVED_BRANCH_OR_TAG: ${{ inputs.branch_or_tag != '' && inputs.branch_or_tag || github.ref_name }}
       COINS_INPUT: ${{ needs.prepare_deploy.outputs.test_coins_csv }}
-      SYNC_TIMEOUT_SECONDS: "1800"
+      SYNC_TIMEOUT_SECONDS: "300"
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -105,3 +105,8 @@ jobs:
 
       - name: Validate backend artifact sources
         run: python3 ./.github/scripts/validate_backend_artifacts.py
+
+      - name: Run CI pipeline script tests
+        # Stdlib-only unit tests for the build/deploy plan scripts; without
+        # this step a regression in .github/scripts ships with green CI.
+        run: python3 -m unittest discover -s .github/scripts -p '*_test.py'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,9 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: [self-hosted, bb-dev-selfhosted]
+    # Generous ceilings so a hung step can't hold a self-hosted runner for
+    # the 360-minute default; sized well above normal runtimes.
+    timeout-minutes: 60
     # Defense-in-depth: never run untrusted fork-PR code on the self-hosted
     # runner. connectivity/integration already carry this guard; without it
     # here, unit-tests relied solely on the repo "require approval for fork
@@ -33,6 +36,7 @@ jobs:
   connectivity-tests:
     name: Connectivity Tests
     runs-on: [self-hosted, bb-dev-selfhosted]
+    timeout-minutes: 30
     needs: unit-tests
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
@@ -58,6 +62,7 @@ jobs:
   integration-tests:
     name: Integration Tests (RPC + Sync)
     runs-on: [self-hosted, bb-dev-selfhosted]
+    timeout-minutes: 180
     needs: connectivity-tests
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: read
 
+# Rapid pushes queue full unit->connectivity->integration chains for
+# already-superseded commits on the shared self-hosted pool. Cancel only
+# superseded PR runs; pushes to master/develop are never cancelled.
+concurrency:
+  group: testing-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
This PR addresses the issues found during a review of the `.github/` CI/CD pipeline (workflows, composite action, and pipeline scripts). Each issue is fixed in its own commit; changes were limited to fixes and guardrails with no intended behavior changes beyond the ones described below.

## Correctness fixes

### `43145215` fix(deploy): run post-deploy verification on partial matrix failure
deploy is a fail-fast:false matrix, but wait-for-sync and e2e-tests were gated on `needs.deploy.result == 'success'`. A single failed coin therefore skipped sync verification and e2e coverage for every coin that DID deploy, leaving freshly deployed instances unverified. Run both jobs on partial failure too; only mode=build (skipped) and cancellation keep them off.

### `de40df24` ci: run .github/scripts unit tests in the lint job
Seven `*_test.py` files (~1000 lines covering runner.py, build/deploy plans, backend policy and wait_for_sync) existed but were executed by no workflow or Makefile target, so regressions in the pipeline scripts shipped with green CI. Run them via unittest discover in the lint job; they are stdlib-only, need no secrets, and are safe for fork PRs on the GitHub-hosted runner.

### `f717d9e0` fix(ci/cd): require exact ref match in branch/tag validation
`git ls-remote` arguments are tail-matching glob patterns, so `mas*` passed validation, and `master` validated even if only `feature/master` existed — after which actions/checkout used the literal (nonexistent or different) ref. Check the returned ref name for an exact match and pass `--` so a ref can never be parsed as a git option. Git forbids glob characters in ref names, so no legitimate ref is rejected. Covered by three new unit tests.

### `0fb3621a` fix(ci/cd): keep wait_for_sync retrying through flaky error responses
`exc.read()` in the HTTPError handlers was unprotected: a connection reset while reading an error body (e.g. proxy 502) raised out of the handler and killed a wait that still had minutes of budget, failing the deploy on one flaky poll. Degrade an unreadable error body to empty instead. Also stop truncating the remaining budget to whole seconds, which declared a timeout with up to a second (and one final poll) left.

## Hardening / guardrails

### `137c161b` fix(deploy): harden shell interpolation and checkout credentials
Pass `matrix.coin` to deploy-bb-and-backend.sh via an env var instead of expanding `${{ }}` directly into the `run:` script, matching how every other dynamic value in this workflow is handled. Set `persist-credentials: false` on all checkouts so the GITHUB_TOKEN is not left in `.git/config` on the persistent self-hosted runners when post-step cleanup is skipped (cancelled job, crashed runner agent) — testing.yml already does this on the same runner pool. Nothing in the build/deploy path performs authenticated git operations after checkout.

### `3a7d3a1a` ci: bound all long-running jobs with timeout-minutes
Only wait-for-sync had a timeout; every other job fell back to GitHub's 360-minute default, so a hung apt lock, unresponsive backend RPC or stalled install could occupy a self-hosted runner for six hours and block everything queued behind it. Ceilings are sized well above normal runtimes so they only trip on genuine hangs.

### `8fd2c78a` ci: cancel superseded PR test runs with a concurrency group
Without a concurrency group, every push to a PR queued a full unit→connectivity→integration chain on the limited self-hosted pool even when a newer commit had already superseded it. Cancel-in-progress applies only to pull_request events; push runs on master/develop always run to completion.

## Tuning / cleanup

### `f39c59b1` ci: reduce wait-for-sync timeout from 30 to 5 minutes
Lower `SYNC_TIMEOUT_SECONDS` to 300 and the job `timeout-minutes` to 6, keeping the one-minute buffer over the script deadline.

### `0bbc5e4c` refactor(deploy): deduplicate ref resolution and drop unused outputs
The `RESOLVED_BRANCH_OR_TAG` ternary was copy-pasted as job-level env into all six jobs; a one-sided edit would make jobs resolve different refs. Hoist it to workflow-level env (inputs/github contexts are available there) so it exists once. Also drop the `prepare_*` `coins_csv` job outputs, which no downstream job consumes.

## UX / visibility

### `806ee57c` feat(ci/cd): show built/deployed coins in the Actions run UI
A dispatched run only showed "Prepare Build Plan → Build (production_builder)", so the run gave no hint which coins it actually built or deployed. Surface it in three places: a `run-name` with mode/coins/env/ref so the runs list says it, the coin list in the Build job name, and a runner→coins markdown table written by build_plan.py / deploy_plan.py to `GITHUB_STEP_SUMMARY` so it renders on the run's summary page.

## Noted during review but intentionally not changed here
- Plan scripts run from the requested `branch_or_tag` checkout rather than the trusted workflow ref (makes the validation step bypassable and old tags un-deployable) — fixing it would break testing modified plan scripts from a feature branch, so it needs a separate decision.
- `build_packages.py` maps `feature/x` and `feature-x` to the same staging directory — the path encoding must change in lockstep with `deploy-bb-and-backend.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
