### PR TITLE
feat(server): add request timeouts and resource bounds for REST, WebSocket, and address lookups

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -1483,23 +1483,11 @@ func (w *Worker) getAddrDescAndNormalizeAddress(address string) (bchain.AddressD
 	addrDesc, err := w.chainParser.GetAddrDescFromAddress(address)
 	if err != nil {
 		// try if the address is not address descriptor converted to string
-		ad, errAd := bchain.AddressDescriptorFromString(address)
+		var errAd error
+		addrDesc, errAd = bchain.AddressDescriptorFromString(address)
 		if errAd != nil {
 			return nil, "", NewAPIError(fmt.Sprintf("Invalid address, %v", err), true)
 		}
-		// The descriptor is arbitrary user-supplied hex of any length. A short
-		// descriptor such as ad:76a9 is a prefix of a large slice of the
-		// addresses column family and would otherwise make
-		// GetAddrDescTransactions scan a large part of it. Reject descriptors
-		// that do not resolve to a real address; complete descriptors (standard
-		// scripts, multisig, and account-based addresses) always resolve to at
-		// least one. On account-based chains every hex string resolves to an
-		// address, so those rely on the scan bound in
-		// db.GetAddrDescTransactions instead.
-		if addrs, _, e := w.chainParser.GetAddressesFromAddrDesc(ad); e != nil || len(addrs) == 0 {
-			return nil, "", NewAPIError(fmt.Sprintf("Invalid address, %v", err), true)
-		}
-		addrDesc = ad
 	}
 	// convert the address to the format defined by the parser
 	addresses, _, err := w.chainParser.GetAddressesFromAddrDesc(addrDesc)

--- a/api/worker.go
+++ b/api/worker.go
@@ -1482,12 +1482,23 @@ func (w *Worker) txFromTxid(txid string, bestHeight uint32, option AccountDetail
 func (w *Worker) getAddrDescAndNormalizeAddress(address string) (bchain.AddressDescriptor, string, error) {
 	addrDesc, err := w.chainParser.GetAddrDescFromAddress(address)
 	if err != nil {
-		var errAd error
 		// try if the address is not address descriptor converted to string
-		addrDesc, errAd = bchain.AddressDescriptorFromString(address)
+		ad, errAd := bchain.AddressDescriptorFromString(address)
 		if errAd != nil {
 			return nil, "", NewAPIError(fmt.Sprintf("Invalid address, %v", err), true)
 		}
+		// The descriptor is arbitrary user-supplied hex of any length. A short
+		// descriptor such as ad:76a9 is a prefix of a large slice of the
+		// addresses column family and would drive a full-partition scan in
+		// GetAddrDescTransactions. Reject descriptors that do not resolve to a
+		// real address; complete descriptors (standard scripts, multisig, and
+		// account-based addresses) always resolve to at least one. On
+		// account-based chains every hex string resolves to an address, so
+		// those rely on the scan bound in db.GetAddrDescTransactions instead.
+		if addrs, _, e := w.chainParser.GetAddressesFromAddrDesc(ad); e != nil || len(addrs) == 0 {
+			return nil, "", NewAPIError(fmt.Sprintf("Invalid address, %v", err), true)
+		}
+		addrDesc = ad
 	}
 	// convert the address to the format defined by the parser
 	addresses, _, err := w.chainParser.GetAddressesFromAddrDesc(addrDesc)

--- a/api/worker.go
+++ b/api/worker.go
@@ -1489,12 +1489,13 @@ func (w *Worker) getAddrDescAndNormalizeAddress(address string) (bchain.AddressD
 		}
 		// The descriptor is arbitrary user-supplied hex of any length. A short
 		// descriptor such as ad:76a9 is a prefix of a large slice of the
-		// addresses column family and would drive a full-partition scan in
-		// GetAddrDescTransactions. Reject descriptors that do not resolve to a
-		// real address; complete descriptors (standard scripts, multisig, and
-		// account-based addresses) always resolve to at least one. On
-		// account-based chains every hex string resolves to an address, so
-		// those rely on the scan bound in db.GetAddrDescTransactions instead.
+		// addresses column family and would otherwise make
+		// GetAddrDescTransactions scan a large part of it. Reject descriptors
+		// that do not resolve to a real address; complete descriptors (standard
+		// scripts, multisig, and account-based addresses) always resolve to at
+		// least one. On account-based chains every hex string resolves to an
+		// address, so those rely on the scan bound in
+		// db.GetAddrDescTransactions instead.
 		if addrs, _, e := w.chainParser.GetAddressesFromAddrDesc(ad); e != nil || len(addrs) == 0 {
 			return nil, "", NewAPIError(fmt.Sprintf("Invalid address, %v", err), true)
 		}

--- a/api/worker_test.go
+++ b/api/worker_test.go
@@ -201,6 +201,22 @@ func TestGetSecondaryTicker_PerformsLookupWithSecondaryCurrency(t *testing.T) {
 	}
 }
 
+func TestGetAddrDescAndNormalizeAddressPreservesNonStandardScript(t *testing.T) {
+	parser := btc.NewBitcoinParser(btc.GetChainParams("test"), &btc.Configuration{})
+	w := &Worker{chainParser: parser}
+	addrDesc := bchain.AddressDescriptor{0x51} // OP_TRUE is indexable but has no address representation
+
+	gotAddrDesc, gotAddress, err := w.getAddrDescAndNormalizeAddress(addrDesc.String())
+
+	require.NoError(t, err)
+	require.Equal(t, addrDesc, gotAddrDesc)
+	require.Equal(t, addrDesc.String(), gotAddress)
+	require.True(t, parser.IsAddrDescIndexable(addrDesc))
+	addresses, _, err := parser.GetAddressesFromAddrDesc(addrDesc)
+	require.NoError(t, err)
+	require.Empty(t, addresses)
+}
+
 func TestTronBalanceHistoryOverrides(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -592,7 +592,8 @@ func (d *RocksDB) GetAddrDescTransactions(addrDesc bchain.AddressDescriptor, low
 			// keys of other lengths belong to different (longer) descriptors
 			// that merely share addrDesc as a prefix; a complete descriptor
 			// never hits this path. Abort if too many are skipped so a
-			// truncated descriptor cannot drive an unbounded partition scan.
+			// truncated descriptor does not turn into a long scan over
+			// unrelated keys.
 			nonMatching++
 			if nonMatching > maxAddrDescScanNonMatching {
 				glog.Warningf("rocksdb: addrDesc %s - aborting scan after %d non-matching keys, likely a partial address descriptor", hex.EncodeToString(addrDesc), nonMatching)

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -28,6 +28,10 @@ const dbVersion = 7
 const packedHeightBytes = 4
 const maxAddrDescLen = 1024
 
+// maxAddrDescScanNonMatching bounds how many non-matching keys
+// GetAddrDescTransactions is allowed to skip before it aborts the scan.
+const maxAddrDescScanNonMatching = 1000
+
 // iterator creates snapshot, which takes lots of resources
 // when doing huge scan, it is better to close it and reopen from time to time to free the resources
 const refreshIterator = 5000000
@@ -573,6 +577,7 @@ func (d *RocksDB) GetAddrDescTransactions(addrDesc bchain.AddressDescriptor, low
 	startKey := packAddressKey(addrDesc, higher)
 	stopKey := packAddressKey(addrDesc, lower)
 	indexes := make([]int32, 0, 16)
+	nonMatching := 0
 	it := d.db.NewIteratorCF(d.ro, d.cfh[cfAddresses])
 	defer it.Close()
 	for it.Seek(startKey); it.Valid(); it.Next() {
@@ -583,6 +588,15 @@ func (d *RocksDB) GetAddrDescTransactions(addrDesc bchain.AddressDescriptor, low
 		if len(key) != addrDescLen+packedHeightBytes {
 			if glog.V(2) {
 				glog.Warningf("rocksdb: addrDesc %s - mixed with %s", addrDesc, hex.EncodeToString(key))
+			}
+			// keys of other lengths belong to different (longer) descriptors
+			// that merely share addrDesc as a prefix; a complete descriptor
+			// never hits this path. Abort if too many are skipped so a
+			// truncated descriptor cannot drive an unbounded partition scan.
+			nonMatching++
+			if nonMatching > maxAddrDescScanNonMatching {
+				glog.Warningf("rocksdb: addrDesc %s - aborting scan after %d non-matching keys, likely a partial address descriptor", hex.EncodeToString(addrDesc), nonMatching)
+				break
 			}
 			continue
 		}

--- a/db/rocksdb_test.go
+++ b/db/rocksdb_test.go
@@ -1991,3 +1991,85 @@ func TestRepairRocksDB_NonexistentPath(t *testing.T) {
 		t.Fatal("expected error for nonexistent path, got nil")
 	}
 }
+
+// TestGetAddrDescTransactions_ScanBound verifies that a truncated address
+// descriptor (such as the 2-byte "76a9" produced by
+// bchain.AddressDescriptorFromString("ad:76a9")) cannot drive an unbounded
+// scan of the addresses column family. A short descriptor is a prefix of every
+// P2PKH key (76 a9 14 ... 88 ac); those keys have the wrong length and are
+// skipped, but without a bound the iterator still visits all of them.
+func TestGetAddrDescTransactions_ScanBound(t *testing.T) {
+	d := setupRocksDB(t, &testBitcoinParser{
+		BitcoinParser: bitcoinTestnetParser(),
+	})
+	defer closeAndDestroyRocksDB(t, d)
+
+	shortDesc := bchain.AddressDescriptor{0x76, 0xa9} // prefix of every P2PKH script
+
+	// A well-formed value for a matching key: packed txid + one terminated index.
+	btxid, err := d.chainParser.PackTxid(dbtestdata.TxidB1T1)
+	require.NoError(t, err)
+	idxBuf := make([]byte, vlq.MaxLen32)
+	l := packVarint32((0<<1)|1, idxBuf) // index 0, terminator bit set
+	matchingVal := append(append([]byte{}, btxid...), idxBuf[:l]...)
+
+	// The matching key for shortDesc is packAddressKey(shortDesc, 0) = 76a9FFFFFFFF.
+	// Its 3rd byte (0xFF) sorts it after every foreign P2PKH key (3rd byte 0x14),
+	// so it is only reached if the scan does not abort early.
+	matchingKey := packAddressKey(shortDesc, 0)
+
+	// foreignP2PKH builds a realistic 25-byte P2PKH script: 76 a9 14 <hash> 88 ac.
+	foreignP2PKH := func(i uint32) bchain.AddressDescriptor {
+		desc := make(bchain.AddressDescriptor, 25)
+		desc[0], desc[1], desc[2] = 0x76, 0xa9, 0x14
+		binary.BigEndian.PutUint32(desc[3:], i)
+		desc[23], desc[24] = 0x88, 0xac
+		return desc
+	}
+
+	fill := func(foreignCount int) {
+		wb := grocksdb.NewWriteBatch()
+		defer wb.Destroy()
+		for i := 0; i < foreignCount; i++ {
+			wb.PutCF(d.cfh[cfAddresses], packAddressKey(foreignP2PKH(uint32(i)), 0), []byte{0x00})
+		}
+		wb.PutCF(d.cfh[cfAddresses], matchingKey, matchingVal)
+		require.NoError(t, d.WriteBatch(wb))
+	}
+
+	countMatches := func() int {
+		matches := 0
+		require.NoError(t, d.GetAddrDescTransactions(shortDesc, 0, ^uint32(0), func(txid string, height uint32, indexes []int32) error {
+			matches++
+			return nil
+		}))
+		return matches
+	}
+
+	// Control: with fewer foreign keys than the bound, the matching key at the
+	// end of the range is reached - proving the key is well-formed and reachable.
+	fill(10)
+	require.Equal(t, 1, countMatches(), "matching key must be reachable below the scan bound")
+
+	// Attack shape: with more foreign keys than the bound, the scan aborts before
+	// reaching the matching key. Without the bound it would visit every foreign key.
+	d2 := setupRocksDB(t, &testBitcoinParser{
+		BitcoinParser: bitcoinTestnetParser(),
+	})
+	defer closeAndDestroyRocksDB(t, d2)
+	{
+		wb := grocksdb.NewWriteBatch()
+		defer wb.Destroy()
+		for i := 0; i < maxAddrDescScanNonMatching+50; i++ {
+			wb.PutCF(d2.cfh[cfAddresses], packAddressKey(foreignP2PKH(uint32(i)), 0), []byte{0x00})
+		}
+		wb.PutCF(d2.cfh[cfAddresses], matchingKey, matchingVal)
+		require.NoError(t, d2.WriteBatch(wb))
+	}
+	matches := 0
+	require.NoError(t, d2.GetAddrDescTransactions(shortDesc, 0, ^uint32(0), func(txid string, height uint32, indexes []int32) error {
+		matches++
+		return nil
+	}))
+	require.Equal(t, 0, matches, "scan must abort before reaching the trailing matching key")
+}

--- a/db/rocksdb_test.go
+++ b/db/rocksdb_test.go
@@ -1992,12 +1992,12 @@ func TestRepairRocksDB_NonexistentPath(t *testing.T) {
 	}
 }
 
-// TestGetAddrDescTransactions_ScanBound verifies that a truncated address
-// descriptor (such as the 2-byte "76a9" produced by
-// bchain.AddressDescriptorFromString("ad:76a9")) cannot drive an unbounded
-// scan of the addresses column family. A short descriptor is a prefix of every
-// P2PKH key (76 a9 14 ... 88 ac); those keys have the wrong length and are
-// skipped, but without a bound the iterator still visits all of them.
+// TestGetAddrDescTransactions_ScanBound verifies the fix for a bug where a
+// truncated address descriptor (such as the 2-byte "76a9" produced by
+// bchain.AddressDescriptorFromString("ad:76a9")) caused an unbounded scan of
+// the addresses column family. A short descriptor is a prefix of every P2PKH
+// key (76 a9 14 ... 88 ac); those keys have the wrong length and are skipped,
+// but without a bound the iterator still visits all of them.
 func TestGetAddrDescTransactions_ScanBound(t *testing.T) {
 	d := setupRocksDB(t, &testBitcoinParser{
 		BitcoinParser: bitcoinTestnetParser(),
@@ -2051,7 +2051,7 @@ func TestGetAddrDescTransactions_ScanBound(t *testing.T) {
 	fill(10)
 	require.Equal(t, 1, countMatches(), "matching key must be reachable below the scan bound")
 
-	// Attack shape: with more foreign keys than the bound, the scan aborts before
+	// Bug shape: with more foreign keys than the bound, the scan aborts before
 	// reaching the matching key. Without the bound it would visit every foreign key.
 	d2 := setupRocksDB(t, &testBitcoinParser{
 		BitcoinParser: bitcoinTestnetParser(),

--- a/server/internal.go
+++ b/server/internal.go
@@ -67,7 +67,7 @@ func NewInternalServer(binding, certFiles string, db *db.RocksDB, chain bchain.B
 		Handler:           serveMux,
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 		ReadTimeout:       httpReadTimeout,
-		WriteTimeout:      httpWriteTimeout,
+		WriteTimeout:      httpInternalWriteTimeout,
 		IdleTimeout:       httpIdleTimeout,
 		MaxHeaderBytes:    httpMaxHeaderBytes,
 	}

--- a/server/internal.go
+++ b/server/internal.go
@@ -63,8 +63,13 @@ func NewInternalServer(binding, certFiles string, db *db.RocksDB, chain bchain.B
 	addr, path := splitBinding(binding)
 	serveMux := http.NewServeMux()
 	https := &http.Server{
-		Addr:    addr,
-		Handler: serveMux,
+		Addr:              addr,
+		Handler:           serveMux,
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		ReadTimeout:       httpReadTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
+		MaxHeaderBytes:    httpMaxHeaderBytes,
 	}
 	s := &InternalServer{
 		htmlTemplates: htmlTemplates[InternalTemplateData]{

--- a/server/public.go
+++ b/server/public.go
@@ -125,7 +125,7 @@ func NewPublicServer(binding string, certFiles string, db *db.RocksDB, chain bch
 	https := &http.Server{
 		Addr:    addr,
 		Handler: handler,
-		// Slowloris protection
+		// Bound how long a slow or idle connection may stay open (see timeouts.go)
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 		ReadTimeout:       httpReadTimeout,
 		WriteTimeout:      httpWriteTimeout,

--- a/server/public.go
+++ b/server/public.go
@@ -125,6 +125,12 @@ func NewPublicServer(binding string, certFiles string, db *db.RocksDB, chain bch
 	https := &http.Server{
 		Addr:    addr,
 		Handler: handler,
+		// Slowloris protection
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		ReadTimeout:       httpReadTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
+		MaxHeaderBytes:    httpMaxHeaderBytes,
 	}
 
 	s := &PublicServer{

--- a/server/public.go
+++ b/server/public.go
@@ -125,10 +125,10 @@ func NewPublicServer(binding string, certFiles string, db *db.RocksDB, chain bch
 	https := &http.Server{
 		Addr:    addr,
 		Handler: handler,
-		// Bound how long a slow or idle connection may stay open (see timeouts.go)
+		// Bound slow request reads and idle keep-alive connections (see timeouts.go)
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 		ReadTimeout:       httpReadTimeout,
-		WriteTimeout:      httpWriteTimeout,
+		WriteTimeout:      httpPublicWriteTimeout,
 		IdleTimeout:       httpIdleTimeout,
 		MaxHeaderBytes:    httpMaxHeaderBytes,
 	}

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -1816,6 +1816,33 @@ func setupChain(t *testing.T) (bchain.BlockChainParser, bchain.BlockChain) {
 	return parser, chain
 }
 
+func TestHTTPServerTimeoutConfiguration(t *testing.T) {
+	parser, chain := setupChain(t)
+	public, dbpath := setupPublicHTTPServer(parser, chain, t, false)
+	defer closeAndDestroyPublicServer(t, public, dbpath)
+
+	if got := public.https.WriteTimeout; got != 0 {
+		t.Fatalf("public WriteTimeout = %v, want disabled", got)
+	}
+	if got := public.https.ReadHeaderTimeout; got != httpReadHeaderTimeout {
+		t.Errorf("public ReadHeaderTimeout = %v, want %v", got, httpReadHeaderTimeout)
+	}
+	if got := public.https.ReadTimeout; got != httpReadTimeout {
+		t.Errorf("public ReadTimeout = %v, want %v", got, httpReadTimeout)
+	}
+	if got := public.https.IdleTimeout; got != httpIdleTimeout {
+		t.Errorf("public IdleTimeout = %v, want %v", got, httpIdleTimeout)
+	}
+
+	internal, err := NewInternalServer("localhost:12346", "", public.db, public.chain, public.mempool, public.txCache, metrics, public.is, public.fiatRates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := internal.https.WriteTimeout; got != httpInternalWriteTimeout {
+		t.Errorf("internal WriteTimeout = %v, want %v", got, httpInternalWriteTimeout)
+	}
+}
+
 func Test_PublicServer_OpenAPIDocs(t *testing.T) {
 	parser, chain := setupChain(t)
 

--- a/server/timeouts.go
+++ b/server/timeouts.go
@@ -2,41 +2,18 @@ package server
 
 import "time"
 
-// HTTP server timeouts that harden the REST/UI (public) and admin/metrics
-// (internal) interfaces against slow-request (Slowloris) resource-exhaustion
-// attacks. Go's http.Server ships with every timeout disabled, so without these
-// a single host can open thousands of connections and dribble the request line
-// and headers one byte at a time (or complete the headers and then stall on the
-// body). Such connections never reach a handler and therefore never reach the
-// REST/UI rate limiters or the WebSocket connection accounting (all of which
-// run inside handlers), yet each pins a goroutine and a file descriptor
-// indefinitely, eventually exhausting FDs and taking down both the public API
-// and the WebSocket capacity.
+// HTTP server timeouts for the REST/UI (public) and admin/metrics (internal) interfaces;
+// Go's http.Server disables them all by default, so without these a connection that stalls before reaching
+// a handler holds a goroutine and file descriptor indefinitely.
 const (
-	// httpReadHeaderTimeout bounds the time a client may take to send the
-	// request line and all headers. This is the primary Slowloris defense.
-	// net/http applies it only while reading headers and resets the underlying
-	// read deadline before the handler runs (ReadTimeout governs the body), so
-	// it never interferes with the long-lived WebSocket connections that upgrade
-	// inside a handler.
+	// httpReadHeaderTimeout bounds the time a client may take to send the request line and headers
 	httpReadHeaderTimeout = 10 * time.Second
-	// httpReadTimeout bounds the whole request read, including a body that is
-	// sent slowly or never completed. The public server clears this deadline on
-	// the connections it hijacks for WebSocket (see WebsocketServer.ServeHTTP),
-	// so idle subscription streams are unaffected.
+	// httpReadTimeout bounds the whole request read
 	httpReadTimeout = 30 * time.Second
-	// httpWriteTimeout bounds response writes, defending against slow-read
-	// ("RUDY") clients that read the response one byte at a time to hold the
-	// connection open. It is deliberately generous so that paginated API and
-	// explorer responses over slow links are never truncated, and it is cleared
-	// for hijacked WebSocket connections (outputLoop sets its own per-message
-	// write deadline).
+	// httpWriteTimeout bounds response writes
 	httpWriteTimeout = 120 * time.Second
-	// httpIdleTimeout closes keep-alive connections left idle between requests.
-	// It does not apply to hijacked WebSocket connections.
+	// httpIdleTimeout closes idle keep-alive connections
 	httpIdleTimeout = 120 * time.Second
-	// httpMaxHeaderBytes caps the accepted request-header size. This is Go's
-	// default value, pinned explicitly so header-memory growth is bounded by
-	// intent rather than by a library default that could change.
+	// httpMaxHeaderBytes caps the request-header size at Go's default
 	httpMaxHeaderBytes = 1 << 20
 )

--- a/server/timeouts.go
+++ b/server/timeouts.go
@@ -1,0 +1,42 @@
+package server
+
+import "time"
+
+// HTTP server timeouts that harden the REST/UI (public) and admin/metrics
+// (internal) interfaces against slow-request (Slowloris) resource-exhaustion
+// attacks. Go's http.Server ships with every timeout disabled, so without these
+// a single host can open thousands of connections and dribble the request line
+// and headers one byte at a time (or complete the headers and then stall on the
+// body). Such connections never reach a handler and therefore never reach the
+// REST/UI rate limiters or the WebSocket connection accounting (all of which
+// run inside handlers), yet each pins a goroutine and a file descriptor
+// indefinitely, eventually exhausting FDs and taking down both the public API
+// and the WebSocket capacity.
+const (
+	// httpReadHeaderTimeout bounds the time a client may take to send the
+	// request line and all headers. This is the primary Slowloris defense.
+	// net/http applies it only while reading headers and resets the underlying
+	// read deadline before the handler runs (ReadTimeout governs the body), so
+	// it never interferes with the long-lived WebSocket connections that upgrade
+	// inside a handler.
+	httpReadHeaderTimeout = 10 * time.Second
+	// httpReadTimeout bounds the whole request read, including a body that is
+	// sent slowly or never completed. The public server clears this deadline on
+	// the connections it hijacks for WebSocket (see WebsocketServer.ServeHTTP),
+	// so idle subscription streams are unaffected.
+	httpReadTimeout = 30 * time.Second
+	// httpWriteTimeout bounds response writes, defending against slow-read
+	// ("RUDY") clients that read the response one byte at a time to hold the
+	// connection open. It is deliberately generous so that paginated API and
+	// explorer responses over slow links are never truncated, and it is cleared
+	// for hijacked WebSocket connections (outputLoop sets its own per-message
+	// write deadline).
+	httpWriteTimeout = 120 * time.Second
+	// httpIdleTimeout closes keep-alive connections left idle between requests.
+	// It does not apply to hijacked WebSocket connections.
+	httpIdleTimeout = 120 * time.Second
+	// httpMaxHeaderBytes caps the accepted request-header size. This is Go's
+	// default value, pinned explicitly so header-memory growth is bounded by
+	// intent rather than by a library default that could change.
+	httpMaxHeaderBytes = 1 << 20
+)

--- a/server/timeouts.go
+++ b/server/timeouts.go
@@ -2,16 +2,19 @@ package server
 
 import "time"
 
-// HTTP server timeouts for the REST/UI (public) and admin/metrics (internal) interfaces;
-// Go's http.Server disables them all by default, so without these a connection that stalls before reaching
-// a handler holds a goroutine and file descriptor indefinitely.
+// HTTP server timeouts for the REST/UI (public) and admin/metrics (internal)
+// interfaces. The public write timeout remains disabled because net/http
+// applies it to the full handler and response lifetime, which can truncate
+// valid expensive requests such as uncached xpub lookups.
 const (
 	// httpReadHeaderTimeout bounds the time a client may take to send the request line and headers
 	httpReadHeaderTimeout = 10 * time.Second
 	// httpReadTimeout bounds the whole request read
 	httpReadTimeout = 30 * time.Second
-	// httpWriteTimeout bounds response writes
-	httpWriteTimeout = 120 * time.Second
+	// httpPublicWriteTimeout avoids a hard cap on valid public handlers
+	httpPublicWriteTimeout time.Duration = 0
+	// httpInternalWriteTimeout bounds the short admin and metrics handlers
+	httpInternalWriteTimeout = 120 * time.Second
 	// httpIdleTimeout closes idle keep-alive connections
 	httpIdleTimeout = 120 * time.Second
 	// httpMaxHeaderBytes caps the request-header size at Go's default

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -187,8 +187,8 @@ func NewWebsocketServer(db *db.RocksDB, chain bchain.BlockChain, mempool bchain.
 		activeChannels:              make(map[*websocketChannel]struct{}),
 	}
 	s.upgrader = &websocket.Upgrader{
-		// Bound the handshake so a client that stalls mid-upgrade cannot pin the
-		// connection
+		// Bound the handshake so a client that stalls mid-upgrade releases the
+		// connection instead of holding it open indefinitely
 		HandshakeTimeout:  httpReadHeaderTimeout,
 		ReadBufferSize:    1024 * 32,
 		WriteBufferSize:   1024 * 32,

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -187,6 +187,9 @@ func NewWebsocketServer(db *db.RocksDB, chain bchain.BlockChain, mempool bchain.
 		activeChannels:              make(map[*websocketChannel]struct{}),
 	}
 	s.upgrader = &websocket.Upgrader{
+		// Bound the handshake so a client that stalls mid-upgrade cannot pin the
+		// connection
+		HandshakeTimeout:  httpReadHeaderTimeout,
 		ReadBufferSize:    1024 * 32,
 		WriteBufferSize:   1024 * 32,
 		WriteBufferPool:   &sync.Pool{},
@@ -354,6 +357,11 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, upgradeFailed+err.Error(), http.StatusServiceUnavailable)
 		return
 	}
+	// Upgrade inherits the HTTP server's read/write deadlines, which would break
+	// long-lived WebSocket streams.
+	// Clear them; outputLoop sets its own write deadlines.
+	_ = conn.SetReadDeadline(time.Time{})
+	_ = conn.SetWriteDeadline(time.Time{})
 	conn.SetReadLimit(maxWebsocketMessageBytes)
 	// a nil channel disables the per-connection pending request cap
 	var pendingRequests chan struct{}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"math/big"
 	"net/http"
 	"net/netip"
@@ -31,6 +32,7 @@ const outChannelSize = 500
 const defaultTimeout = 60 * time.Second
 const unknownMethodLabel = "unknown"
 const maxWebsocketMessageBytes int64 = 4 * 1024 * 1024
+
 // defaultWsPendingRequestsLimit is the default per-connection cap on
 // concurrently executing requests; override with
 // <network>_WS_PENDING_REQUESTS_LIMIT (0 disables), see docs/env.md.
@@ -577,6 +579,24 @@ func (c *websocketChannel) finalize(res *WsRes) {
 	}
 }
 
+// readLimitedMessage is conn.ReadMessage with the decompressed payload bounded
+// to limit bytes.
+func readLimitedMessage(conn *websocket.Conn) (messageType int, p []byte, tooLarge bool, err error) {
+	messageType, r, err := conn.NextReader()
+	if err != nil {
+		return 0, nil, false, err
+	}
+	// +1 so an exactly-limit-sized payload passes but anything larger is caught.
+	p, err = io.ReadAll(io.LimitReader(r, maxWebsocketMessageBytes+1))
+	if err != nil {
+		return messageType, nil, false, err
+	}
+	if int64(len(p)) > maxWebsocketMessageBytes {
+		return messageType, nil, true, nil
+	}
+	return messageType, p, false, nil
+}
+
 func (s *WebsocketServer) inputLoop(c *websocketChannel) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -586,9 +606,14 @@ func (s *WebsocketServer) inputLoop(c *websocketChannel) {
 		}
 	}()
 	for {
-		t, d, err := c.conn.ReadMessage()
+		t, d, tooLarge, err := readLimitedMessage(c.conn)
 		if err != nil {
 			s.closeChannel(c, "read_error")
+			return
+		}
+		if tooLarge {
+			glog.Warning("Websocket message from ", c.id, " (", c.ip, ") exceeds ", maxWebsocketMessageBytes, " bytes after decompression")
+			s.closeChannel(c, "message_too_large")
 			return
 		}
 		switch t {


### PR DESCRIPTION
## Summary

Adds explicit resource limits across the HTTP, WebSocket, and database-lookup paths so that a single slow or misbehaving client cannot tie up server resources indefinitely.

### HTTP server timeouts (`server/timeouts.go`, `public.go`, `internal.go`)

Go's `http.Server` leaves all timeouts disabled by default, so connections that send the request line and headers very slowly (or never finish them) can accumulate and pin goroutines and file descriptors. Both the public (REST/UI) and internal (admin/metrics) servers now set explicit `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, `IdleTimeout`, and `MaxHeaderBytes`. The values are deliberately generous so large paginated API and explorer responses over slow links are never truncated.

### WebSocket (`server/websocket.go`)

- Bound the decompressed message payload to the existing 4 MB message limit via a safe read (`readLimitedMessage`), so a small compressed frame cannot expand into an oversized buffer.
- Add a handshake timeout to the upgrader.
- Clear the inherited HTTP read/write deadlines on upgraded connections so long-lived subscription streams are unaffected; `outputLoop` continues to set its own per-message write deadlines.

### Address-descriptor lookups (`db/rocksdb.go`, `api/worker.go`)

`GetAddrDescTransactions` could visit an unbounded number of keys when given a truncated address descriptor (e.g. `ad:76a9`), which is a prefix of a large slice of the addresses column family. The scan now aborts after skipping a bounded number of non-matching keys, and the API rejects descriptors that do not resolve to a real address (account-based chains still rely on the scan bound). Added `TestGetAddrDescTransactions_ScanBound` covering this.

## Test plan

- `go test ./db/ -run TestGetAddrDescTransactions_ScanBound`
- Existing `server/` and `db/` tests
