### PR TITLE
fix(eth): avoid int64 overflow in on-chain base fee conversion

### DIFF
--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -2004,7 +2004,10 @@ func (b *EthereumRPC) EthereumTypeGetEip1559Fees() (*bchain.Eip1559Fees, error) 
 
 	hs, _ := json.Marshal(h)
 	baseFee, _ := hexutil.DecodeUint64(h.BaseFeePerGas[blocks-1])
-	fees.BaseFeePerGas = big.NewInt(int64(baseFee))
+	// SetUint64, not big.NewInt(int64(...)): base fee is wei and a value above math.MaxInt64
+	// (~9.22e18) would wrap negative on the int64 cast. Unreachable on mainnet today but possible
+	// on high-fee L2s. Matches the header path in attachBlockGas.
+	fees.BaseFeePerGas = new(big.Int).SetUint64(baseFee)
 	// We expose only baseFeePerGas here and deliberately do NOT add a separate "next block" base-fee
 	// field. eth_feeHistory returns one extra projected element beyond the requested range, but its
 	// meaning is backend-dependent: nodes with no distinct pending block (e.g. Erigon, which ethereum


### PR DESCRIPTION
**Severity: minor** — theoretical today, but a cheap and correct fix worth taking.

The pull-path EIP-1559 estimate (`EthereumTypeGetEip1559Fees`) decoded `baseFeePerGas` as `uint64` and then cast it to `int64` for `big.NewInt`. A value above `math.MaxInt64` (~9.22e18 wei) would wrap to a negative `big.Int`.

Not reachable on Ethereum mainnet today, but possible on high-fee L2s. Switching to `new(big.Int).SetUint64()` also makes this consistent with the header path in `attachBlockGas`, which already handles it correctly.

Follow-up from review of the EIP-1559 fields work (already merged to master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)