### PR TITLE
fix(build): warn instead of fail on RPC env vars for off-branch coins

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,7 +64,10 @@ jobs:
           # CI can reach the node RPC backends directly, so check them too; local
           # runs default to Blockbook-only connectivity.
           BB_TEST_BACKEND_CONNECTIVITY: "1"
-        run: make test-connectivity
+        # -v so a passing run still surfaces LoadConfig's ::warning:: for RPC env
+        # vars referencing coins absent on this branch; go test buffers (and thus
+        # discards) a passing binary's stderr without it. Mirrors integration/e2e.
+        run: make test-connectivity ARGS="-v"
 
   integration-tests:
     name: Integration Tests (RPC + Sync)

--- a/build/tools/templates.go
+++ b/build/tools/templates.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 )
@@ -360,13 +361,25 @@ func copyNonZeroBackendFields(toValue *Backend, fromValue *Backend) {
 	}
 }
 
+// rpcEnvWarnOnce keeps the cross-branch RPC-env warning to a single line per
+// process; LoadConfig runs once per coin (17+ times in a connectivity run) but
+// the offending variable set is process-global, so repeating it is just noise.
+var rpcEnvWarnOnce sync.Once
+
 // LoadConfig loads the config files
 func LoadConfig(configsDir, coin string) (*Config, error) {
 	config := new(Config)
 
-	// Fail fast if RPC override variables reference coins that do not exist in configs/coins.
+	// Warn (don't fail) when RPC override variables reference coins missing from
+	// configs/coins. GitHub repository variables are repo-global and shared by
+	// every branch, but configs/coins is per-branch: a variable added for a coin
+	// that only exists on another feature branch (e.g. BB_*_RPC_URL_*_robinhood_archive)
+	// would otherwise fail-fast here for every unrelated coin. The override for a
+	// missing coin is inert anyway, so surface it as an annotation and continue.
 	if err := validateRPCEnvVars(configsDir); err != nil {
-		return nil, err
+		rpcEnvWarnOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "::warning::%v (ignored: these coins are not present in configs/coins on this branch)\n", err)
+		})
 	}
 	buildEnv, err := resolveBuildEnv()
 	if err != nil {

--- a/build/tools/templates_test.go
+++ b/build/tools/templates_test.go
@@ -162,6 +162,26 @@ func TestLoadConfigSetsWantsBackendServiceFromEffectiveRPCURL(t *testing.T) {
 	})
 }
 
+func TestLoadConfigToleratesRPCEnvForCoinMissingOnBranch(t *testing.T) {
+	// Repo-global GitHub variables are shared by every branch, so a variable for
+	// a coin whose config lives only on another feature branch (here a stand-in
+	// "robinhood_archive" that has no configs/coins entry) must not fail the load
+	// of an unrelated coin. Regression guard for the cross-branch connectivity CI
+	// failure that this warn-don't-fail behavior fixes.
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	t.Setenv(buildEnvVar, buildEnvDev)
+	t.Setenv(devRPCURLHTTPPrefix+"robinhood_archive", "https://robinhood-archive.example:8030")
+
+	config, err := LoadConfig(configsDir, "bitcoin")
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil (off-branch RPC var must only warn)", err)
+	}
+	if config == nil {
+		t.Fatal("LoadConfig() returned nil config")
+	}
+}
+
 func TestLoadConfigOverridesMessageQueueBindingFromEnv(t *testing.T) {
 	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
 


### PR DESCRIPTION
## Problem

`Connectivity`/`Integration` CI fails on any branch whenever a repo-level GitHub variable references a coin that isn't on that branch. Example: [run 29475317828](https://github.com/trezor/blockbook/actions/runs/29475317828) failed for *every* coin with:

```
load config for arbitrum: RPC env vars reference unknown coin aliases:
robinhood_archive (from BB_DEV_RPC_URL_HTTP_robinhood_archive), ...
```

Root cause is structural: **GitHub repository variables are repo-global** (shared by every branch, no branch scoping), while **`configs/coins/` is per-branch**. The `BB_*_RPC_URL_*_robinhood_archive` variables were added at repo level for the robinhood feature branch, whose `configs/coins/robinhood_archive.json` doesn't exist on other branches. Because `validateRPCEnvVars` runs a global fail-fast inside `LoadConfig`, one off-branch variable takes down the config load of every unrelated coin.

## Change

Downgrade the unknown-alias result in `LoadConfig` from a hard error to a non-fatal `::warning::` annotation. The override for a missing coin is inert anyway, so the drift stays visible in the Actions UI without blocking unrelated work. A `sync.Once` keeps it to one line per process instead of one per coin. This also fixes local `make test-connectivity` runs for developers who have those vars in their shell.

`validateRPCEnvVars` itself is unchanged (still pure/testable). Added `TestLoadConfigToleratesRPCEnvForCoinMissingOnBranch` as a regression guard.

## Trade-off

This removes the hard gate everywhere, including the `deploy.yml` build/deploy path. If a wrong RPC must never *silently ship* on deploy, the follow-up is a hybrid: gate strictness behind a `BB_RPC_ENV_VALIDATION=strict` env var that only `deploy.yml` sets. Not included here to keep the fix minimal.

## Testing

- `go test ./build/tools/` — pass
- `go vet ./build/tools/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)