### PR TITLE
chore: remove remaining Holesky testnet references

### DIFF
--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -80,8 +80,6 @@ func init() {
 	BlockChainFactories["Ethereum Classic"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Sepolia"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Sepolia Archive"] = eth.NewEthereumRPC
-	BlockChainFactories["Ethereum Testnet Holesky"] = eth.NewEthereumRPC
-	BlockChainFactories["Ethereum Testnet Holesky Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Hoodi"] = eth.NewEthereumRPC
 	BlockChainFactories["Ethereum Testnet Hoodi Archive"] = eth.NewEthereumRPC
 	BlockChainFactories["Bcash"] = bch.NewBCashRPC

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -39,8 +39,6 @@ const (
 	MainNet Network = 1
 	// TestNetSepolia is Sepolia test network
 	TestNetSepolia Network = 11155111
-	// TestNetHolesky is Holesky test network
-	TestNetHolesky Network = 17000
 	// TestNetHoodi is Hoodi test network
 	TestNetHoodi Network = 560048
 )
@@ -555,9 +553,6 @@ func (b *EthereumRPC) Initialize() error {
 	case TestNetSepolia:
 		b.Testnet = true
 		b.Network = "sepolia"
-	case TestNetHolesky:
-		b.Testnet = true
-		b.Network = "holesky"
 	case TestNetHoodi:
 		b.Testnet = true
 		b.Network = "hoodi"
@@ -2151,7 +2146,7 @@ func (b *EthereumRPC) EthereumTypeGetEip1559Fees() (*bchain.Eip1559Fees, error) 
 			priorityFee /= rows
 		}
 		// A zero tip is a deliberate, accepted outcome on idle chains: when eth_feeHistory reports empty or
-		// all-zero reward percentiles (quiet testnets such as Sepolia/Holesky, or a backend that omits
+		// all-zero reward percentiles (quiet testnets such as Sepolia, or a backend that omits
 		// rewards) there is no priority competition to price, so maxPriorityFeePerGas is 0. maxFeePerGas
 		// still covers eip1559BaseFeeMultiplier*baseFee below, so the tx stays mineable.
 		tip := big.NewInt(priorityFee)

--- a/configs/coins/ethereum_testnet_hoodi_consensus.json
+++ b/configs/coins/ethereum_testnet_hoodi_consensus.json
@@ -32,7 +32,7 @@
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --hoodi --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17506 --rpc-port=17507 --monitoring-port=17508 --p2p-tcp-port=13506 --p2p-udp-port=12506 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_hoodi/backend/erigon/jwt.hex --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
         "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log",
-        "postinst_script_template": "wget https://github.com/eth-clients/holesky/raw/main/metadata/genesis.ssz -O {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz",
+        "postinst_script_template": "wget https://github.com/eth-clients/hoodi/raw/main/metadata/genesis.ssz -O {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz",
         "service_type": "simple",
         "service_additional_params_template": "",
         "protect_memory": true,

--- a/configs/coins/ethereum_testnet_sepolia_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_consensus.json
@@ -32,7 +32,7 @@
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --sepolia --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17576 --rpc-port=17577 --monitoring-port=17578 --p2p-tcp-port=13576 --p2p-udp-port=12576 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_sepolia/backend/erigon/jwt.hex --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
         "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log",
-        "postinst_script_template": "wget https://github.com/eth-clients/holesky/raw/main/metadata/genesis.ssz -O {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz",
+        "postinst_script_template": "wget https://github.com/eth-clients/sepolia/raw/main/metadata/genesis.ssz -O {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz",
         "service_type": "simple",
         "service_additional_params_template": "",
         "protect_memory": true,

--- a/configs/grafana/template.json
+++ b/configs/grafana/template.json
@@ -6329,11 +6329,6 @@
           },
           {
             "selected": false,
-            "text": "Ethereum Testnet  Holesky Archive",
-            "value": "Ethereum Testnet  Holesky Archive"
-          },
-          {
-            "selected": false,
             "text": "Ethereum Testnet  Sepolia Archive",
             "value": "Ethereum Testnet  Sepolia Archive"
           },
@@ -6348,7 +6343,7 @@
             "value": "Avalanche Archive"
           }
         ],
-        "query": "Bitcoin,Ethereum Archive,Polygon Archive,BNB Smart Chain Archive,Arbitrum Archive,Base Archive,Optimism Archive,Litecoin,Namecoin,Vertcoin,Zcash,Bgold,Bcash,Dash,DigiByte,Dogecoin,Ethereum Classic,Testnet,Ethereum Testnet  Holesky Archive,Ethereum Testnet  Sepolia Archive,Tron,Avalanche Archive",
+        "query": "Bitcoin,Ethereum Archive,Polygon Archive,BNB Smart Chain Archive,Arbitrum Archive,Base Archive,Optimism Archive,Litecoin,Namecoin,Vertcoin,Zcash,Bgold,Bcash,Dash,DigiByte,Dogecoin,Ethereum Classic,Testnet,Ethereum Testnet  Sepolia Archive,Tron,Avalanche Archive",
         "skipUrlSync": false,
         "type": "custom"
       }

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -82,8 +82,6 @@
 | Koto Testnet                     | 19151            | 19051              | 18051       | 48351                                               |
 | Decred Testnet                   | 19161            | 19061              | 18061       | 48361                                               |
 | Flo Testnet                      | 19166            | 19066              | 18066       | 48366                                               |
-| Ethereum Testnet Holesky         | 19116            | 19016              | 18016       | 18116 http, 18516 authrpc, 48316 p2p                |
-| Ethereum Testnet Holesky Archive | 19136            | 19036              | 18036       | 18136 http, 18136 torrent, 18536 authrpc, 48336 p2p |
 | Ethereum Testnet Hoodi           | 19106            | 19006              | 18006       | 18106 http, 18506 authrpc, 48306 p2p                |
 | Ethereum Testnet Hoodi Archive   | 19126            | 19026              | 18026       | 18126 http, 18126 torrent, 18526 authrpc, 48326 p2p |
 | Ethereum Testnet Sepolia         | 19176            | 19076              | 18076       | 18176 http, 18576 authrpc, 48376 p2p                |


### PR DESCRIPTION
Closes #1404.

Holesky was decommissioned and replaced by Hoodi. This PR removes all remaining Holesky references:

- Remove `TestNetHolesky` constant and its case branch in `ethrpc.go`
- Remove Holesky entries from `blockchain.go` factory map
- Fix incorrect Holesky genesis URLs in `ethereum_testnet_hoodi_consensus.json` → hoodi and `ethereum_testnet_sepolia_consensus.json` → sepolia
- Remove Holesky rows from `docs/ports.md`
- Remove Holesky option from `configs/grafana/template.json`

Build and all unit tests pass.