### PR TITLE
ci: BB_STAGING escape hatch for work-in-progress coins

### DIFF
--- a/.github/scripts/runner.py
+++ b/.github/scripts/runner.py
@@ -113,6 +113,34 @@ def load_runner_map(vars_map: dict) -> dict[str, str]:
     return mapping
 
 
+def load_staging_coins(vars_map: dict) -> set[str]:
+    # BB_STAGING lists work-in-progress coins (comma/space separated); include the
+    # '-'/'_' variants so it matches either coin-name spelling.
+    staging: set[str] = set()
+    for token in re.split(r"[\s,]+", str(vars_map.get("BB_STAGING") or "")):
+        name = token.strip().lower()
+        if name:
+            staging.update({name, name.replace("-", "_"), name.replace("_", "-")})
+    return staging
+
+
+def prune_staging_coins(
+    workspace: Path, runner_map: dict[str, str], staging: set[str]
+) -> dict[str, str]:
+    # Drop a staging coin only where its config is absent, so an unmerged coin's
+    # repo-wide variables don't break sibling branches while the feature branch that
+    # carries the config still builds and deploys it normally.
+    if not staging:
+        return runner_map
+    kept = {}
+    for coin, runner in runner_map.items():
+        if coin in staging and not coin_config_path(workspace, coin).exists():
+            log(f"BB_STAGING: skipping '{coin}' (no configs/coins/{coin}.json on this branch)")
+            continue
+        kept[coin] = runner
+    return kept
+
+
 def parse_coin_tokens(raw: str, *, allow_all: bool) -> tuple[bool, list[str]]:
     text = raw.strip()
     if not text:
@@ -201,6 +229,7 @@ def validate_runner_map_configs(workspace: Path, runner_map: dict[str, str]) -> 
         raise ValidationError(
             "BB_RUNNER_* entries without matching configs/coins/<coin>.json: "
             + ", ".join(missing)
+            + " (add a work-in-progress coin to the BB_STAGING variable if its config is on another branch)"
         )
 
 
@@ -305,6 +334,7 @@ def load_coin_context(
 ) -> CoinContext:
     runner_map = load_runner_map(vars_map)
     runner_map = normalize_runner_map(workspace, runner_map)
+    runner_map = prune_staging_coins(workspace, runner_map, load_staging_coins(vars_map))
     if not runner_map:
         raise ValidationError("no BB_RUNNER_* variables found")
 

--- a/.github/scripts/runner.py
+++ b/.github/scripts/runner.py
@@ -334,9 +334,13 @@ def load_coin_context(
 ) -> CoinContext:
     runner_map = load_runner_map(vars_map)
     runner_map = normalize_runner_map(workspace, runner_map)
-    runner_map = prune_staging_coins(workspace, runner_map, load_staging_coins(vars_map))
     if not runner_map:
         raise ValidationError("no BB_RUNNER_* variables found")
+    runner_map = prune_staging_coins(workspace, runner_map, load_staging_coins(vars_map))
+    if not runner_map:
+        raise ValidationError(
+            "all BB_RUNNER_* coins are BB_STAGING work-in-progress without a config on this branch"
+        )
 
     validate_runner_map_configs(workspace, runner_map)
     all_coins = list_all_coins(workspace, runner_map)

--- a/.github/scripts/runner_test.py
+++ b/.github/scripts/runner_test.py
@@ -78,6 +78,17 @@ class RunnerSelectionTest(unittest.TestCase):
 
         self.assertIn("dogecoin", context.all_coins)
 
+    def test_load_coin_context_reports_all_staging_pruned_distinctly(self) -> None:
+        vars_map = {
+            "BB_RUNNER_ROBINHOOD_ARCHIVE": "blockbook-dev",
+            "BB_STAGING": "robinhood_archive",
+        }
+
+        with self.assertRaisesRegex(
+            ValidationError, r"all BB_RUNNER_\* coins are BB_STAGING"
+        ):
+            load_coin_context(self.workspace, vars_map)
+
     def test_staging_prune_matches_hyphen_underscore_variant(self) -> None:
         vars_map = {
             **self.valid_vars_map,

--- a/.github/scripts/runner_test.py
+++ b/.github/scripts/runner_test.py
@@ -63,6 +63,32 @@ class RunnerSelectionTest(unittest.TestCase):
         ):
             load_coin_context(self.workspace, self.stale_vars_map)
 
