### PR TITLE
fix(ci): widen block-index search window to reduce flaky ETC tests

### DIFF
--- a/tests/openapi/src/constants.ts
+++ b/tests/openapi/src/constants.ts
@@ -1,6 +1,6 @@
 export const wsDialTimeoutMs = 3_000;
 export const wsMessageTimeoutMs = 10_000;
-export const txSearchWindow = 12;
+export const txSearchWindow = 20;
 export const blockPageSize = 1;
 export const sampleBlockPageSize = 3;
 export const sampleBlockProbeMax = 3;


### PR DESCRIPTION
The `getSampleIndexedHeight()` probe searches from `bestHeight - 2` backward for an indexed block hash. At `txSearchWindow = 12`, chains with slower indexers sometimes have zero indexed blocks in the window.

Ethereum Classic is particularly affected because it runs on different hardware with a different backend (core-geth vs Erigon). An occasional indexing lag of just 30–60s is enough to miss the 12-block window (~2.6 min).