### PR TITLE
fix(eth): prevent slice-bounds panic from ENS log name-length overflow

### DIFF
--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -156,7 +156,7 @@ func processParam(data string, index int, dataOffset int, t *abi.Type, processed
 		offset <<= 1
 		d = int(offset) + dataOffset
 		dynIndex := d >> 6
-		if d+64 > len(data) || d < 0 {
+		if d+64 > len(data) || d < 0 || d+64 < d {
 			return nil, 0, false
 		}
 		// get element count of dynamic type
@@ -314,17 +314,18 @@ func getEnsRecord(l *rpcLogWithTxHash) *bchain.AddressAliasRecord {
 		if err != nil {
 			return nil
 		}
+		const nameStart = 194 + 64
 		// int(c)<<1 can overflow: c is attacker-controlled (up to 2^63-1) and Go's
 		// signed left shift wraps silently, so de can land anywhere in [0, 257]
-		// below the name start offset (194+64). The lower bound must be the slice
-		// start index, not 0 — a de below the start makes l.Data[194+64:de] a
-		// low>high slice expression that panics. Checking de < 194+64 guarantees
-		// 194+64 <= de <= len(l.Data), so the slice below can never panic.
-		de := 194 + 64 + (int(c) << 1)
-		if de > len(l.Data) || de < 194+64 {
+		// below nameStart. The lower bound must be the slice
+		// start index, not 0 — a de below the start makes l.Data[nameStart:de] a
+		// low>high slice expression that panics. Checking de < nameStart guarantees
+		// nameStart <= de <= len(l.Data), so the slice below can never panic.
+		de := nameStart + (int(c) << 1)
+		if de > len(l.Data) || de < nameStart {
 			return nil
 		}
-		b, err := hex.DecodeString(l.Data[194+64 : de])
+		b, err := hex.DecodeString(l.Data[nameStart:de])
 		if err != nil {
 			return nil
 		}

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -169,8 +169,12 @@ func processParam(data string, index int, dataOffset int, t *abi.Type, processed
 		dynIndex++
 		if t.T == abi.StringTy || t.T == abi.BytesTy {
 			d += 64
+			// count<<1 can overflow and wrap below d (same class as the
+			// getEnsRecord bug); the lower bound must be the slice start d, not 0,
+			// so that d <= de <= len(data) and data[d:de] below can never panic.
+			// count==0 gives de==d, which is still accepted.
 			de := d + (count << 1)
-			if de > len(data) || de < 0 {
+			if de > len(data) || de < d {
 				return nil, 0, false
 			}
 			if count == 0 {
@@ -310,8 +314,14 @@ func getEnsRecord(l *rpcLogWithTxHash) *bchain.AddressAliasRecord {
 		if err != nil {
 			return nil
 		}
+		// int(c)<<1 can overflow: c is attacker-controlled (up to 2^63-1) and Go's
+		// signed left shift wraps silently, so de can land anywhere in [0, 257]
+		// below the name start offset (194+64). The lower bound must be the slice
+		// start index, not 0 — a de below the start makes l.Data[194+64:de] a
+		// low>high slice expression that panics. Checking de < 194+64 guarantees
+		// 194+64 <= de <= len(l.Data), so the slice below can never panic.
 		de := 194 + 64 + (int(c) << 1)
-		if de > len(l.Data) || de < 0 {
+		if de > len(l.Data) || de < 194+64 {
 			return nil
 		}
 		b, err := hex.DecodeString(l.Data[194+64 : de])

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -457,6 +457,27 @@ func TestParseInputDataMisalignedDynamicData(t *testing.T) {
 	}
 }
 
+func TestParseInputDataOverflowDynamicLength(t *testing.T) {
+	parser := NewEthereumParser(1, false)
+	signatures := []bchain.FourByteSignature{
+		{Name: "store", Parameters: []string{"bytes"}},
+	}
+	// A "bytes" argument whose declared length word is 0x7FFFFFFFFFFFFFC0.
+	// In processParam count<<1 overflows int64 and wraps to -128, so
+	// de = d + (count<<1) = 128 - 128 = 0 while d = 128. Before the fix the old
+	// `de < 0` guard did not catch de==0 and data[128:0] panicked (recovered by
+	// ParseInputData, which then returned nil); with the `de < d` guard the field
+	// is rejected cleanly and ParseInputData returns the method id only.
+	data := "0xaabbccdd" +
+		"0000000000000000000000000000000000000000000000000000000000000020" +
+		"0000000000000000000000000000000000000000000000007fffffffffffffc0"
+	got := parser.ParseInputData(&signatures, data)
+	want := &bchain.EthereumParsedInputData{MethodId: "0xaabbccdd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseInputData() = %#v, want %#v", got, want)
+	}
+}
+
 func Test_getEnsRecord(t *testing.T) {
 	tests := []struct {
 		name string
@@ -519,6 +540,43 @@ func Test_getEnsRecord(t *testing.T) {
 						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
 					},
 					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000000000000000000ff9756e726176656c65640000000000000000000000000000000000000000000000",
+				},
+			},
+			want: nil,
+		},
+		{
+			// Regression: c = 0x7FFFFFFFFFFFFF7F makes int(c)<<1 wrap to -258, so
+			// de = 194+64+(-258) = 0. Before the fix this slipped past the old
+			// `de < 0` guard (0 is not < 0) and l.Data[258:0] panicked, crashing the
+			// sync goroutine. Must be rejected cleanly.
+			name: "overflow name length wrapping to de=0",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5",
+					Topics: []string{
+						"0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000007fffffffffffff7f756e726176656c65640000000000000000000000000000000000000000000000",
+				},
+			},
+			want: nil,
+		},
+		{
+			// Regression: c = 0x7FFFFFFFFFFFFFFF (MaxInt64) makes int(c)<<1 wrap to
+			// -2, so de = 256. Before the fix this passed both old guards and
+			// l.Data[258:256] panicked (start > end). Must be rejected cleanly.
+			name: "overflow name length wrapping to de=256",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5",
+					Topics: []string{
+						"0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000007fffffffffffffff756e726176656c65640000000000000000000000000000000000000000000000",
 				},
 			},
 			want: nil,

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -1626,6 +1627,18 @@ func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error
 	logsCh := make(chan logsResult, 1)         // Buffered so send won't block if we return early.
 	internalCh := make(chan internalResult, 1) // Buffered to avoid goroutine leak on early return.
 	go func() {
+		// Defense-in-depth: processEventsForBlock/getEnsRecord parse attacker-controlled
+		// on-chain log data. This goroutine has no other recover() on its stack, so an
+		// unrecovered panic here would terminate the whole process and — because the
+		// block is not yet committed — crash-loop on restart. Recover into an error so
+		// block sync surfaces/handles it instead of the process dying.
+		defer func() {
+			if r := recover(); r != nil {
+				glog.Error("GetBlock: recovered from panic in processEventsForBlock: ", r)
+				debug.PrintStack()
+				logsCh <- logsResult{err: fmt.Errorf("recovered from panic in processEventsForBlock: %v", r)}
+			}
+		}()
 		logs, ens, err := b.processEventsForBlock(head.Number)
 		logsCh <- logsResult{logs: logs, ens: ens, err: err} // Send result without shared state.
 	}()


### PR DESCRIPTION
## Problem

`getEnsRecord` (`bchain/coins/eth/dataparser.go`) reads a 32-byte name-length word `c` from an attacker-controlled ENS `NameRegistered` log and computes a slice end `de = 194+64+(int(c)<<1)`. `int(c)<<1` overflows: Go's signed left shift wraps silently, so for `c ∈ [0x7FFFFFFFFFFFFF7F, 0x7FFFFFFFFFFFFFFF]` (129 values) `de` lands in `[0, 256]`. The guard `de > len(l.Data) || de < 0` does not catch `de` in that range, so `l.Data[194+64 : de]` is a `low > high` slice expression and panics (`slice bounds out of range [258:0]`).

The call runs in the `GetBlock` log-processing goroutine (`ethrpc.go:1628`), which has no `recover()` (nor does the `db` sync path). An unrecovered panic in a goroutine terminates the whole process, and because it fires before the block is committed, the same block is re-fetched on restart → deterministic crash-loop.

Trigger: any contract emitting a `LOG3` with the ENS `NameRegistered` topic, 3 topics, `len(Data) ≥ 322`, and the length word set to `0x…7fffffffffffff7f`. Unauthenticated, low-cost availability DoS of the EVM backend.

## Changes

- **`getEnsRecord`**: guard the slice start — `de < 194+64` instead of `de < 0`. After the guard `258 ≤ de ≤ len(l.Data)`, so the slice can never panic (32- and 64-bit).
- **`processParam`**: same-class fix `de < d` for the sibling `data[d:de]` slice. Already under `ParseInputData`'s `recover()`, so no live crash — correctness only. `count==0` (`de==d`) still accepted.
- **`GetBlock`**: `recover()` in the log goroutine as defense-in-depth, returning an error instead of crashing (adds `runtime/debug` import).
- **Tests**: regression cases for `de=0`, `de=256`, and the `processParam` variant. Verified to panic with the fix reverted; return `nil` with it.

## Verification

`go vet`, `gofmt`, `go build`, and `go test -tags unittest ./bchain/coins/eth/` all pass.

## Notes

- The `recover()` returns a non-retryable error; the parallel range-sync worker (`db/sync.go:677`) would retry the same block rather than skip it — process stays up, but a deterministic panic would stall that worker. Moot once the guard removes the panic; flagged as a follow-up.
- The sibling `getInternalDataForBlock` goroutine (`ethrpc.go:1632`) has the same structural exposure and no `recover()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)