+    def test_load_coin_context_prunes_staging_coin_without_config(self) -> None:
+        vars_map = {**self.stale_vars_map, "BB_STAGING": "stale"}
+
+        context = load_coin_context(self.workspace, vars_map)
+
+        self.assertNotIn("stale", context.all_coins)
+        self.assertIn("dogecoin", context.all_coins)
+
+    def test_load_coin_context_keeps_staging_coin_that_has_config(self) -> None:
+        vars_map = {**self.valid_vars_map, "BB_STAGING": "dogecoin"}
+
+        context = load_coin_context(self.workspace, vars_map)
+
+        self.assertIn("dogecoin", context.all_coins)
+
+    def test_staging_prune_matches_hyphen_underscore_variant(self) -> None:
+        vars_map = {
+            **self.valid_vars_map,
+            "BB_RUNNER_ROBINHOOD_ARCHIVE": "blockbook-dev",
+            "BB_STAGING": "robinhood-archive",
+        }
+
+        context = load_coin_context(self.workspace, vars_map)
+
+        self.assertNotIn("robinhood_archive", context.all_coins)
+
     def test_build_all_uses_all_configured_runner_mapped_coins(self) -> None:
         context = load_coin_context(self.workspace, self.valid_vars_map)
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ GITCOMMIT ?= $(shell git describe --always --dirty 2>/dev/null)
 # (BB_BUILD_ENV is forwarded separately via -e BB_BUILD_ENV=... on each docker run.)
 BB_VAR_PREFIX_FILE := build/bb-build-var-prefixes.txt
 BB_RPC_ENV := $(shell env | awk -F= 'NR==FNR{line=$$0;gsub(/[[:space:]]/,"",line);if(substr(line,1,3)=="BB_")pfx[line]=1;next}{for(p in pfx){if(index($$1,p)==1){print "-e " $$1;next}}}' $(BB_VAR_PREFIX_FILE) -)
+# BB_STAGING is a standalone control var (no coin-alias suffix, like BB_BUILD_ENV):
+# forward it too so its config-absent coin exemption applies inside the container.
+BB_RPC_ENV := $(BB_RPC_ENV)$(if $(BB_STAGING), -e BB_STAGING)
 
 TARGETS=$(subst .json,, $(shell ls configs/coins))
 

--- a/build/tools/templates.go
+++ b/build/tools/templates.go
@@ -146,18 +146,38 @@ func generateRPCAuth(user, pass string) (string, error) {
 	return out.String(), nil
 }
 
