### PR TITLE
fix(eth): treat "contract not exist" eth_call errors as non-retriable

### DIFF
--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -663,7 +663,11 @@ func isNonRetriableEthCallError(err error) bool {
 		strings.Contains(msg, "invalid opcode") ||
 		strings.Contains(msg, "out of gas") ||
 		strings.Contains(msg, "stack underflow") ||
-		strings.Contains(msg, "revert")
+		strings.Contains(msg, "revert") ||
+		// Java-Tron throws these messages
+		strings.Contains(msg, "smart contract is not exist") ||
+		strings.Contains(msg, "no contract") ||
+		strings.Contains(msg, "not deployed")
 }
 
 // GetTokenURI returns URI of non fungible or multi token defined by token id

--- a/bchain/coins/eth/contract_batch_test.go
+++ b/bchain/coins/eth/contract_batch_test.go
@@ -499,3 +499,74 @@ func TestEthereumTypeGetErc20ContractBalancesPartialError(t *testing.T) {
 		t.Fatalf("expected balance[1] to be nil, got %v", balances[1])
 	}
 }
+
+// A deterministic per-element error (e.g. TRON's "Smart contract is not exist"
+// for a dead/fake TRC20 contract) must not trigger a single-call fallback: the
+// retry cannot succeed and only amplifies RPC load and log noise.
+func TestErc20BalancesBatchNonRetriableSkipsFallback(t *testing.T) {
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000011")
+	contractA := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	contractB := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	contractAKey := hexutil.Encode(contractA.Bytes())
+	contractBKey := hexutil.Encode(contractB.Bytes())
+	callData := erc20BalanceOfCallData(bchain.AddressDescriptor(addr.Bytes()))
+	mock := &mockBatchCallRPC{
+		batchResults: map[string]string{
+			contractAKey: fmt.Sprintf("0x%064x", 1),
+		},
+		batchErrors: map[string]error{
+			contractBKey: errors.New("contract validate error : Smart contract is not exist."),
+		},
+		// Provide a would-be fallback result; the code must not reach it.
+		callResults: map[string]string{
+			contractBKey: fmt.Sprintf("0x%064x", 5),
+		},
+	}
+	rpcClient := &EthereumRPC{
+		RPC:     mock,
+		Timeout: time.Second,
+	}
+	balances, err := rpcClient.erc20BalancesBatch(mock, callData, []bchain.AddressDescriptor{
+		bchain.AddressDescriptor(contractA.Bytes()),
+		bchain.AddressDescriptor(contractB.Bytes()),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if balances[0] == nil || balances[0].Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("unexpected balance[0]: %v", balances[0])
+	}
+	if balances[1] != nil {
+		t.Fatalf("expected balance[1] to be nil (non-retriable), got %v", balances[1])
+	}
+	if len(mock.calls) != 0 {
+		t.Fatalf("expected no single-call fallback for non-retriable error, got %d", len(mock.calls))
+	}
+}
+
+func TestIsNonRetriableEthCallError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"execution reverted", errors.New("execution reverted"), true},
+		{"invalid opcode", errors.New("invalid opcode: INVALID"), true},
+		{"out of gas", errors.New("out of gas"), true},
+		{"stack underflow", errors.New("stack underflow"), true},
+		{"generic revert", errors.New("VM Exception: revert"), true},
+		{"tron smart contract not exist", errors.New("contract validate error : Smart contract is not exist."), true},
+		{"no contract", errors.New("no contract code at given address"), true},
+		{"not deployed", errors.New("contract not deployed"), true},
+		{"transient rpc", errors.New("connection reset by peer"), false},
+		{"timeout", errors.New("context deadline exceeded"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNonRetriableEthCallError(tt.err); got != tt.want {
+				t.Fatalf("isNonRetriableEthCallError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On a TRON Blockbook deployment, the logs show pairs of warnings for token `balanceOf` calls:

```
W contract.go:629] erc20 batch eth_call failed for 0x70a9…cc29: Smart contract is not exist.
W contract.go:633] erc20 single eth_call fallback failed for 0x70a9…cc29: Smart contract is not exist.
```

These occur when an address recorded as a token contract isn't backed by live code on the node — typically self-destructed contracts, or **fake/spam TRC20 transfer logs** referencing non-contract addresses (very common on TRON). java-tron answers such `eth_call`s with `Smart contract is not exist`.

`isNonRetriableEthCallError` did not recognize this message, so the batch fallback classified it as *retriable* and re-issued each one as a single call. That retry is deterministic and guaranteed to fail — it only wastes an RPC round-trip and logs a second warning per contract.

This is not a Trezor Suite or node bug: Suite just requests token balances, and the node correctly reports the address isn't a contract. It's benign Blockbook log-noise plus wasted RPC.

## Fix

Classify `smart contract is not exist` (and the generic `no contract` / `not deployed` variants from other backends) as non-retriable. The batch element is then skipped instead of retried, removing both the redundant call and both warning lines. Account-info responses are unchanged — the balance stays `nil` for such contracts, exactly as before.

## Tests

- `TestErc20BalancesBatchNonRetriableSkipsFallback` — feeds the real TRON error string as a batch-element error and asserts **zero** single-call fallbacks and a `nil` balance.
- `TestIsNonRetriableEthCallError` — table test covering the new strings, the pre-existing ones, and negative cases (transient RPC / timeout stay retriable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)