### PR TITLE
fix(ws): cap subscribeFiatRates tokens array length

### DIFF
--- a/server/public_test.go
+++ b/server/public_test.go
@@ -2207,6 +2207,80 @@ func Test_WebsocketFiatRates_SubscribeBroadcastAndUnsubscribe(t *testing.T) {
 	assertNoWebsocketMessage(t, ws, 300*time.Millisecond)
 }
 
+func Test_WebsocketFiatRates_SubscribeTokensCap(t *testing.T) {
+	parser, chain := setupChain(t)
+	s, dbpath := setupPublicHTTPServer(parser, chain, t, false)
+	defer closeAndDestroyPublicServer(t, s, dbpath)
+	s.ConnectFullPublicInterface()
+	ts := httptest.NewServer(s.https.Handler)
+	defer ts.Close()
+
+	ws := connectWebsocket(t, ts)
+	defer ws.Close()
+
+	makeTokens := func(n int) []string {
+		tokens := make([]string, n)
+		for i := range tokens {
+			tokens[i] = "0xa4dd6bc15be95af55f0447555c8b6aa3088562f3"
+		}
+		return tokens
+	}
+
+	// Over the cap: the subscription is rejected with a public error and no
+	// token slice is retained for the connection.
+	if err := ws.WriteJSON(websocketReq{
+		ID:     "sub-over",
+		Method: "subscribeFiatRates",
+		Params: map[string]interface{}{
+			"currency": "USD",
+			"tokens":   makeTokens(maxWebsocketSubscribeFiatRatesTokens + 1),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	over := readWebsocketResponse(t, ws, time.Second)
+	if over.ID != "sub-over" {
+		t.Fatalf("unexpected response id: got %q, want %q", over.ID, "sub-over")
+	}
+	var overData struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(over.Data, &overData); err != nil {
+		t.Fatal(err)
+	}
+	wantMsg := "tokens max " + strconv.Itoa(maxWebsocketSubscribeFiatRatesTokens)
+	if overData.Error.Message != wantMsg {
+		t.Fatalf("unexpected error message: got %q, want %q", overData.Error.Message, wantMsg)
+	}
+
+	// Exactly at the cap: the subscription succeeds.
+	if err := ws.WriteJSON(websocketReq{
+		ID:     "sub-at",
+		Method: "subscribeFiatRates",
+		Params: map[string]interface{}{
+			"currency": "USD",
+			"tokens":   makeTokens(maxWebsocketSubscribeFiatRatesTokens),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	at := readWebsocketResponse(t, ws, time.Second)
+	if at.ID != "sub-at" {
+		t.Fatalf("unexpected response id: got %q, want %q", at.ID, "sub-at")
+	}
+	var atData struct {
+		Subscribed bool `json:"subscribed"`
+	}
+	if err := json.Unmarshal(at.Data, &atData); err != nil {
+		t.Fatal(err)
+	}
+	if !atData.Subscribed {
+		t.Fatalf("expected subscribed=true at the token cap, got false (data %s)", at.Data)
+	}
+}
+
 func Test_WebsocketFiatRates_GetCurrentFiatRates_TokenContractsCaseHandling_BitcoinType(t *testing.T) {
 	parser, chain := setupChain(t)
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -46,12 +46,6 @@ const maxWebsocketActiveRequests = 2048
 const maxWebsocketEstimateFeeBlocks = 32
 const maxWebsocketSubscribeAddresses = 1000
 const maxWebsocketSubscribeAddressesWithNewBlockTxs = 100
-
-// maxWebsocketSubscribeFiatRatesTokens caps the number of tokens a single
-// subscribeFiatRates request may register. The list is retained for the
-// connection lifetime and re-iterated on every fiat-rate broadcast (per
-// subscribed currency) while the global fiatRatesSubscriptionsLock is held, so
-// an uncapped list allows both amplified heap retention and lock contention.
 const maxWebsocketSubscribeFiatRatesTokens = 1000
 const websocketLogPreviewBytes = 256
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -46,6 +46,13 @@ const maxWebsocketActiveRequests = 2048
 const maxWebsocketEstimateFeeBlocks = 32
 const maxWebsocketSubscribeAddresses = 1000
 const maxWebsocketSubscribeAddressesWithNewBlockTxs = 100
+
+// maxWebsocketSubscribeFiatRatesTokens caps the number of tokens a single
+// subscribeFiatRates request may register. The list is retained for the
+// connection lifetime and re-iterated on every fiat-rate broadcast (per
+// subscribed currency) while the global fiatRatesSubscriptionsLock is held, so
+// an uncapped list allows both amplified heap retention and lock contention.
+const maxWebsocketSubscribeFiatRatesTokens = 1000
 const websocketLogPreviewBytes = 256
 
 // allRates is a special "currency" parameter that means all available currencies
@@ -836,6 +843,9 @@ var requestHandlers = map[string]func(*WebsocketServer, *websocketChannel, *WsRe
 		err = json.Unmarshal(req.Params, &r)
 		if err != nil {
 			return nil, err
+		}
+		if len(r.Tokens) > maxWebsocketSubscribeFiatRatesTokens {
+			return nil, api.NewAPIError("tokens max "+strconv.Itoa(maxWebsocketSubscribeFiatRatesTokens), true)
 		}
 		r.Currency = strings.ToLower(r.Currency)
 


### PR DESCRIPTION
## Summary

The `subscribeFiatRates` WebSocket handler accepted a `tokens` array of any length. It was the only list parameter in the WebSocket API without a bound — addresses (≤1000/100), currencies (≤128), timestamps (≤1000), and `estimateFee` blocks (≤32) are all capped.

The subscribed token list is retained for the lifetime of the connection and re-iterated on every fiat-rate broadcast (per subscribed currency) while the fiat-rates subscription lock is held, so leaving it unbounded lets a single request pin a large amount of memory and add avoidable work to each broadcast.

## Change

- Add `maxWebsocketSubscribeFiatRatesTokens = 1000` and reject requests exceeding it with a public `tokens max 1000` API error, before the list is stored — consistent with the existing caps on the other list parameters.
- Add a regression test covering rejection at cap+1 and success at exactly the cap.

## Testing

- `go test -tags unittest ./server/ -run Test_WebsocketFiatRates` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)