### PR TITLE
fix(btc): accept array-form "warnings" from Bitcoin Core 25.0+

### DIFF
--- a/bchain/coins/btc/bitcoinrpc.go
+++ b/bchain/coins/btc/bitcoinrpc.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -363,6 +364,29 @@ type ResGetBlockCount struct {
 	Result uint32           `json:"result"`
 }
 
+// coreWarnings decodes the "warnings" field of getblockchaininfo and
+// getnetworkinfo. Bitcoin Core 25.0+ returns it as an array of strings, while
+// older versions (and nodes started with -deprecatedrpc=warnings) return a
+// single string. Accepting either shape keeps blockbook compatible across Core
+// versions.
+type coreWarnings string
+
+func (w *coreWarnings) UnmarshalJSON(data []byte) error {
+	// Core 25.0+: array of warning strings.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*w = coreWarnings(strings.Join(arr, " "))
+		return nil
+	}
+	// Pre-25.0 / -deprecatedrpc=warnings: a single string.
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*w = coreWarnings(s)
+	return nil
+}
+
 // getblockchaininfo
 
 type CmdGetBlockChainInfo struct {
@@ -378,7 +402,7 @@ type ResGetBlockChainInfo struct {
 		Bestblockhash string            `json:"bestblockhash"`
 		Difficulty    common.JSONNumber `json:"difficulty"`
 		SizeOnDisk    int64             `json:"size_on_disk"`
-		Warnings      string            `json:"warnings"`
+		Warnings      coreWarnings      `json:"warnings"`
 	} `json:"result"`
 }
 
@@ -395,7 +419,7 @@ type ResGetNetworkInfo struct {
 		Subversion      common.JSONNumber `json:"subversion"`
 		ProtocolVersion common.JSONNumber `json:"protocolversion"`
 		Timeoffset      float64           `json:"timeoffset"`
-		Warnings        string            `json:"warnings"`
+		Warnings        coreWarnings      `json:"warnings"`
 	} `json:"result"`
 }
 
@@ -620,10 +644,10 @@ func (b *BitcoinRPC) GetChainInfo() (*bchain.ChainInfo, error) {
 	rv.Version = string(resNi.Result.Version)
 	rv.ProtocolVersion = string(resNi.Result.ProtocolVersion)
 	if len(resCi.Result.Warnings) > 0 {
-		rv.Warnings = resCi.Result.Warnings + " "
+		rv.Warnings = string(resCi.Result.Warnings) + " "
 	}
 	if resCi.Result.Warnings != resNi.Result.Warnings {
-		rv.Warnings += resNi.Result.Warnings
+		rv.Warnings += string(resNi.Result.Warnings)
 	}
 	return rv, nil
 }

--- a/bchain/coins/btc/bitcoinrpc_test.go
+++ b/bchain/coins/btc/bitcoinrpc_test.go
@@ -32,3 +32,44 @@ func TestDecodeBatchRawTransactions(t *testing.T) {
 		t.Fatalf("expected txid %s, got %s", txid, got[txid].Txid)
 	}
 }
+
+func TestCoreWarningsUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"legacy empty string", `""`, ""},
+		{"legacy string", `"beware"`, "beware"},
+		{"core 25 empty array", `[]`, ""},
+		{"core 25 single element", `["beware"]`, "beware"},
+		{"core 25 multiple elements", `["a","b"]`, "a b"},
+		{"null", `null`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w coreWarnings
+			if err := json.Unmarshal([]byte(tt.in), &w); err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tt.in, err)
+			}
+			if string(w) != tt.want {
+				t.Errorf("Unmarshal(%s) = %q, want %q", tt.in, string(w), tt.want)
+			}
+		})
+	}
+}
+
+// TestGetBlockChainInfoWarningsArray guards the actual regression: Bitcoin Core
+// 25.0+ returns getblockchaininfo "warnings" as an array, which must decode
+// through the struct field rather than failing with "cannot unmarshal array
+// into Go struct field .result.warnings of type string".
+func TestGetBlockChainInfoWarningsArray(t *testing.T) {
+	const data = `{"result":{"chain":"main","warnings":["disk space is low"]}}`
+	var res ResGetBlockChainInfo
+	if err := json.Unmarshal([]byte(data), &res); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := string(res.Result.Warnings); got != "disk space is low" {
+		t.Errorf("warnings = %q, want %q", got, "disk space is low")
+	}
+}

--- a/bchain/coins/zec/zcashrpc.go
+++ b/bchain/coins/zec/zcashrpc.go
@@ -108,7 +108,7 @@ func (z *ZCashRPC) GetChainInfo() (*bchain.ChainInfo, error) {
 		ProtocolVersion: string(networkInfo.Result.ProtocolVersion),
 		Timeoffset:      networkInfo.Result.Timeoffset,
 		Consensus:       chainInfo.Result.Consensus,
-		Warnings:        networkInfo.Result.Warnings,
+		Warnings:        string(networkInfo.Result.Warnings),
 	}, nil
 }
 


### PR DESCRIPTION
Bitcoin Core 25.0 changed the "warnings" field of getblockchaininfo and getnetworkinfo from a single string to an array of strings. Blockbook types the field as a plain string, so GetChainInfo fails against any Core 25+ node with:

  cannot unmarshal array into Go struct field .result.warnings of type string

This blocks initialization: getBlockChainWithRetry never succeeds, so blockbook cannot connect to a modern bitcoind (reproduced against Core 31.1).

Add a coreWarnings type whose UnmarshalJSON accepts either shape: an array (joined with spaces) or the legacy string (still produced by -deprecatedrpc=warnings). Use it for the "warnings" field of ResGetBlockChainInfo and ResGetNetworkInfo, casting back to string at the use sites. zec reuses btc's ResGetNetworkInfo and gets the same cast.

Tests cover both wire shapes (string, empty/single/multi-element array, null) plus a struct-level regression for the getblockchaininfo array case.