### PR TITLE
test(fiat): raise concurrency-test drain timeout to avoid CI flake

### DIFF
--- a/fiat/fiat_rates_test.go
+++ b/fiat/fiat_rates_test.go
@@ -427,7 +427,7 @@ func TestGetTickersForTimestamps_ConcurrentReadersAndWriters(t *testing.T) {
 		writers      = 2
 		readers      = 8
 		testDuration = 1200 * time.Millisecond
-		waitTimeout  = 3 * time.Second
+		waitTimeout  = 30 * time.Second // deadlock safety-net; kept generous so a CPU-starved CI runner does not flake
 	)
 
 	stop := make(chan struct{})
@@ -581,7 +581,7 @@ func TestLogTickersInfo_ConcurrentWithCacheWriters(t *testing.T) {
 		writers      = 2
 		loggers      = 4
 		testDuration = 300 * time.Millisecond
-		waitTimeout  = 3 * time.Second
+		waitTimeout  = 30 * time.Second // deadlock safety-net; kept generous so a CPU-starved CI runner does not flake
 	)
 
 	stop := make(chan struct{})


### PR DESCRIPTION
## Problem

`TestGetTickersForTimestamps_ConcurrentReadersAndWriters` and `TestLogTickersInfo_ConcurrentWithCacheWriters` (`fiat/fiat_rates_test.go`) run reader/writer/logger goroutines for `testDuration`, close `stop`, then wait `waitTimeout` for `wg.Wait()` to drain.

`waitTimeout` was `3s`. It is only a deadlock safety-net, but it is too tight on a CPU-starved CI runner (the Unit Tests job compiles RocksDB with `make -j 4` in parallel), so the goroutines occasionally don't get scheduled to drain within 3s and the test fails with `concurrent ... did not finish in time`. This is timing-only — the tests pass locally and on re-run; the failing package's code is unchanged.

## Change

Raise both `waitTimeout` deadlines from `3s` to `30s`. Still fails fast on a genuine deadlock, but tolerant of scheduling delays under load. Test-only; the concurrency exercise (driven by `testDuration`) is unchanged.

## Verification

`go test -tags unittest ./fiat/ -count=1` → `ok`. `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)