+const stagingEnvVar = "BB_STAGING"
+
 func validateRPCEnvVars(configsDir string) error {
 	// Use coin aliases as the source of truth so env naming matches coin config and deployment conventions.
 	validAliases, err := loadCoinAliases(configsDir)
 	if err != nil {
 		return err
 	}
+	// Tolerate BB_STAGING work-in-progress coins whose config lives only on a feature branch.
+	for alias := range stagingAliases() {
+		validAliases[alias] = struct{}{}
+	}
 	unknown := collectUnknownRPCEnvVars(validAliases, rpcEnvPrefixes())
 	if len(unknown) == 0 {
 		return nil
 	}
 	sort.Strings(unknown)
-	return fmt.Errorf("RPC env vars reference unknown coin aliases: %s", strings.Join(unknown, ", "))
+	return fmt.Errorf("RPC env vars reference unknown coin aliases: %s (add work-in-progress coins to BB_STAGING)", strings.Join(unknown, ", "))
+}
+
+// stagingAliases parses BB_STAGING (comma/space separated work-in-progress coins)
+// into an alias set with '-'/'_' variants so their RPC vars validate on branches
+// that do not yet carry the coin config.
+func stagingAliases() map[string]struct{} {
+	aliases := map[string]struct{}{}
+	for _, field := range strings.Fields(strings.ReplaceAll(os.Getenv(stagingEnvVar), ",", " ")) {
+		name := strings.ToLower(field)
+		aliases[name] = struct{}{}
+		aliases[strings.ReplaceAll(name, "-", "_")] = struct{}{}
+		aliases[strings.ReplaceAll(name, "_", "-")] = struct{}{}
+	}
+	return aliases
 }
 
 type coinAliasHolder struct {

--- a/build/tools/templates_test.go
+++ b/build/tools/templates_test.go
@@ -405,13 +405,15 @@ func TestValidateRPCEnvVarsToleratesStagingCoin(t *testing.T) {
 	// An RPC override for a coin whose config lives only on a feature branch.
 	t.Setenv(devRPCURLHTTPPrefix+"robinhood_archive", "http://backend.example:8030")
 
-	if err := validateRPCEnvVars(configsDir); err == nil {
-		t.Fatal("expected unknown coin alias to be rejected without BB_STAGING")
+	// Assert on this coin specifically, not on a globally-clean result: the env may
+	// carry other orphan overrides (the multi-WIP-coin case this feature targets).
+	if err := validateRPCEnvVars(configsDir); err == nil || !strings.Contains(err.Error(), "robinhood_archive") {
+		t.Fatalf("expected robinhood_archive to be rejected without BB_STAGING, got %v", err)
 	}
 
 	t.Setenv(stagingEnvVar, "robinhood_archive")
-	if err := validateRPCEnvVars(configsDir); err != nil {
-		t.Fatalf("BB_STAGING should tolerate the orphan RPC var, got %v", err)
+	if err := validateRPCEnvVars(configsDir); err != nil && strings.Contains(err.Error(), "robinhood_archive") {
+		t.Fatalf("BB_STAGING should tolerate robinhood_archive, got %v", err)
 	}
 }
 

--- a/build/tools/templates_test.go
+++ b/build/tools/templates_test.go
@@ -398,6 +398,34 @@ func TestEthereumClassicRPCAndBackendHTTPPortStayAligned(t *testing.T) {
 	}
 }
 
+func TestValidateRPCEnvVarsToleratesStagingCoin(t *testing.T) {
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	withTemporarilyUnsetEnv(t, stagingEnvVar)
+	// An RPC override for a coin whose config lives only on a feature branch.
+	t.Setenv(devRPCURLHTTPPrefix+"robinhood_archive", "http://backend.example:8030")
+
+	if err := validateRPCEnvVars(configsDir); err == nil {
+		t.Fatal("expected unknown coin alias to be rejected without BB_STAGING")
+	}
+
+	t.Setenv(stagingEnvVar, "robinhood_archive")
+	if err := validateRPCEnvVars(configsDir); err != nil {
+		t.Fatalf("BB_STAGING should tolerate the orphan RPC var, got %v", err)
+	}
+}
+
+func TestStagingAliasesParsesListAndVariants(t *testing.T) {
+	t.Setenv(stagingEnvVar, "robinhood_archive, foo-bar")
+
+	got := stagingAliases()
+	for _, want := range []string{"robinhood_archive", "robinhood-archive", "foo-bar", "foo_bar"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("stagingAliases() missing %q", want)
+		}
+	}
+}
+
 func withTemporarilyUnsetEnv(t *testing.T, keys ...string) {
 	t.Helper()
 

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -85,6 +85,7 @@ Special cases:
 - `mode=build` + `env=dev` fails if you explicitly request a coin whose `BB_RUNNER_*` is `production_builder`
 - `mode=deploy` is dev-only and fails fast if any selected coin is mapped to `production_builder`
 - a coin listed in the `BB_STAGING` repository variable is skipped where its `configs/coins/<coin>.json` is absent, so a work-in-progress coin's repo-wide `BB_*` variables don't fail builds/deploys on branches that lack its config yet
+- tolerance is opt-in, so a mistyped or abandoned `BB_STAGING` entry (no config on any branch) is silently skipped rather than erroring — the skip is logged, and entries should be removed once the coin merges
 
 ## Naming Matrix
 

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -84,6 +84,7 @@ Special cases:
 - `mode=build` + `env=prod` + `coins=ALL` builds all configured coins with `BB_RUNNER_*` mappings on the `production-builder` runner
 - `mode=build` + `env=dev` fails if you explicitly request a coin whose `BB_RUNNER_*` is `production_builder`
 - `mode=deploy` is dev-only and fails fast if any selected coin is mapped to `production_builder`
+- a coin listed in the `BB_STAGING` repository variable is skipped where its `configs/coins/<coin>.json` is absent, so a work-in-progress coin's repo-wide `BB_*` variables don't fail builds/deploys on branches that lack its config yet
 
 ## Naming Matrix
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -143,6 +143,10 @@ On EVM chains the internal server also exposes `/admin/contract-info/` (same Bas
 -   `BB_RUNNER_<coin>` - Maps a workflow/config coin name from `configs/coins/<coin>.json` to the self-hosted runner label
     used by the `Build / Deploy` workflow. `production_builder` marks coins that are buildable only in `env=prod`; those builds run on the `production-builder` self-hosted runner label.
 
+-   `BB_STAGING` - Comma/space separated work-in-progress coins whose `BB_*` variables exist repo-wide but whose
+    `configs/coins/<coin>.json` is only on a feature branch. Each listed coin is skipped where its config is absent (so
+    sibling branches don't fail on the orphan variables) and builds/tests/deploys normally where the config is present.
+
 -   `BB_PACKAGE_ROOT` - Absolute filesystem path where workflow build jobs stage copied `.deb` packages after build.
     Defaults to `/opt/blockbook-builds` in the workflow.
 


### PR DESCRIPTION
## Problem

A new coin's `BB_RUNNER_<coin>` / `BB_*_RPC_URL_*_<coin>` **repository variables are visible on every branch at once**, but its `configs/coins/<coin>.json` lives only on the feature branch that adds it. On `master` and every sibling branch that orphaned variable trips two global fail-closed validations and breaks builds/deploys/tests **for every coin**:

- `.github/scripts/runner.py` `validate_runner_map_configs` → `BB_RUNNER_* entries without matching configs/coins/<coin>.json: robinhood_archive`
- `build/tools/templates.go` `validateRPCEnvVars` (run on every per-coin `LoadConfig`) → `RPC env vars reference unknown coin aliases: robinhood_archive ...`

GitHub has no per-branch variables (only org/repo/environment scopes), so the fix keys off the artifact that *is* already per-branch: the committed config.

## Solution

A new `BB_STAGING` repository variable lists work-in-progress coins (comma/space separated). Because it's a repo variable it is visible on every branch, which is exactly what's needed to tell all branches "tolerate this coin." It means **"tolerate the *absence* of this coin's config"**, not "disable checks":

| Config on this branch? | In `BB_STAGING`? | Result |
|---|---|---|
| Yes (feature branch) | Yes/No | coin fully built / tested / deployed (`BB_STAGING` is a no-op) |
| No (master / others) | Yes | coin skipped, no error |
| No (master / others) | No | still fails closed — typo/stale detection preserved |

The discriminator is config-file presence, not branch name, so the feature branch that carries the config exercises the coin normally while sibling branches skip it.

- **`runner.py`**: drop a `BB_STAGING` coin from the runner map only where its config is absent (also keeps it out of `all_coins` / `build ALL`).
- **`templates.go`**: add `BB_STAGING` coins (with `-`/`_` variants) to the valid-alias set so their orphan RPC vars are tolerated.
- **`Makefile`**: `BB_STAGING` is a standalone control var (like `BB_BUILD_ENV`), forwarded into the build/test container via `BB_RPC_ENV` — name-only `-e BB_STAGING` so a multi-coin list value survives intact. Covers the deb build path (`generate.go` → `LoadConfig`).

## Known limitation

Tolerance is opt-in: a coin mistyped in *both* the coin variable and `BB_STAGING` (no config on any branch) is silently skipped rather than erroring. It's caught where it matters — on the feature branch the config is present, so the coin fails to build and the author notices — and the skip is logged. Documented in `docs/ci_cd.md`.

## Testing

- `python3 -m unittest discover -s .github/scripts -p '*_test.py'` — 69 pass
- `go test ./build/tools/` — pass
- Covers: prune-without-config, keep-with-config, `-`/`_` variant matching, all-pruned diagnostic, and RPC-alias tolerance.

## Review

Reviewed at xhigh effort; addressed in the final commit: fixed a misleading `no BB_RUNNER_* variables found` diagnostic when pruning empties the map, and made the Go test robust to ambient orphan RPC overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)