### PR TITLE
fix(eth): restrict ENS aliases to trusted registrars; index modern ENS controllers

### DIFF
--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -537,6 +537,19 @@ func (c *blockChainWithMetrics) MissingBlockRetryOverride() *bchain.MissingBlock
 	return nil
 }
 
+// RebuildEnsAliases forwards the wrapped chain's ENS alias rebuild (EthereumType
+// coins) through the metrics wrapper so the -rebuildensaliases maintenance flag
+// reaches it; without this the duck-typed lookup only sees the wrapper. Returns
+// an error when the underlying chain doesn't support it.
+func (c *blockChainWithMetrics) RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks int, isInterrupted func() bool, store func([]bchain.AddressAliasRecord) error) error {
+	if p, ok := c.b.(interface {
+		RebuildEnsAliases(uint32, uint32, int, func() bool, func([]bchain.AddressAliasRecord) error) error
+	}); ok {
+		return p.RebuildEnsAliases(fromBlock, toBlock, chunkBlocks, isInterrupted, store)
+	}
+	return errors.New("ENS alias rebuild not supported by underlying chain")
+}
+
 // XpubConfigOverride forwards the wrapped chain's per-chain xpub config
 // override through the metrics wrapper; nil when none is provided.
 func (c *blockChainWithMetrics) XpubConfigOverride() *bchain.XpubConfig {

--- a/bchain/coins/blockchain.go
+++ b/bchain/coins/blockchain.go
@@ -550,6 +550,18 @@ func (c *blockChainWithMetrics) RebuildEnsAliases(fromBlock, toBlock uint32, chu
 	return errors.New("ENS alias rebuild not supported by underlying chain")
 }
 
+// EnsRegistrarsFingerprint forwards the wrapped chain's ENS registrar fingerprint
+// so the startup self-heal can detect a changed registrar set through the metrics
+// wrapper. Empty when the underlying chain doesn't expose one.
+func (c *blockChainWithMetrics) EnsRegistrarsFingerprint() string {
+	if p, ok := c.b.(interface {
+		EnsRegistrarsFingerprint() string
+	}); ok {
+		return p.EnsRegistrarsFingerprint()
+	}
+	return ""
+}
+
 // XpubConfigOverride forwards the wrapped chain's per-chain xpub config
 // override through the metrics wrapper; nil when none is provided.
 func (c *blockChainWithMetrics) XpubConfigOverride() *bchain.XpubConfig {

--- a/bchain/coins/blockchain_test.go
+++ b/bchain/coins/blockchain_test.go
@@ -1,0 +1,47 @@
+//go:build unittest
+
+package coins
+
+import (
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+// ensRebuilderIface mirrors db.EnsAliasRebuilder's method set. The blockbook.go
+// -rebuildensaliases path reaches the chain through exactly this duck-typed
+// assertion, so the metrics wrapper must expose the method (defining it here
+// avoids importing db and the resulting import cycle).
+type ensRebuilderIface interface {
+	RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks int, isInterrupted func() bool, store func([]bchain.AddressAliasRecord) error) error
+}
+
+type fakeEnsChain struct {
+	bchain.BlockChain
+	called bool
+}
+
+func (f *fakeEnsChain) RebuildEnsAliases(_, _ uint32, _ int, _ func() bool, _ func([]bchain.AddressAliasRecord) error) error {
+	f.called = true
+	return nil
+}
+
+// Test_blockChainWithMetrics_ForwardsRebuildEnsAliases guards the regression
+// where the metrics wrapper hid the EthereumType RebuildEnsAliases method, so
+// running -rebuildensaliases failed with "coin does not support ENS alias
+// rebuild" even on Ethereum.
+func Test_blockChainWithMetrics_ForwardsRebuildEnsAliases(t *testing.T) {
+	inner := &fakeEnsChain{}
+	var chain bchain.BlockChain = &blockChainWithMetrics{b: inner}
+
+	rebuilder, ok := chain.(ensRebuilderIface)
+	if !ok {
+		t.Fatal("metrics wrapper does not expose RebuildEnsAliases; blockbook.go assertion would fail")
+	}
+	if err := rebuilder.RebuildEnsAliases(0, 1, 0, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !inner.called {
+		t.Fatal("RebuildEnsAliases was not forwarded to the underlying chain")
+	}
+}

--- a/bchain/coins/blockchain_test.go
+++ b/bchain/coins/blockchain_test.go
@@ -18,13 +18,16 @@ type ensRebuilderIface interface {
 
 type fakeEnsChain struct {
 	bchain.BlockChain
-	called bool
+	called      bool
+	fingerprint string
 }
 
 func (f *fakeEnsChain) RebuildEnsAliases(_, _ uint32, _ int, _ func() bool, _ func([]bchain.AddressAliasRecord) error) error {
 	f.called = true
 	return nil
 }
+
+func (f *fakeEnsChain) EnsRegistrarsFingerprint() string { return f.fingerprint }
 
 // Test_blockChainWithMetrics_ForwardsRebuildEnsAliases guards the regression
 // where the metrics wrapper hid the EthereumType RebuildEnsAliases method, so
@@ -43,5 +46,20 @@ func Test_blockChainWithMetrics_ForwardsRebuildEnsAliases(t *testing.T) {
 	}
 	if !inner.called {
 		t.Fatal("RebuildEnsAliases was not forwarded to the underlying chain")
+	}
+}
+
+// Test_blockChainWithMetrics_ForwardsEnsRegistrarsFingerprint guards that the
+// startup self-heal can read the registrar fingerprint through the wrapper.
+func Test_blockChainWithMetrics_ForwardsEnsRegistrarsFingerprint(t *testing.T) {
+	inner := &fakeEnsChain{fingerprint: "v1|0xabc"}
+	var chain bchain.BlockChain = &blockChainWithMetrics{b: inner}
+
+	fp, ok := chain.(interface{ EnsRegistrarsFingerprint() string })
+	if !ok {
+		t.Fatal("metrics wrapper does not expose EnsRegistrarsFingerprint")
+	}
+	if got := fp.EnsRegistrarsFingerprint(); got != "v1|0xabc" {
+		t.Fatalf("EnsRegistrarsFingerprint() = %q, want %q", got, "v1|0xabc")
 	}
 }

--- a/bchain/coins/bsc/bscrpc.go
+++ b/bchain/coins/bsc/bscrpc.go
@@ -38,7 +38,6 @@ func NewBNBSmartChainRPC(config json.RawMessage, pushHandler func(bchain.Notific
 	s := &BNBSmartChainRPC{
 		EthereumRPC: c.(*eth.EthereumRPC),
 	}
-	s.Parser.SetEnsSuffix(".bnb")
 
 	return s, nil
 }

--- a/bchain/coins/bsc/bscrpc.go
+++ b/bchain/coins/bsc/bscrpc.go
@@ -38,6 +38,11 @@ func NewBNBSmartChainRPC(config json.RawMessage, pushHandler func(bchain.Notific
 	s := &BNBSmartChainRPC{
 		EthereumRPC: c.(*eth.EthereumRPC),
 	}
+	// New ENS-style aliases are no longer recorded on BSC (empty ens_registrars),
+	// but legacy records from earlier accept-any syncs remain in the DB; keep the
+	// .bnb suffix so they render with their original (Space ID) label rather than
+	// a misleading .eth one.
+	s.Parser.SetEnsSuffix(".bnb")
 
 	return s, nil
 }

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -24,15 +24,12 @@ const tokenTransferEventSignature = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f16
 const tokenERC1155TransferSingleEventSignature = "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
 const tokenERC1155TransferBatchEventSignature = "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb"
 
-// nameRegisteredEventSignature is keccak256("NameRegistered(string,bytes32,address,uint256,uint256)"),
-// the ENS NameRegistered event emitted by the original ETHRegistrarController.
+// ENS NameRegistered event, original 5-arg ETHRegistrarController:
+// keccak256("NameRegistered(string,bytes32,address,uint256,uint256)").
 const nameRegisteredEventSignature = "0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f"
 
-// nameRegisteredWithPremiumEventSignature is keccak256("NameRegistered(string,bytes32,address,uint256,uint256,uint256)"),
-// the event emitted by the newer ETHRegistrarController versions, which split
-// cost into baseCost + premium (one extra data word). Both events carry the
-// registered name as their first dynamic parameter, so getEnsRecord parses them
-// uniformly via the ABI offset word.
+// Newer 6-arg ETHRegistrarController (baseCost + premium):
+// keccak256("NameRegistered(string,bytes32,address,uint256,uint256,uint256)").
 const nameRegisteredWithPremiumEventSignature = "0x69e37f151eb98a09618ddaa80c8cfaf1ce5996867c489f45b555b412271ebf27"
 
 const contractNameSignature = "0x06fdde03"

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -32,6 +32,10 @@ const nameRegisteredEventSignature = "0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621
 // keccak256("NameRegistered(string,bytes32,address,uint256,uint256,uint256)").
 const nameRegisteredWithPremiumEventSignature = "0x69e37f151eb98a09618ddaa80c8cfaf1ce5996867c489f45b555b412271ebf27"
 
+// Current 7-arg ETHRegistrarController (adds referrer), the live mainnet emitter:
+// keccak256("NameRegistered(string,bytes32,address,uint256,uint256,uint256,bytes32)").
+const nameRegisteredWithReferrerEventSignature = "0xc2240194853531f1ae318dcef227de79c6ad0fd9d1b0e4fe08568415be2e08a5"
+
 const contractNameSignature = "0x06fdde03"
 const contractSymbolSignature = "0x95d89b41"
 const contractDecimalsSignature = "0x313ce567"

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -24,7 +24,16 @@ const tokenTransferEventSignature = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f16
 const tokenERC1155TransferSingleEventSignature = "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
 const tokenERC1155TransferBatchEventSignature = "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb"
 
+// nameRegisteredEventSignature is keccak256("NameRegistered(string,bytes32,address,uint256,uint256)"),
+// the ENS NameRegistered event emitted by the original ETHRegistrarController.
 const nameRegisteredEventSignature = "0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f"
+
+// nameRegisteredWithPremiumEventSignature is keccak256("NameRegistered(string,bytes32,address,uint256,uint256,uint256)"),
+// the event emitted by the newer ETHRegistrarController versions, which split
+// cost into baseCost + premium (one extra data word). Both events carry the
+// registered name as their first dynamic parameter, so getEnsRecord parses them
+// uniformly via the ABI offset word.
+const nameRegisteredWithPremiumEventSignature = "0x69e37f151eb98a09618ddaa80c8cfaf1ce5996867c489f45b555b412271ebf27"
 
 const contractNameSignature = "0x06fdde03"
 const contractSymbolSignature = "0x95d89b41"

--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -36,6 +36,17 @@ const nameRegisteredWithPremiumEventSignature = "0x69e37f151eb98a09618ddaa80c8cf
 // keccak256("NameRegistered(string,bytes32,address,uint256,uint256,uint256,bytes32)").
 const nameRegisteredWithReferrerEventSignature = "0xc2240194853531f1ae318dcef227de79c6ad0fd9d1b0e4fe08568415be2e08a5"
 
+// nameRegisteredEventSignatures lists every NameRegistered topic0 getEnsRecord
+// can parse. It is the single source of truth shared by the live emitter check
+// (isTrustedNameRegisteredEvent) and the -rebuildensaliases eth_getLogs filter,
+// so the two can never drift: a controller version added here is picked up by
+// both live sync and backfill.
+var nameRegisteredEventSignatures = []string{
+	nameRegisteredEventSignature,
+	nameRegisteredWithPremiumEventSignature,
+	nameRegisteredWithReferrerEventSignature,
+}
+
 const contractNameSignature = "0x06fdde03"
 const contractSymbolSignature = "0x95d89b41"
 const contractDecimalsSignature = "0x313ce567"

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -303,9 +303,47 @@ func (p *EthereumParser) ParseInputData(signatures *[]bchain.FourByteSignature, 
 	return &parsed
 }
 
-// getEnsRecord processes transaction log entry and tries to parse ENS record from it
-func getEnsRecord(l *rpcLogWithTxHash) *bchain.AddressAliasRecord {
+// maxEnsAliasNameLen caps the decoded ENS name length (in bytes) accepted as an
+// address alias, bounding storage and display abuse from an oversized log.
+const maxEnsAliasNameLen = 256
+
+// validEnsAliasName rejects names unsafe to store or render as an address alias:
+// empty, over the length cap, not valid UTF-8, or containing control characters
+// (NUL, newline, ANSI escapes) or bidirectional overrides (e.g. U+202E) that could
+// spoof or corrupt the displayed alias. Bidi_Control is used rather than the whole
+// Cf category so legitimate emoji names using the zero-width joiner still pass.
+func validEnsAliasName(name string) bool {
+	if len(name) == 0 || len(name) > maxEnsAliasNameLen {
+		return false
+	}
+	if !utf8.ValidString(name) {
+		return false
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) || unicode.Is(unicode.Bidi_Control, r) {
+			return false
+		}
+	}
+	return true
+}
+
+// getEnsRecord processes transaction log entry and tries to parse ENS record from it.
+// registrars is the set of contract addresses (lower-cased, 0x-prefixed) trusted to
+// emit NameRegistered events: a log whose emitter (l.Address) is not in the set is
+// rejected, so an arbitrary contract cannot forge an ENS alias for any address. An
+// empty set therefore trusts no one and records nothing; the special entry "*"
+// accepts any emitter (legacy behavior, for chains with a different name service).
+func getEnsRecord(l *rpcLogWithTxHash, registrars map[string]struct{}) *bchain.AddressAliasRecord {
 	if len(l.Topics) == 3 && l.Topics[0] == nameRegisteredEventSignature && len(l.Data) >= 322 {
+		if _, acceptAny := registrars[ensRegistrarWildcard]; !acceptAny {
+			emitter := strings.ToLower(l.Address)
+			if !strings.HasPrefix(emitter, "0x") {
+				emitter = "0x" + emitter
+			}
+			if _, ok := registrars[emitter]; !ok {
+				return nil
+			}
+		}
 		address, err := addressFromPaddedHex(l.Topics[2])
 		if err != nil {
 			return nil
@@ -329,7 +367,11 @@ func getEnsRecord(l *rpcLogWithTxHash) *bchain.AddressAliasRecord {
 		if err != nil {
 			return nil
 		}
-		return &bchain.AddressAliasRecord{Address: address, Name: string(b)}
+		name := string(b)
+		if !validEnsAliasName(name) {
+			return nil
+		}
+		return &bchain.AddressAliasRecord{Address: address, Name: name}
 	}
 	return nil
 }

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -327,51 +327,83 @@ func validEnsAliasName(name string) bool {
 	return true
 }
 
-// getEnsRecord processes transaction log entry and tries to parse ENS record from it.
-// registrars is the set of contract addresses (lower-cased, 0x-prefixed) trusted to
-// emit NameRegistered events: a log whose emitter (l.Address) is not in the set is
-// rejected, so an arbitrary contract cannot forge an ENS alias for any address. An
-// empty set therefore trusts no one and records nothing; the special entry "*"
-// accepts any emitter (legacy behavior, for chains with a different name service).
+// getEnsRecord processes a transaction log entry and tries to parse an ENS
+// address alias (a NameRegistered event) from it. Both the original 5-argument
+// event (old ETHRegistrarController) and the newer 6-argument event that split
+// cost into baseCost + premium are recognized. registrars is the set of contract
+// addresses (lower-cased, 0x-prefixed) trusted to emit these events: a log whose
+// emitter (l.Address) is not in the set is rejected, so an arbitrary contract
+// cannot forge an ENS alias for any address. An empty set therefore trusts no
+// one and records nothing; the special entry "*" accepts any emitter (legacy
+// behavior, for chains with a different name service).
 func getEnsRecord(l *rpcLogWithTxHash, registrars map[string]struct{}) *bchain.AddressAliasRecord {
-	if len(l.Topics) == 3 && l.Topics[0] == nameRegisteredEventSignature && len(l.Data) >= 322 {
-		if _, acceptAny := registrars[ensRegistrarWildcard]; !acceptAny {
-			emitter := strings.ToLower(l.Address)
-			if !strings.HasPrefix(emitter, "0x") {
-				emitter = "0x" + emitter
-			}
-			if _, ok := registrars[emitter]; !ok {
-				return nil
-			}
-		}
-		address, err := addressFromPaddedHex(l.Topics[2])
-		if err != nil {
-			return nil
-		}
-		c, err := strconv.ParseInt(l.Data[194:194+64], 16, 64)
-		if err != nil {
-			return nil
-		}
-		const nameStart = 194 + 64
-		// int(c)<<1 can overflow: c is attacker-controlled (up to 2^63-1) and Go's
-		// signed left shift wraps silently, so de can land anywhere in [0, 257]
-		// below nameStart. The lower bound must be the slice
-		// start index, not 0 — a de below the start makes l.Data[nameStart:de] a
-		// low>high slice expression that panics. Checking de < nameStart guarantees
-		// nameStart <= de <= len(l.Data), so the slice below can never panic.
-		de := nameStart + (int(c) << 1)
-		if de > len(l.Data) || de < nameStart {
-			return nil
-		}
-		b, err := hex.DecodeString(l.Data[nameStart:de])
-		if err != nil {
-			return nil
-		}
-		name := string(b)
-		if !validEnsAliasName(name) {
-			return nil
-		}
-		return &bchain.AddressAliasRecord{Address: address, Name: name}
+	if len(l.Topics) != 3 {
+		return nil
 	}
-	return nil
+	if l.Topics[0] != nameRegisteredEventSignature && l.Topics[0] != nameRegisteredWithPremiumEventSignature {
+		return nil
+	}
+	if _, acceptAny := registrars[ensRegistrarWildcard]; !acceptAny {
+		emitter := strings.ToLower(l.Address)
+		if !strings.HasPrefix(emitter, "0x") {
+			emitter = "0x" + emitter
+		}
+		if _, ok := registrars[emitter]; !ok {
+			return nil
+		}
+	}
+	address, err := addressFromPaddedHex(l.Topics[2])
+	if err != nil {
+		return nil
+	}
+	name, ok := parseEnsNameFromLogData(l.Data)
+	if !ok || !validEnsAliasName(name) {
+		return nil
+	}
+	return &bchain.AddressAliasRecord{Address: address, Name: name}
+}
+
+// readHexWordAt reads one 32-byte EVM word starting at hexStart (an index into
+// the 0x-prefixed hex data string) as an int64, reporting false if the word is
+// out of range or does not fit in an int64.
+func readHexWordAt(data string, hexStart int) (int64, bool) {
+	if hexStart < 2 || hexStart+evmWordHex > len(data) {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(data[hexStart:hexStart+evmWordHex], 16, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseEnsNameFromLogData extracts the ABI-encoded `string name` (the first
+// non-indexed parameter of every NameRegistered variant) from a log's data. The
+// leading word holds the byte offset to the name's length word; the name bytes
+// follow. Reading via the offset - rather than a hardcoded position - keeps this
+// layout-agnostic, so the extra baseCost/premium word of the newer event is
+// handled without special-casing. Every index derives from attacker-controlled
+// input, so all bounds are checked and no slice expression can panic.
+func parseEnsNameFromLogData(data string) (string, bool) {
+	offset, ok := readHexWordAt(data, 2) // leading word: byte offset to the name length word
+	if !ok || offset < 0 || offset > int64(len(data)) {
+		return "", false
+	}
+	lenStart := 2 + int(offset)*2
+	length, ok := readHexWordAt(data, lenStart)
+	// Cap the length before using it as a slice bound: it both rejects absurd,
+	// overflow-prone values and enforces the alias length limit early.
+	if !ok || length < 0 || length > maxEnsAliasNameLen {
+		return "", false
+	}
+	nameStart := lenStart + evmWordHex
+	nameEnd := nameStart + int(length)*2
+	if nameEnd > len(data) {
+		return "", false
+	}
+	b, err := hex.DecodeString(data[nameStart:nameEnd])
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
 }

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -307,7 +307,9 @@ func (p *EthereumParser) ParseInputData(signatures *[]bchain.FourByteSignature, 
 const maxEnsAliasNameLen = 256
 
 // validEnsAliasName rejects alias names that are empty, over the length cap, not
-// UTF-8, or carry control chars / bidi overrides (emoji ZWJ is allowed).
+// UTF-8, or carry chars that could hide or spoof the displayed alias: controls,
+// bidi overrides, line/paragraph separators, and invisible format chars. ZWJ and
+// ZWNJ are allowed, as they occur in legitimate emoji and script names.
 func validEnsAliasName(name string) bool {
 	if len(name) == 0 || len(name) > maxEnsAliasNameLen {
 		return false
@@ -316,28 +318,36 @@ func validEnsAliasName(name string) bool {
 		return false
 	}
 	for _, r := range name {
-		if unicode.IsControl(r) || unicode.Is(unicode.Bidi_Control, r) {
+		// ZWJ (U+200D) and ZWNJ (U+200C) are legitimate in emoji and some scripts.
+		if r == 0x200D || r == 0x200C {
+			continue
+		}
+		if unicode.IsControl(r) || unicode.Is(unicode.Bidi_Control, r) ||
+			unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
 			return false
 		}
 	}
 	return true
 }
 
-// getEnsRecord parses an ENS alias from a NameRegistered log (5- and 6-arg events).
-// Only emitters in registrars are accepted; empty records nothing, "*" accepts any.
+// isTrustedNameRegisteredEvent reports whether topic0 is one of the ENS
+// NameRegistered event signatures getEnsRecord knows how to parse: the original
+// 5-arg, the 6-arg (baseCost+premium) and the current 7-arg (referrer) events.
+func isTrustedNameRegisteredEvent(topic0 string) bool {
+	return topic0 == nameRegisteredEventSignature ||
+		topic0 == nameRegisteredWithPremiumEventSignature ||
+		topic0 == nameRegisteredWithReferrerEventSignature
+}
+
+// getEnsRecord parses an ENS alias from a NameRegistered log (5-, 6- and 7-arg
+// events). Only emitters in registrars are accepted; empty records nothing, "*"
+// accepts any.
 func getEnsRecord(l *rpcLogWithTxHash, registrars map[string]struct{}) *bchain.AddressAliasRecord {
-	if len(l.Topics) != 3 {
-		return nil
-	}
-	if l.Topics[0] != nameRegisteredEventSignature && l.Topics[0] != nameRegisteredWithPremiumEventSignature {
+	if len(l.Topics) != 3 || !isTrustedNameRegisteredEvent(l.Topics[0]) {
 		return nil
 	}
 	if _, acceptAny := registrars[ensRegistrarWildcard]; !acceptAny {
-		emitter := strings.ToLower(l.Address)
-		if !strings.HasPrefix(emitter, "0x") {
-			emitter = "0x" + emitter
-		}
-		if _, ok := registrars[emitter]; !ok {
+		if _, ok := registrars[normalizeEnsRegistrar(l.Address)]; !ok {
 			return nil
 		}
 	}
@@ -352,30 +362,23 @@ func getEnsRecord(l *rpcLogWithTxHash, registrars map[string]struct{}) *bchain.A
 	return &bchain.AddressAliasRecord{Address: address, Name: name}
 }
 
-// readHexWordAt reads one 32-byte EVM word at hexStart as int64; false if out of
-// range or not representable.
-func readHexWordAt(data string, hexStart int) (int64, bool) {
-	if hexStart < 2 || hexStart+evmWordHex > len(data) {
-		return 0, false
-	}
-	v, err := strconv.ParseInt(data[hexStart:hexStart+evmWordHex], 16, 64)
-	if err != nil {
-		return 0, false
-	}
-	return v, true
-}
-
-// parseEnsNameFromLogData extracts the ABI `string name` via its offset word (so
-// both event layouts work); all indices are bounds-checked against untrusted input.
+// parseEnsNameFromLogData extracts the ABI `string name` (the first dynamic
+// parameter of every NameRegistered variant) via its offset word, so all event
+// layouts work uniformly. All indices derive from untrusted input, so each word
+// read is bounds-checked (parseEVMLogWordUint64) and the length is capped before
+// use as a slice bound.
 func parseEnsNameFromLogData(data string) (string, bool) {
-	offset, ok := readHexWordAt(data, 2) // leading word: byte offset to the name length word
-	if !ok || offset < 0 || offset > int64(len(data)) {
+	if has0xPrefix(data) {
+		data = data[2:]
+	}
+	// leading word: byte offset from data start to the name's length word
+	offsetBytes, err := parseEVMLogWordUint64(data, 0)
+	if err != nil || offsetBytes > uint64(len(data)) {
 		return "", false
 	}
-	lenStart := 2 + int(offset)*2
-	length, ok := readHexWordAt(data, lenStart)
-	// cap length before using it as a slice bound (rejects overflow, enforces limit)
-	if !ok || length < 0 || length > maxEnsAliasNameLen {
+	lenStart := int(offsetBytes) * 2
+	length, err := parseEVMLogWordUint64(data, lenStart)
+	if err != nil || length > maxEnsAliasNameLen {
 		return "", false
 	}
 	nameStart := lenStart + evmWordHex

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -303,15 +303,11 @@ func (p *EthereumParser) ParseInputData(signatures *[]bchain.FourByteSignature, 
 	return &parsed
 }
 
-// maxEnsAliasNameLen caps the decoded ENS name length (in bytes) accepted as an
-// address alias, bounding storage and display abuse from an oversized log.
+// maxEnsAliasNameLen caps the decoded ENS name length (bytes) stored as an alias.
 const maxEnsAliasNameLen = 256
 
-// validEnsAliasName rejects names unsafe to store or render as an address alias:
-// empty, over the length cap, not valid UTF-8, or containing control characters
-// (NUL, newline, ANSI escapes) or bidirectional overrides (e.g. U+202E) that could
-// spoof or corrupt the displayed alias. Bidi_Control is used rather than the whole
-// Cf category so legitimate emoji names using the zero-width joiner still pass.
+// validEnsAliasName rejects alias names that are empty, over the length cap, not
+// UTF-8, or carry control chars / bidi overrides (emoji ZWJ is allowed).
 func validEnsAliasName(name string) bool {
 	if len(name) == 0 || len(name) > maxEnsAliasNameLen {
 		return false
@@ -327,15 +323,8 @@ func validEnsAliasName(name string) bool {
 	return true
 }
 
-// getEnsRecord processes a transaction log entry and tries to parse an ENS
-// address alias (a NameRegistered event) from it. Both the original 5-argument
-// event (old ETHRegistrarController) and the newer 6-argument event that split
-// cost into baseCost + premium are recognized. registrars is the set of contract
-// addresses (lower-cased, 0x-prefixed) trusted to emit these events: a log whose
-// emitter (l.Address) is not in the set is rejected, so an arbitrary contract
-// cannot forge an ENS alias for any address. An empty set therefore trusts no
-// one and records nothing; the special entry "*" accepts any emitter (legacy
-// behavior, for chains with a different name service).
+// getEnsRecord parses an ENS alias from a NameRegistered log (5- and 6-arg events).
+// Only emitters in registrars are accepted; empty records nothing, "*" accepts any.
 func getEnsRecord(l *rpcLogWithTxHash, registrars map[string]struct{}) *bchain.AddressAliasRecord {
 	if len(l.Topics) != 3 {
 		return nil
@@ -363,9 +352,8 @@ func getEnsRecord(l *rpcLogWithTxHash, registrars map[string]struct{}) *bchain.A
 	return &bchain.AddressAliasRecord{Address: address, Name: name}
 }
 
-// readHexWordAt reads one 32-byte EVM word starting at hexStart (an index into
-// the 0x-prefixed hex data string) as an int64, reporting false if the word is
-// out of range or does not fit in an int64.
+// readHexWordAt reads one 32-byte EVM word at hexStart as int64; false if out of
+// range or not representable.
 func readHexWordAt(data string, hexStart int) (int64, bool) {
 	if hexStart < 2 || hexStart+evmWordHex > len(data) {
 		return 0, false
@@ -377,13 +365,8 @@ func readHexWordAt(data string, hexStart int) (int64, bool) {
 	return v, true
 }
 
-// parseEnsNameFromLogData extracts the ABI-encoded `string name` (the first
-// non-indexed parameter of every NameRegistered variant) from a log's data. The
-// leading word holds the byte offset to the name's length word; the name bytes
-// follow. Reading via the offset - rather than a hardcoded position - keeps this
-// layout-agnostic, so the extra baseCost/premium word of the newer event is
-// handled without special-casing. Every index derives from attacker-controlled
-// input, so all bounds are checked and no slice expression can panic.
+// parseEnsNameFromLogData extracts the ABI `string name` via its offset word (so
+// both event layouts work); all indices are bounds-checked against untrusted input.
 func parseEnsNameFromLogData(data string) (string, bool) {
 	offset, ok := readHexWordAt(data, 2) // leading word: byte offset to the name length word
 	if !ok || offset < 0 || offset > int64(len(data)) {
@@ -391,8 +374,7 @@ func parseEnsNameFromLogData(data string) (string, bool) {
 	}
 	lenStart := 2 + int(offset)*2
 	length, ok := readHexWordAt(data, lenStart)
-	// Cap the length before using it as a slice bound: it both rejects absurd,
-	// overflow-prone values and enforces the alias length limit early.
+	// cap length before using it as a slice bound (rejects overflow, enforces limit)
 	if !ok || length < 0 || length > maxEnsAliasNameLen {
 		return "", false
 	}

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -334,9 +334,12 @@ func validEnsAliasName(name string) bool {
 // NameRegistered event signatures getEnsRecord knows how to parse: the original
 // 5-arg, the 6-arg (baseCost+premium) and the current 7-arg (referrer) events.
 func isTrustedNameRegisteredEvent(topic0 string) bool {
-	return topic0 == nameRegisteredEventSignature ||
-		topic0 == nameRegisteredWithPremiumEventSignature ||
-		topic0 == nameRegisteredWithReferrerEventSignature
+	for _, sig := range nameRegisteredEventSignatures {
+		if topic0 == sig {
+			return true
+		}
+	}
+	return false
 }
 
 // getEnsRecord parses an ENS alias from a NameRegistered log (5-, 6- and 7-arg

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -586,9 +586,8 @@ func Test_getEnsRecord(t *testing.T) {
 			want: nil,
 		},
 		{
-			// Security: a valid NameRegistered payload emitted by an untrusted
-			// contract must NOT be turned into an alias (ENS alias spoofing).
-			name: "forged emitter rejected",
+			// A valid payload from an untrusted emitter must not become an alias.
+			name: "untrusted emitter rejected",
 			log: rpcLogWithTxHash{
 				RpcLog: bchain.RpcLog{
 					Address: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
@@ -603,8 +602,7 @@ func Test_getEnsRecord(t *testing.T) {
 			want: nil,
 		},
 		{
-			// An empty trusted set means trust none: even a well-formed event
-			// records nothing.
+			// Empty set trusts none: even a well-formed event records nothing.
 			name: "empty registrar set records nothing",
 			log: rpcLogWithTxHash{
 				RpcLog: bchain.RpcLog{
@@ -638,8 +636,7 @@ func Test_getEnsRecord(t *testing.T) {
 			want:       &bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
 		},
 		{
-			// Security: a name carrying a control character (here a newline, 0x0a)
-			// must be rejected so it cannot spoof or corrupt the displayed alias.
+			// A name with a control character (newline 0x0a) must be rejected.
 			name: "control character in name rejected",
 			log: rpcLogWithTxHash{
 				RpcLog: bchain.RpcLog{
@@ -655,9 +652,8 @@ func Test_getEnsRecord(t *testing.T) {
 			want: nil,
 		},
 		{
-			// Newer ETHRegistrarController: 6-argument event (topic0 0x69e37f15…)
-			// with an extra baseCost/premium word, so the name offset is 0x80 and
-			// the length word sits one slot later than the old layout.
+			// Newer controller 6-arg event (topic0 0x69e37f15…): extra baseCost/premium
+			// word shifts the name offset to 0x80.
 			name: "newer controller 6-arg event",
 			log: rpcLogWithTxHash{
 				RpcLog: bchain.RpcLog{
@@ -678,8 +674,7 @@ func Test_getEnsRecord(t *testing.T) {
 			want: &bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
 		},
 	}
-	// Cases with a nil registrars field default to trusting the mainnet ENS
-	// ETHRegistrarController versions used as emitters in the fixtures above.
+	// Default trusted set for cases with a nil registrars field.
 	trusted := ensRegistrarSet([]string{
 		"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5",
 		"0x253553366da8546fc250f225fe3d25d0c782303b",

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -668,7 +668,30 @@ func Test_getEnsRecord(t *testing.T) {
 						"0000000000000000000000000000000000000000000000000000000000000000" + // premium
 						"0000000000000000000000000000000000000000000000000000000069dbb21d" + // expires
 						"0000000000000000000000000000000000000000000000000000000000000009" + // name length = 9
-						"756e726176656c6564000000000000000000000000000000000000000000000000", // "unraveled" + padding
+						"756e726176656c65640000000000000000000000000000000000000000000000", // "unraveled" + padding (32-byte word)
+				},
+			},
+			want: &bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
+		},
+		{
+			// Current controller 7-arg event (topic0 0xc224…): adds a referrer word,
+			// shifting the name offset to 0xa0. This is the live mainnet emitter.
+			name: "current controller 7-arg event",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0x59E16fcCd424Cc24e280Be16E11Bcd56fb0CE547",
+					Topics: []string{
+						"0xc2240194853531f1ae318dcef227de79c6ad0fd9d1b0e4fe08568415be2e08a5",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000a0" + // offset to name = 160
+						"0000000000000000000000000000000000000000000000000017629245f5a86f" + // baseCost
+						"0000000000000000000000000000000000000000000000000000000000000000" + // premium
+						"0000000000000000000000000000000000000000000000000000000069dbb21d" + // expires
+						"0000000000000000000000000000000000000000000000000000000000000000" + // referrer
+						"0000000000000000000000000000000000000000000000000000000000000009" + // name length = 9
+						"756e726176656c65640000000000000000000000000000000000000000000000", // "unraveled" + padding
 				},
 			},
 			want: &bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
@@ -708,8 +731,16 @@ func Test_validEnsAliasName(t *testing.T) {
 		{name: "newline", in: "foo\nbar", want: false},
 		{name: "null byte", in: "foo\x00bar", want: false},
 		{name: "ansi escape", in: "foo\x1b[31mbar", want: false},
-		{name: "right-to-left override", in: "foo‮bar", want: false},
+		{name: "right-to-left override", in: "foo\u202ebar", want: false},
 		{name: "invalid utf8", in: "\xff\xfe", want: false},
+		{name: "zero-width space", in: "foo\u200bbar", want: false},
+		{name: "word joiner", in: "foo\u2060bar", want: false},
+		{name: "byte order mark", in: "foo\ufeffbar", want: false},
+		{name: "soft hyphen", in: "foo\u00adbar", want: false},
+		{name: "line separator", in: "foo\u2028bar", want: false},
+		{name: "paragraph separator", in: "foo\u2029bar", want: false},
+		{name: "tag character", in: "foo\U000e0041bar", want: false},
+		{name: "zero-width non-joiner allowed", in: "foo\u200cbar", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -654,10 +654,37 @@ func Test_getEnsRecord(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			// Newer ETHRegistrarController: 6-argument event (topic0 0x69e37f15…)
+			// with an extra baseCost/premium word, so the name offset is 0x80 and
+			// the length word sits one slot later than the old layout.
+			name: "newer controller 6-arg event",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0x253553366Da8546fC250F225fe3d25d0C782303b",
+					Topics: []string{
+						"0x69e37f151eb98a09618ddaa80c8cfaf1ce5996867c489f45b555b412271ebf27",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x0000000000000000000000000000000000000000000000000000000000000080" + // offset to name = 128
+						"0000000000000000000000000000000000000000000000000017629245f5a86f" + // baseCost
+						"0000000000000000000000000000000000000000000000000000000000000000" + // premium
+						"0000000000000000000000000000000000000000000000000000000069dbb21d" + // expires
+						"0000000000000000000000000000000000000000000000000000000000000009" + // name length = 9
+						"756e726176656c6564000000000000000000000000000000000000000000000000", // "unraveled" + padding
+				},
+			},
+			want: &bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
+		},
 	}
 	// Cases with a nil registrars field default to trusting the mainnet ENS
-	// ETHRegistrarController, the emitter used in the fixtures above.
-	trusted := ensRegistrarSet([]string{"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"})
+	// ETHRegistrarController versions used as emitters in the fixtures above.
+	trusted := ensRegistrarSet([]string{
+		"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5",
+		"0x253553366da8546fc250f225fe3d25d0c782303b",
+		"0x59e16fccd424cc24e280be16e11bcd56fb0ce547",
+	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registrars := tt.registrars

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -4,6 +4,7 @@ package eth
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/trezor/blockbook/bchain"
@@ -482,7 +483,10 @@ func Test_getEnsRecord(t *testing.T) {
 	tests := []struct {
 		name string
 		log  rpcLogWithTxHash
-		want *bchain.AddressAliasRecord
+		// registrars is the trusted-emitter set passed to getEnsRecord. nil means
+		// "use the built-in default"; an explicit (possibly empty) map overrides it.
+		registrars map[string]struct{}
+		want       *bchain.AddressAliasRecord
 	}{
 		{
 			name: "unraveled",
@@ -581,11 +585,114 @@ func Test_getEnsRecord(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			// Security: a valid NameRegistered payload emitted by an untrusted
+			// contract must NOT be turned into an alias (ENS alias spoofing).
+			name: "forged emitter rejected",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+					Topics: []string{
+						"0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000000000000000000009756e726176656c65640000000000000000000000000000000000000000000000",
+				},
+			},
+			want: nil,
+		},
+		{
+			// An empty trusted set means trust none: even a well-formed event
+			// records nothing.
+			name: "empty registrar set records nothing",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5",
+					Topics: []string{
+						"0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000000000000000000009756e726176656c65640000000000000000000000000000000000000000000000",
+				},
+			},
+			registrars: map[string]struct{}{},
+			want:       nil,
+		},
+		{
+			// The "*" wildcard accepts any emitter (opt-in legacy behavior).
+			name: "wildcard accepts untrusted emitter",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+					Topics: []string{
+						"0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000000000000000000009756e726176656c65640000000000000000000000000000000000000000000000",
+				},
+			},
+			registrars: ensRegistrarSet([]string{"*"}),
+			want:       &bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
+		},
+		{
+			// Security: a name carrying a control character (here a newline, 0x0a)
+			// must be rejected so it cannot spoof or corrupt the displayed alias.
+			name: "control character in name rejected",
+			log: rpcLogWithTxHash{
+				RpcLog: bchain.RpcLog{
+					Address: "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5",
+					Topics: []string{
+						"0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+						"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+						"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+					},
+					Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d00000000000000000000000000000000000000000000000000000000000000010a00000000000000000000000000000000000000000000000000000000000000",
+				},
+			},
+			want: nil,
+		},
+	}
+	// Cases with a nil registrars field default to trusting the mainnet ENS
+	// ETHRegistrarController, the emitter used in the fixtures above.
+	trusted := ensRegistrarSet([]string{"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registrars := tt.registrars
+			if registrars == nil {
+				registrars = trusted
+			}
+			if got := getEnsRecord(&tt.log, registrars); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getEnsRecord() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_validEnsAliasName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "plain", in: "unraveled", want: true},
+		{name: "unicode letters", in: "münchen", want: true},
+		{name: "emoji with zero-width joiner", in: "👨‍👩‍👧", want: true},
+		{name: "empty", in: "", want: false},
+		{name: "too long", in: strings.Repeat("a", maxEnsAliasNameLen+1), want: false},
+		{name: "at length cap", in: strings.Repeat("a", maxEnsAliasNameLen), want: true},
+		{name: "newline", in: "foo\nbar", want: false},
+		{name: "null byte", in: "foo\x00bar", want: false},
+		{name: "ansi escape", in: "foo\x1b[31mbar", want: false},
+		{name: "right-to-left override", in: "foo‮bar", want: false},
+		{name: "invalid utf8", in: "\xff\xfe", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getEnsRecord(&tt.log); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getEnsRecord() = %v, want %v", got, tt.want)
+			if got := validEnsAliasName(tt.in); got != tt.want {
+				t.Errorf("validEnsAliasName(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/bchain/coins/eth/ethparser.go
+++ b/bchain/coins/eth/ethparser.go
@@ -41,12 +41,15 @@ type EthereumLikeParser interface {
 	bchain.BlockChainParser
 	EthTxToTx(tx *bchain.RpcTransaction, receipt *bchain.RpcReceipt, internalData *bchain.EthereumInternalData, blocktime int64, confirmations uint32, fixEIP55 bool) (*bchain.Tx, error)
 	SetEnsSuffix(suffix string)
+	SetEnsRegistrars(addrs []string)
+	GetEnsRegistrars() map[string]struct{}
 }
 
 // EthereumParser handle
 type EthereumParser struct {
 	*bchain.BaseParser
 	EnsSuffix                      string
+	EnsRegistrars                  map[string]struct{}
 	HotAddressMinContracts         int
 	HotAddressLRUCacheSize         int
 	HotAddressMinHits              int
@@ -117,6 +120,49 @@ type rpcBlockTxids struct {
 
 func (p *EthereumParser) SetEnsSuffix(suffix string) {
 	p.EnsSuffix = suffix
+}
+
+// ensRegistrarWildcard, when present in the trusted set, disables the emitter
+// check so any contract's NameRegistered event is accepted (legacy behavior,
+// opt-in for chains with a different name service).
+const ensRegistrarWildcard = "*"
+
+// normalizeEnsRegistrar lower-cases an address and ensures the 0x prefix so it
+// can be compared directly against the (lower-cased, 0x-prefixed) address field
+// returned by eth_getLogs. The wildcard token is passed through unchanged.
+func normalizeEnsRegistrar(addr string) string {
+	a := strings.ToLower(strings.TrimSpace(addr))
+	if a == "" || a == ensRegistrarWildcard {
+		return a
+	}
+	if !strings.HasPrefix(a, "0x") {
+		a = "0x" + a
+	}
+	return a
+}
+
+// ensRegistrarSet builds a lookup set of trusted ENS registrar emitter addresses.
+func ensRegistrarSet(addrs []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(addrs))
+	for _, a := range addrs {
+		if n := normalizeEnsRegistrar(a); n != "" {
+			m[n] = struct{}{}
+		}
+	}
+	return m
+}
+
+// SetEnsRegistrars replaces the set of contract addresses trusted to emit
+// NameRegistered events. An empty (or nil) list means trust none - no ENS
+// aliases are recorded. The special entry "*" accepts any emitter, restoring
+// the legacy behavior for chains with a different name service.
+func (p *EthereumParser) SetEnsRegistrars(addrs []string) {
+	p.EnsRegistrars = ensRegistrarSet(addrs)
+}
+
+// GetEnsRegistrars returns the set of trusted NameRegistered emitter addresses.
+func (p *EthereumParser) GetEnsRegistrars() map[string]struct{} {
+	return p.EnsRegistrars
 }
 
 func ethNumber(n string) (int64, error) {

--- a/bchain/coins/eth/ethparser.go
+++ b/bchain/coins/eth/ethparser.go
@@ -41,15 +41,12 @@ type EthereumLikeParser interface {
 	bchain.BlockChainParser
 	EthTxToTx(tx *bchain.RpcTransaction, receipt *bchain.RpcReceipt, internalData *bchain.EthereumInternalData, blocktime int64, confirmations uint32, fixEIP55 bool) (*bchain.Tx, error)
 	SetEnsSuffix(suffix string)
-	SetEnsRegistrars(addrs []string)
-	GetEnsRegistrars() map[string]struct{}
 }
 
 // EthereumParser handle
 type EthereumParser struct {
 	*bchain.BaseParser
 	EnsSuffix                      string
-	EnsRegistrars                  map[string]struct{}
 	HotAddressMinContracts         int
 	HotAddressLRUCacheSize         int
 	HotAddressMinHits              int
@@ -138,26 +135,30 @@ func normalizeEnsRegistrar(addr string) string {
 	return a
 }
 
-// ensRegistrarSet builds a lookup set of trusted ENS registrar emitter addresses.
+// isValidEnsRegistrar reports whether a normalized entry is the wildcard or a
+// well-formed 20-byte 0x address; malformed entries can never match a real
+// eth_getLogs emitter and are dropped from the set.
+func isValidEnsRegistrar(norm string) bool {
+	if norm == ensRegistrarWildcard {
+		return true
+	}
+	if !strings.HasPrefix(norm, "0x") {
+		return false
+	}
+	b, err := hex.DecodeString(norm[2:])
+	return err == nil && len(b) == 20
+}
+
+// ensRegistrarSet builds a lookup set of trusted ENS registrar emitters, skipping
+// malformed entries. Empty/nil trusts none (records nothing); "*" accepts any.
 func ensRegistrarSet(addrs []string) map[string]struct{} {
 	m := make(map[string]struct{}, len(addrs))
 	for _, a := range addrs {
-		if n := normalizeEnsRegistrar(a); n != "" {
+		if n := normalizeEnsRegistrar(a); isValidEnsRegistrar(n) {
 			m[n] = struct{}{}
 		}
 	}
 	return m
-}
-
-// SetEnsRegistrars sets the trusted NameRegistered emitters: empty/nil trusts
-// none (records nothing), "*" accepts any emitter.
-func (p *EthereumParser) SetEnsRegistrars(addrs []string) {
-	p.EnsRegistrars = ensRegistrarSet(addrs)
-}
-
-// GetEnsRegistrars returns the set of trusted NameRegistered emitter addresses.
-func (p *EthereumParser) GetEnsRegistrars() map[string]struct{} {
-	return p.EnsRegistrars
 }
 
 func ethNumber(n string) (int64, error) {

--- a/bchain/coins/eth/ethparser.go
+++ b/bchain/coins/eth/ethparser.go
@@ -122,14 +122,11 @@ func (p *EthereumParser) SetEnsSuffix(suffix string) {
 	p.EnsSuffix = suffix
 }
 
-// ensRegistrarWildcard, when present in the trusted set, disables the emitter
-// check so any contract's NameRegistered event is accepted (legacy behavior,
-// opt-in for chains with a different name service).
+// ensRegistrarWildcard in the trusted set disables the emitter check (accept any).
 const ensRegistrarWildcard = "*"
 
-// normalizeEnsRegistrar lower-cases an address and ensures the 0x prefix so it
-// can be compared directly against the (lower-cased, 0x-prefixed) address field
-// returned by eth_getLogs. The wildcard token is passed through unchanged.
+// normalizeEnsRegistrar lower-cases and 0x-prefixes an address to match
+// eth_getLogs output; the wildcard token passes through unchanged.
 func normalizeEnsRegistrar(addr string) string {
 	a := strings.ToLower(strings.TrimSpace(addr))
 	if a == "" || a == ensRegistrarWildcard {
@@ -152,10 +149,8 @@ func ensRegistrarSet(addrs []string) map[string]struct{} {
 	return m
 }
 
-// SetEnsRegistrars replaces the set of contract addresses trusted to emit
-// NameRegistered events. An empty (or nil) list means trust none - no ENS
-// aliases are recorded. The special entry "*" accepts any emitter, restoring
-// the legacy behavior for chains with a different name service.
+// SetEnsRegistrars sets the trusted NameRegistered emitters: empty/nil trusts
+// none (records nothing), "*" accepts any emitter.
 func (p *EthereumParser) SetEnsRegistrars(addrs []string) {
 	p.EnsRegistrars = ensRegistrarSet(addrs)
 }

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1443,6 +1444,109 @@ func (b *EthereumRPC) processEventsForBlock(blockNumber string) (map[string][]*b
 		}
 	}
 	return r, ensRecords, nil
+}
+
+// ErrEnsRebuildInterrupted is returned by RebuildEnsAliases when the caller
+// signals a shutdown between chunks.
+var ErrEnsRebuildInterrupted = stdErrors.New("ENS alias rebuild interrupted")
+
+// ensRebuildDefaultChunkBlocks is the default block span per eth_getLogs request
+// in RebuildEnsAliases. NameRegistered logs are filtered server-side by address
+// and topic, so a wide span still returns few rows; operators whose node caps
+// getLogs ranges (e.g. dev Erigon at 1000 blocks) can lower it.
+const ensRebuildDefaultChunkBlocks = 100000
+
+// ensRebuildProgressEvery throttles the per-chunk progress log so a small chunk
+// size over a long chain does not flood the log; a chunk that finds aliases is
+// always logged.
+const ensRebuildProgressEvery = 64
+
+// RebuildEnsAliases rescans ENS NameRegistered logs emitted by the trusted
+// registrars over [fromBlock, toBlock] in chunkBlocks-sized ranges and passes
+// each chunk's decoded alias records to store. It is a one-shot maintenance
+// operation backing the -rebuildensaliases flag; the caller is expected to have
+// wiped the existing aliases first. An empty trusted set records nothing (there
+// is nothing to trust); "*" scans every emitter. isInterrupted, if non-nil, is
+// polled between chunks and aborts the scan with ErrEnsRebuildInterrupted.
+func (b *EthereumRPC) RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks int, isInterrupted func() bool, store func([]bchain.AddressAliasRecord) error) error {
+	if len(b.ensRegistrars) == 0 {
+		glog.Info("RebuildEnsAliases: ens_registrars is empty (trust none); nothing to backfill")
+		return nil
+	}
+	if chunkBlocks <= 0 {
+		chunkBlocks = ensRebuildDefaultChunkBlocks
+	}
+	// topic0 filter: the NameRegistered signatures getEnsRecord can parse (OR).
+	filter := map[string]interface{}{
+		"topics": []interface{}{[]string{
+			nameRegisteredEventSignature,
+			nameRegisteredWithPremiumEventSignature,
+			nameRegisteredWithReferrerEventSignature,
+		}},
+	}
+	// Unless the wildcard is set, restrict emitters to the trusted registrars so
+	// the node returns only their logs; the wildcard scans every emitter.
+	if _, acceptAny := b.ensRegistrars[ensRegistrarWildcard]; !acceptAny {
+		addrs := make([]string, 0, len(b.ensRegistrars))
+		for a := range b.ensRegistrars {
+			addrs = append(addrs, a)
+		}
+		sort.Strings(addrs)
+		filter["address"] = addrs
+	}
+	glog.Infof("RebuildEnsAliases: scanning blocks [%d, %d] in chunks of %d", fromBlock, toBlock, chunkBlocks)
+	step := uint64(chunkBlocks)
+	total, chunk := 0, 0
+	for from := uint64(fromBlock); from <= uint64(toBlock); from += step {
+		if isInterrupted != nil && isInterrupted() {
+			return ErrEnsRebuildInterrupted
+		}
+		to := from + step - 1
+		if to > uint64(toBlock) {
+			to = uint64(toBlock)
+		}
+		records, err := b.getEnsAliasLogs(filter, from, to)
+		if err != nil {
+			return errors.Annotatef(err, "eth_getLogs blocks [%d, %d]", from, to)
+		}
+		if len(records) > 0 {
+			if err := store(records); err != nil {
+				return errors.Annotatef(err, "store aliases for blocks [%d, %d]", from, to)
+			}
+			total += len(records)
+		}
+		chunk++
+		if len(records) > 0 || chunk%ensRebuildProgressEvery == 0 || to == uint64(toBlock) {
+			glog.Infof("RebuildEnsAliases: scanned up to block %d, %d aliases recorded", to, total)
+		}
+		if to == uint64(toBlock) {
+			break
+		}
+	}
+	glog.Infof("RebuildEnsAliases: finished, %d aliases recorded", total)
+	return nil
+}
+
+// getEnsAliasLogs runs one eth_getLogs call for [from, to] using the shared
+// NameRegistered filter and decodes the trusted logs it returns into alias
+// records. The filter map is reused across calls (this runs single-goroutine),
+// only its block bounds change.
+func (b *EthereumRPC) getEnsAliasLogs(filter map[string]interface{}, from, to uint64) ([]bchain.AddressAliasRecord, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+	defer cancel()
+	filter["fromBlock"] = "0x" + strconv.FormatUint(from, 16)
+	filter["toBlock"] = "0x" + strconv.FormatUint(to, 16)
+	var logs []rpcLogWithTxHash
+	if err := b.RPC.CallContext(ctx, &logs, "eth_getLogs", filter); err != nil {
+		return nil, err
+	}
+	var records []bchain.AddressAliasRecord
+	for i := range logs {
+		if ens := getEnsRecord(&logs[i], b.ensRegistrars); ens != nil {
+			records = append(records, *ens)
+		}
+	}
+	return records, nil
 }
 
 type rpcCallTrace struct {

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -1464,6 +1464,31 @@ const ensRebuildDefaultChunkBlocks = 100000
 // always logged.
 const ensRebuildProgressEvery = 64
 
+// ensRebuildSchemaVersion is bumped when the ENS alias parsing or signature set
+// changes. It is part of the registrar fingerprint, so a deploy that improves
+// parsing re-heals stored aliases even when the configured registrars are
+// unchanged.
+const ensRebuildSchemaVersion = 1
+
+// EnsRegistrarsFingerprint returns a stable marker of the trusted ENS registrar
+// set (schema version + sorted, normalized registrars). It changes whenever the
+// operator edits ens_registrars or the parsing schema is bumped; the startup
+// self-heal compares it against the stored value to decide when to rebuild.
+// Empty when no registrars are configured, so trust-none coins never auto-heal
+// (and are therefore never auto-wiped) — the -rebuildensaliases flag still
+// forces a rebuild there.
+func (b *EthereumRPC) EnsRegistrarsFingerprint() string {
+	if len(b.ensRegistrars) == 0 {
+		return ""
+	}
+	addrs := make([]string, 0, len(b.ensRegistrars))
+	for a := range b.ensRegistrars {
+		addrs = append(addrs, a)
+	}
+	sort.Strings(addrs)
+	return fmt.Sprintf("v%d|%s", ensRebuildSchemaVersion, strings.Join(addrs, ","))
+}
+
 // RebuildEnsAliases rescans ENS NameRegistered logs emitted by the trusted
 // registrars over [fromBlock, toBlock] in chunkBlocks-sized ranges and passes
 // each chunk's decoded alias records to store. It is a one-shot maintenance

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -94,7 +94,7 @@ type Configuration struct {
 	AddressContractsCacheBulkMaxBytes int64  `json:"address_contracts_cache_bulk_max_bytes,omitempty"`
 	AddressAliases                    bool   `json:"address_aliases,omitempty"`
 	// EnsRegistrars are the contracts trusted to emit ENS NameRegistered events.
-	// Absent/empty trusts none; "*" accepts any emitter (see SetEnsRegistrars).
+	// Absent/empty trusts none (records nothing); "*" accepts any emitter.
 	EnsRegistrars                   []string `json:"ens_registrars,omitempty"`
 	MempoolTxTimeoutHours           int      `json:"mempoolTxTimeoutHours"`
 	MempoolTxTimeout                string   `json:"mempoolTxTimeout,omitempty"`
@@ -205,6 +205,9 @@ type EthereumRPC struct {
 	alternativeSendTxProvider *AlternativeSendTxProvider
 	InternalDataProvider      bchain.EthereumInternalDataProvider
 	consensusMonitor          *consensusVersionMonitor
+	// ensRegistrars is the set of contract addresses (lower-cased, 0x-prefixed)
+	// trusted to emit ENS NameRegistered events; empty trusts none, "*" any.
+	ensRegistrars map[string]struct{}
 	// Multicall3 deployment state; lazily probed on first call. See multicall.go.
 	multicall3Probe   atomic.Int32
 	multicall3ProbeSF singleflight.Group
@@ -284,8 +287,13 @@ func NewEthereumRPC(config json.RawMessage, pushHandler func(bchain.Notification
 	parser.AddrContractsCacheMinSize = c.AddressContractsCacheMinSize
 	parser.AddrContractsCacheMaxBytes = c.AddressContractsCacheMaxBytes
 	parser.AddrContractsCacheBulkMaxBytes = c.AddressContractsCacheBulkMaxBytes
-	parser.SetEnsRegistrars(c.EnsRegistrars)
 	s.Parser = parser
+	for _, a := range c.EnsRegistrars {
+		if !isValidEnsRegistrar(normalizeEnsRegistrar(a)) {
+			glog.Warningf("ens_registrars: ignoring invalid entry %q (want 0x + 40 hex, or \"*\")", a)
+		}
+	}
+	s.ensRegistrars = ensRegistrarSet(c.EnsRegistrars)
 	if c.RPCTimeout <= 0 {
 		glog.Warningf("rpc_timeout=%d is invalid, using default %d seconds", c.RPCTimeout, defaultRPCTimeoutSeconds)
 		c.RPCTimeout = defaultRPCTimeoutSeconds
@@ -1425,7 +1433,7 @@ func (b *EthereumRPC) processEventsForBlock(blockNumber string) (map[string][]*b
 		return nil, nil, errors.Annotatef(err, "%s blockNumber %v", method, blockNumber)
 	}
 	r := make(map[string][]*bchain.RpcLog)
-	ensRegistrars := b.Parser.GetEnsRegistrars()
+	ensRegistrars := b.ensRegistrars
 	for i := range logs {
 		l := &logs[i]
 		r[l.Hash] = append(r[l.Hash], &l.RpcLog)

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -93,12 +93,8 @@ type Configuration struct {
 	AddressContractsCacheMaxBytes     int64  `json:"address_contracts_cache_max_bytes,omitempty"`
 	AddressContractsCacheBulkMaxBytes int64  `json:"address_contracts_cache_bulk_max_bytes,omitempty"`
 	AddressAliases                    bool   `json:"address_aliases,omitempty"`
-	// EnsRegistrars lists the contract addresses trusted to emit ENS
-	// NameRegistered events that become address aliases. Absent or empty means
-	// trust none (no ENS aliases are recorded); a list of addresses restricts to
-	// those emitters (e.g. the mainnet ENS ETHRegistrarController); the special
-	// entry "*" accepts any emitter, restoring the legacy accept-any behavior for
-	// a chain with a different, self-hosted name service.
+	// EnsRegistrars are the contracts trusted to emit ENS NameRegistered events.
+	// Absent/empty trusts none; "*" accepts any emitter (see SetEnsRegistrars).
 	EnsRegistrars                   []string `json:"ens_registrars,omitempty"`
 	MempoolTxTimeoutHours           int      `json:"mempoolTxTimeoutHours"`
 	MempoolTxTimeout                string   `json:"mempoolTxTimeout,omitempty"`
@@ -288,8 +284,6 @@ func NewEthereumRPC(config json.RawMessage, pushHandler func(bchain.Notification
 	parser.AddrContractsCacheMinSize = c.AddressContractsCacheMinSize
 	parser.AddrContractsCacheMaxBytes = c.AddressContractsCacheMaxBytes
 	parser.AddrContractsCacheBulkMaxBytes = c.AddressContractsCacheBulkMaxBytes
-	// Trust none by default: absent/empty records no ENS aliases, an address list
-	// restricts to those emitters, and ["*"] accepts any (see EnsRegistrars).
 	parser.SetEnsRegistrars(c.EnsRegistrars)
 	s.Parser = parser
 	if c.RPCTimeout <= 0 {

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -295,6 +295,9 @@ func NewEthereumRPC(config json.RawMessage, pushHandler func(bchain.Notification
 		}
 	}
 	s.ensRegistrars = ensRegistrarSet(c.EnsRegistrars)
+	if c.AddressAliases && len(s.ensRegistrars) == 0 {
+		glog.Warning("ens_registrars is empty while address_aliases is enabled: no ENS aliases will be recorded during sync (contract/token names are unaffected)")
+	}
 	if c.RPCTimeout <= 0 {
 		glog.Warningf("rpc_timeout=%d is invalid, using default %d seconds", c.RPCTimeout, defaultRPCTimeoutSeconds)
 		c.RPCTimeout = defaultRPCTimeoutSeconds
@@ -1464,10 +1467,10 @@ const ensRebuildProgressEvery = 64
 // RebuildEnsAliases rescans ENS NameRegistered logs emitted by the trusted
 // registrars over [fromBlock, toBlock] in chunkBlocks-sized ranges and passes
 // each chunk's decoded alias records to store. It is a one-shot maintenance
-// operation backing the -rebuildensaliases flag; the caller is expected to have
-// wiped the existing aliases first. An empty trusted set records nothing (there
-// is nothing to trust); "*" scans every emitter. isInterrupted, if non-nil, is
-// polled between chunks and aborts the scan with ErrEnsRebuildInterrupted.
+// operation backing the -rebuildensaliases flag. An empty trusted set records
+// nothing (there is nothing to trust); "*" scans every emitter. isInterrupted,
+// if non-nil, is polled between chunks and aborts the scan with
+// ErrEnsRebuildInterrupted.
 func (b *EthereumRPC) RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks int, isInterrupted func() bool, store func([]bchain.AddressAliasRecord) error) error {
 	if len(b.ensRegistrars) == 0 {
 		glog.Info("RebuildEnsAliases: ens_registrars is empty (trust none); nothing to backfill")
@@ -1477,12 +1480,9 @@ func (b *EthereumRPC) RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks i
 		chunkBlocks = ensRebuildDefaultChunkBlocks
 	}
 	// topic0 filter: the NameRegistered signatures getEnsRecord can parse (OR).
+	// Shared with the live emitter check so the two can never drift.
 	filter := map[string]interface{}{
-		"topics": []interface{}{[]string{
-			nameRegisteredEventSignature,
-			nameRegisteredWithPremiumEventSignature,
-			nameRegisteredWithReferrerEventSignature,
-		}},
+		"topics": []interface{}{nameRegisteredEventSignatures},
 	}
 	// Unless the wildcard is set, restrict emitters to the trusted registrars so
 	// the node returns only their logs; the wildcard scans every emitter.

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -97,8 +97,8 @@ type Configuration struct {
 	// NameRegistered events that become address aliases. Absent or empty means
 	// trust none (no ENS aliases are recorded); a list of addresses restricts to
 	// those emitters (e.g. the mainnet ENS ETHRegistrarController); the special
-	// entry "*" accepts any emitter, restoring the legacy behavior for chains
-	// with a different name service (e.g. .bnb).
+	// entry "*" accepts any emitter, restoring the legacy accept-any behavior for
+	// a chain with a different, self-hosted name service.
 	EnsRegistrars                   []string `json:"ens_registrars,omitempty"`
 	MempoolTxTimeoutHours           int      `json:"mempoolTxTimeoutHours"`
 	MempoolTxTimeout                string   `json:"mempoolTxTimeout,omitempty"`

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -93,17 +93,24 @@ type Configuration struct {
 	AddressContractsCacheMaxBytes     int64  `json:"address_contracts_cache_max_bytes,omitempty"`
 	AddressContractsCacheBulkMaxBytes int64  `json:"address_contracts_cache_bulk_max_bytes,omitempty"`
 	AddressAliases                    bool   `json:"address_aliases,omitempty"`
-	MempoolTxTimeoutHours             int    `json:"mempoolTxTimeoutHours"`
-	MempoolTxTimeout                  string `json:"mempoolTxTimeout,omitempty"`
-	AlternativeMempoolTxTimeout       string `json:"alternativeMempoolTxTimeout,omitempty"`
-	QueryBackendOnMempoolResync       bool   `json:"queryBackendOnMempoolResync"`
-	ProcessInternalTransactions       bool   `json:"processInternalTransactions"`
-	ProcessZeroInternalTransactions   bool   `json:"processZeroInternalTransactions"`
-	ConsensusNodeVersionURL           string `json:"consensusNodeVersion"`
-	DisableMempoolSync                bool   `json:"disableMempoolSync,omitempty"`
-	Eip1559Fees                       bool   `json:"eip1559Fees,omitempty"`
-	AlternativeEstimateFee            string `json:"alternative_estimate_fee,omitempty"`
-	AlternativeEstimateFeeParams      string `json:"alternative_estimate_fee_params,omitempty"`
+	// EnsRegistrars lists the contract addresses trusted to emit ENS
+	// NameRegistered events that become address aliases. Absent or empty means
+	// trust none (no ENS aliases are recorded); a list of addresses restricts to
+	// those emitters (e.g. the mainnet ENS ETHRegistrarController); the special
+	// entry "*" accepts any emitter, restoring the legacy behavior for chains
+	// with a different name service (e.g. .bnb).
+	EnsRegistrars                   []string `json:"ens_registrars,omitempty"`
+	MempoolTxTimeoutHours           int      `json:"mempoolTxTimeoutHours"`
+	MempoolTxTimeout                string   `json:"mempoolTxTimeout,omitempty"`
+	AlternativeMempoolTxTimeout     string   `json:"alternativeMempoolTxTimeout,omitempty"`
+	QueryBackendOnMempoolResync     bool     `json:"queryBackendOnMempoolResync"`
+	ProcessInternalTransactions     bool     `json:"processInternalTransactions"`
+	ProcessZeroInternalTransactions bool     `json:"processZeroInternalTransactions"`
+	ConsensusNodeVersionURL         string   `json:"consensusNodeVersion"`
+	DisableMempoolSync              bool     `json:"disableMempoolSync,omitempty"`
+	Eip1559Fees                     bool     `json:"eip1559Fees,omitempty"`
+	AlternativeEstimateFee          string   `json:"alternative_estimate_fee,omitempty"`
+	AlternativeEstimateFeeParams    string   `json:"alternative_estimate_fee_params,omitempty"`
 	// AverageBlockTimeMs is the chain's nominal block cadence in ms;
 	// required for EVM coins (translates duration settings to block counts).
 	AverageBlockTimeMs int `json:"averageBlockTimeMs,omitempty"`
@@ -281,6 +288,9 @@ func NewEthereumRPC(config json.RawMessage, pushHandler func(bchain.Notification
 	parser.AddrContractsCacheMinSize = c.AddressContractsCacheMinSize
 	parser.AddrContractsCacheMaxBytes = c.AddressContractsCacheMaxBytes
 	parser.AddrContractsCacheBulkMaxBytes = c.AddressContractsCacheBulkMaxBytes
+	// Trust none by default: absent/empty records no ENS aliases, an address list
+	// restricts to those emitters, and ["*"] accepts any (see EnsRegistrars).
+	parser.SetEnsRegistrars(c.EnsRegistrars)
 	s.Parser = parser
 	if c.RPCTimeout <= 0 {
 		glog.Warningf("rpc_timeout=%d is invalid, using default %d seconds", c.RPCTimeout, defaultRPCTimeoutSeconds)
@@ -1421,10 +1431,11 @@ func (b *EthereumRPC) processEventsForBlock(blockNumber string) (map[string][]*b
 		return nil, nil, errors.Annotatef(err, "%s blockNumber %v", method, blockNumber)
 	}
 	r := make(map[string][]*bchain.RpcLog)
+	ensRegistrars := b.Parser.GetEnsRegistrars()
 	for i := range logs {
 		l := &logs[i]
 		r[l.Hash] = append(r[l.Hash], &l.RpcLog)
-		ens := getEnsRecord(l)
+		ens := getEnsRecord(l, ensRegistrars)
 		if ens != nil {
 			ensRecords = append(ensRecords, *ens)
 		}

--- a/bchain/coins/eth/ethrpc_ens_rebuild_test.go
+++ b/bchain/coins/eth/ethrpc_ens_rebuild_test.go
@@ -199,6 +199,32 @@ func Test_RebuildEnsAliases_WildcardScansAllEmitters(t *testing.T) {
 	}
 }
 
+func Test_EnsRegistrarsFingerprint(t *testing.T) {
+	fp := func(addrs []string) string {
+		return (&EthereumRPC{ensRegistrars: ensRegistrarSet(addrs)}).EnsRegistrarsFingerprint()
+	}
+	if got := fp(nil); got != "" {
+		t.Errorf("empty set fingerprint = %q, want empty (trust-none never auto-heals)", got)
+	}
+	// Order-independent: the same set in any order yields the same fingerprint.
+	a := fp([]string{"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"})
+	b := fp([]string{"0x59e16fccd424cc24e280be16e11bcd56fb0ce547", "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"})
+	if a == "" {
+		t.Fatal("non-empty set produced empty fingerprint")
+	}
+	if a != b {
+		t.Errorf("fingerprint depends on order: %q vs %q", a, b)
+	}
+	// Changing a registrar address changes the fingerprint (drives the self-heal).
+	c := fp([]string{"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x0000000000000000000000000000000000000001"})
+	if c == a {
+		t.Errorf("fingerprint unchanged after a registrar address changed: %q", c)
+	}
+	if got := fp([]string{"*"}); got == "" {
+		t.Error("wildcard set produced empty fingerprint")
+	}
+}
+
 func Test_RebuildEnsAliases_Interrupted(t *testing.T) {
 	mock := &mockEnsLogsRPC{entries: []ensLogEntry{{block: 5, log: unraveledLog("0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5")}}}
 	b := &EthereumRPC{RPC: mock, Timeout: time.Second, ensRegistrars: ensRegistrarSet([]string{"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"})}

--- a/bchain/coins/eth/ethrpc_ens_rebuild_test.go
+++ b/bchain/coins/eth/ethrpc_ens_rebuild_test.go
@@ -1,0 +1,212 @@
+//go:build unittest
+
+package eth
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+// ensLogEntry pairs a NameRegistered log with the block it was emitted in so the
+// mock can honor the eth_getLogs block range the way a node would.
+type ensLogEntry struct {
+	block uint64
+	log   rpcLogWithTxHash
+}
+
+// mockEnsLogsRPC serves eth_getLogs from a fixed set of logs, filtering only by
+// block range (emitter/topic filtering is left to getEnsRecord, so the test
+// exercises Blockbook's own emitter check rather than trusting the node's).
+type mockEnsLogsRPC struct {
+	entries     []ensLogEntry
+	calls       int
+	lastFilters []map[string]interface{}
+}
+
+func (m *mockEnsLogsRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockEnsLogsRPC) Close() {}
+
+func (m *mockEnsLogsRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	if method != "eth_getLogs" {
+		return fmt.Errorf("unexpected method %q", method)
+	}
+	m.calls++
+	out, ok := result.(*[]rpcLogWithTxHash)
+	if !ok {
+		return fmt.Errorf("unexpected result type %T", result)
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 filter arg, got %d", len(args))
+	}
+	filter, ok := args[0].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected filter type %T", args[0])
+	}
+	// Snapshot the filter: RebuildEnsAliases reuses one map and mutates its block
+	// bounds in place, so we must copy to assert per-call.
+	snap := make(map[string]interface{}, len(filter))
+	for k, v := range filter {
+		snap[k] = v
+	}
+	m.lastFilters = append(m.lastFilters, snap)
+	from, err := blockBoundToUint(filter["fromBlock"])
+	if err != nil {
+		return err
+	}
+	to, err := blockBoundToUint(filter["toBlock"])
+	if err != nil {
+		return err
+	}
+	var logs []rpcLogWithTxHash
+	for _, e := range m.entries {
+		if e.block >= from && e.block <= to {
+			logs = append(logs, e.log)
+		}
+	}
+	*out = logs
+	return nil
+}
+
+func blockBoundToUint(v interface{}) (uint64, error) {
+	s, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("block bound is not a string: %T", v)
+	}
+	return strconv.ParseUint(strings.TrimPrefix(s, "0x"), 16, 64)
+}
+
+// unraveledLog builds a valid 5-arg NameRegistered log for name "unraveled"
+// (owner 0x2C630b16…) emitted by the given contract. Payload mirrors the
+// getEnsRecord unit-test vectors.
+func unraveledLog(emitter string) rpcLogWithTxHash {
+	return rpcLogWithTxHash{
+		RpcLog: bchain.RpcLog{
+			Address: emitter,
+			Topics: []string{
+				nameRegisteredEventSignature,
+				"0x40ce2aa8cd9ee9fef4bf3a68abab7fbcceb6bac89370518caf6a602cefe836bd",
+				"0x0000000000000000000000002c630b16aa53ae0189880e15c23323688acb607c",
+			},
+			Data: "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000017629245f5a86f0000000000000000000000000000000000000000000000000000000069dbb21d0000000000000000000000000000000000000000000000000000000000000009756e726176656c65640000000000000000000000000000000000000000000000",
+		},
+	}
+}
+
+var unraveledRecord = bchain.AddressAliasRecord{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"}
+
+func Test_RebuildEnsAliases(t *testing.T) {
+	const (
+		trusted1  = "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5"
+		trusted2  = "0x253553366Da8546fC250F225fe3d25d0C782303b"
+		untrusted = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	)
+	mock := &mockEnsLogsRPC{
+		entries: []ensLogEntry{
+			{block: 100, log: unraveledLog(trusted1)},
+			{block: 200, log: unraveledLog(untrusted)},  // must be dropped by getEnsRecord
+			{block: 15000, log: unraveledLog(trusted2)}, // lands in a later chunk
+		},
+	}
+	b := &EthereumRPC{
+		RPC:     mock,
+		Timeout: time.Second,
+		ensRegistrars: ensRegistrarSet([]string{
+			"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5",
+			"0x253553366da8546fc250f225fe3d25d0c782303b",
+		}),
+	}
+	var got []bchain.AddressAliasRecord
+	store := func(r []bchain.AddressAliasRecord) error {
+		got = append(got, r...)
+		return nil
+	}
+	if err := b.RebuildEnsAliases(0, 20000, 1000, nil, store); err != nil {
+		t.Fatal(err)
+	}
+	want := []bchain.AddressAliasRecord{unraveledRecord, unraveledRecord}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("records = %+v, want %+v (untrusted emitter must be dropped)", got, want)
+	}
+	// [0,20000] stepped by 1000 = 21 chunks.
+	if mock.calls != 21 {
+		t.Errorf("eth_getLogs calls = %d, want 21", mock.calls)
+	}
+	// Filter must restrict emitters to the trusted set and OR the 3 topic0 sigs.
+	f := mock.lastFilters[0]
+	gotAddrs := append([]string(nil), f["address"].([]string)...)
+	sort.Strings(gotAddrs)
+	wantAddrs := []string{
+		"0x253553366da8546fc250f225fe3d25d0c782303b",
+		"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5",
+	}
+	if !reflect.DeepEqual(gotAddrs, wantAddrs) {
+		t.Errorf("filter address = %v, want %v", gotAddrs, wantAddrs)
+	}
+	topics, ok := f["topics"].([]interface{})
+	if !ok || len(topics) != 1 {
+		t.Fatalf("filter topics = %v, want a single-element slice", f["topics"])
+	}
+	if topic0, ok := topics[0].([]string); !ok || len(topic0) != 3 {
+		t.Errorf("filter topic0 = %v, want the 3 NameRegistered signatures", topics[0])
+	}
+}
+
+func Test_RebuildEnsAliases_EmptySetRecordsNothing(t *testing.T) {
+	mock := &mockEnsLogsRPC{entries: []ensLogEntry{{block: 100, log: unraveledLog("0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5")}}}
+	b := &EthereumRPC{RPC: mock, Timeout: time.Second, ensRegistrars: ensRegistrarSet(nil)}
+	var got []bchain.AddressAliasRecord
+	if err := b.RebuildEnsAliases(0, 1000, 1000, nil, func(r []bchain.AddressAliasRecord) error {
+		got = append(got, r...)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("records = %v, want none for an empty trusted set", got)
+	}
+	if mock.calls != 0 {
+		t.Errorf("eth_getLogs calls = %d, want 0 (no scan for trust-none)", mock.calls)
+	}
+}
+
+func Test_RebuildEnsAliases_WildcardScansAllEmitters(t *testing.T) {
+	untrusted := "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	mock := &mockEnsLogsRPC{entries: []ensLogEntry{{block: 5, log: unraveledLog(untrusted)}}}
+	b := &EthereumRPC{RPC: mock, Timeout: time.Second, ensRegistrars: ensRegistrarSet([]string{"*"})}
+	var got []bchain.AddressAliasRecord
+	if err := b.RebuildEnsAliases(0, 10, 100, nil, func(r []bchain.AddressAliasRecord) error {
+		got = append(got, r...)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []bchain.AddressAliasRecord{unraveledRecord}) {
+		t.Fatalf("records = %+v, want the wildcard to accept the untrusted emitter", got)
+	}
+	if _, restricted := mock.lastFilters[0]["address"]; restricted {
+		t.Error("wildcard filter must not restrict address")
+	}
+}
+
+func Test_RebuildEnsAliases_Interrupted(t *testing.T) {
+	mock := &mockEnsLogsRPC{entries: []ensLogEntry{{block: 5, log: unraveledLog("0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5")}}}
+	b := &EthereumRPC{RPC: mock, Timeout: time.Second, ensRegistrars: ensRegistrarSet([]string{"0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"})}
+	err := b.RebuildEnsAliases(0, 1000000, 1000, func() bool { return true }, func(r []bchain.AddressAliasRecord) error { return nil })
+	if err != ErrEnsRebuildInterrupted {
+		t.Fatalf("err = %v, want ErrEnsRebuildInterrupted", err)
+	}
+	if mock.calls != 0 {
+		t.Errorf("eth_getLogs calls = %d, want 0 (interrupted before first chunk)", mock.calls)
+	}
+}

--- a/blockbook.go
+++ b/blockbook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
@@ -294,10 +295,18 @@ func mainWithExitCode() int {
 	if *rebuildEnsAliases {
 		internalState.DbState = common.DbStateOpen
 		err = performEnsAliasRebuild(chanOsSignal)
-		if err != nil && err != db.ErrOperationInterrupted {
+		if err == db.ErrOperationInterrupted {
+			// The rebuild is atomic (nothing is committed until a full scan
+			// succeeds), so an interrupt leaves aliases unchanged — but exit
+			// non-zero so operators know it did not complete.
+			glog.Warning("rebuildEnsAliases: interrupted before completion — address aliases left UNCHANGED")
+			return exitCodeFatal
+		}
+		if err != nil {
 			glog.Error("rebuildEnsAliases: ", err)
 			return exitCodeFatal
 		}
+		glog.Info("rebuildEnsAliases: completed")
 		return exitCodeOK
 	}
 
@@ -544,6 +553,15 @@ func performRollback() error {
 // The scan defaults to the whole chain (block 0 to the backend tip) and can be
 // bounded with -blockheight/-blockuntil.
 func performEnsAliasRebuild(stop chan os.Signal) error {
+	rebuilder, ok := chain.(db.EnsAliasRebuilder)
+	if !ok {
+		return errors.New("rebuildEnsAliases: coin does not support ENS alias rebuild (EthereumType only)")
+	}
+	// -blockheight/-blockuntil are ints; reject values that would wrap on the
+	// uint32 cast below rather than silently scanning a wrong (small) range.
+	if int64(*blockFrom) > math.MaxUint32 || int64(*blockUntil) > math.MaxUint32 {
+		return errors.Errorf("rebuildEnsAliases: -blockheight/-blockuntil exceed max block height %d", math.MaxUint32)
+	}
 	bestHeight, err := chain.GetBestBlockHeight()
 	if err != nil {
 		return errors.Annotatef(err, "GetBestBlockHeight")
@@ -560,7 +578,7 @@ func performEnsAliasRebuild(stop chan os.Signal) error {
 		return errors.Errorf("rebuildEnsAliases: from block %d is above to block %d", from, to)
 	}
 	glog.Infof("rebuildEnsAliases: rebuilding ENS aliases for blocks [%d, %d]", from, to)
-	return index.RebuildEnsAliases(chain, from, to, *ensRebuildChunk, stop)
+	return index.RebuildEnsAliases(rebuilder, from, to, *ensRebuildChunk, stop)
 }
 
 func blockbookAppInfoMetric(db *db.RocksDB, chain bchain.BlockChain, txCache *db.TxCache, is *common.InternalState, metrics *common.Metrics) error {

--- a/blockbook.go
+++ b/blockbook.go
@@ -292,22 +292,40 @@ func mainWithExitCode() int {
 		return exitCodeOK
 	}
 
-	if *rebuildEnsAliases {
+	// Rebuild ENS address aliases when -rebuildensaliases is given, and self-heal
+	// at startup whenever the trusted registrar set changes (fingerprint mismatch)
+	// or on the first run after enabling it. Trust-none coins report an empty
+	// fingerprint and never auto-heal (never auto-wiped); the flag still forces a
+	// rebuild there. The auto path falls through and continues to serve; the
+	// explicit flag is a one-shot that exits.
+	ensFP := ensRegistrarsFingerprint(chain)
+	if *rebuildEnsAliases || (ensFP != "" && internalState.EnsRegistrarsFingerprint != ensFP) {
 		internalState.DbState = common.DbStateOpen
 		err = performEnsAliasRebuild(chanOsSignal)
 		if err == db.ErrOperationInterrupted {
 			// The rebuild is atomic (nothing is committed until a full scan
-			// succeeds), so an interrupt leaves aliases unchanged — but exit
-			// non-zero so operators know it did not complete.
+			// succeeds), so an interrupt leaves aliases unchanged and the
+			// fingerprint is left as-is, so the next start retries.
 			glog.Warning("rebuildEnsAliases: interrupted before completion — address aliases left UNCHANGED")
-			return exitCodeFatal
+			if *rebuildEnsAliases {
+				return exitCodeFatal // explicit one-shot: signal it did not complete
+			}
+			return exitCodeOK // auto self-heal during shutdown: clean stop, retries next boot
 		}
 		if err != nil {
 			glog.Error("rebuildEnsAliases: ", err)
 			return exitCodeFatal
 		}
+		internalState.EnsRegistrarsFingerprint = ensFP
+		if err = index.StoreInternalState(internalState); err != nil {
+			glog.Error("StoreInternalState: ", err)
+			return exitCodeFatal
+		}
 		glog.Info("rebuildEnsAliases: completed")
-		return exitCodeOK
+		if *rebuildEnsAliases {
+			return exitCodeOK // explicit flag: one-shot, exit
+		}
+		// auto self-heal: fall through and continue to normal startup
 	}
 
 	// Per-chain missing-block retry override, if any. Coin RPCs that opt in
@@ -552,6 +570,16 @@ func performRollback() error {
 // family from NameRegistered logs, an alias-only alternative to a full reindex.
 // The scan defaults to the whole chain (block 0 to the backend tip) and can be
 // bounded with -blockheight/-blockuntil.
+// ensRegistrarsFingerprint returns the chain's trusted ENS registrar fingerprint
+// (EthereumType coins), or "" for chains that don't expose one. A change in this
+// value across restarts drives the startup ENS alias self-heal.
+func ensRegistrarsFingerprint(chain bchain.BlockChain) string {
+	if p, ok := chain.(interface{ EnsRegistrarsFingerprint() string }); ok {
+		return p.EnsRegistrarsFingerprint()
+	}
+	return ""
+}
+
 func performEnsAliasRebuild(stop chan os.Signal) error {
 	rebuilder, ok := chain.(db.EnsAliasRebuilder)
 	if !ok {

--- a/blockbook.go
+++ b/blockbook.go
@@ -80,6 +80,9 @@ var (
 	computeFeeStatsFlag = flag.Bool("computefeestats", false, "compute fee stats for blocks in blockheight-blockuntil range and exit")
 	dbStatsPeriodHours  = flag.Int("dbstatsperiod", 24, "period of db stats collection in hours, 0 disables stats collection")
 
+	rebuildEnsAliases = flag.Bool("rebuildensaliases", false, "rebuild ENS address aliases from NameRegistered logs and exit (EthereumType coins only); optionally bounded by -blockheight/-blockuntil")
+	ensRebuildChunk   = flag.Int("ensrebuildchunk", 0, "block span per eth_getLogs request during -rebuildensaliases (0 = default); lower it for nodes that cap getLogs ranges")
+
 	// resync index at least each resyncIndexPeriodMs (could be more often if invoked by message from ZeroMQ)
 	resyncIndexPeriodMs = flag.Int("resyncindexperiod", 935093, "resync index period in milliseconds")
 
@@ -285,6 +288,16 @@ func mainWithExitCode() int {
 			return exitCodeFatal
 		}
 		glog.Info("DB size on disk: ", index.DatabaseSizeOnDisk(), ", DB size as computed: ", internalState.DBSizeTotal())
+		return exitCodeOK
+	}
+
+	if *rebuildEnsAliases {
+		internalState.DbState = common.DbStateOpen
+		err = performEnsAliasRebuild(chanOsSignal)
+		if err != nil && err != db.ErrOperationInterrupted {
+			glog.Error("rebuildEnsAliases: ", err)
+			return exitCodeFatal
+		}
 		return exitCodeOK
 	}
 
@@ -524,6 +537,30 @@ func performRollback() error {
 		}
 	}
 	return nil
+}
+
+// performEnsAliasRebuild wipes and re-derives the ENS address-alias column
+// family from NameRegistered logs, an alias-only alternative to a full reindex.
+// The scan defaults to the whole chain (block 0 to the backend tip) and can be
+// bounded with -blockheight/-blockuntil.
+func performEnsAliasRebuild(stop chan os.Signal) error {
+	bestHeight, err := chain.GetBestBlockHeight()
+	if err != nil {
+		return errors.Annotatef(err, "GetBestBlockHeight")
+	}
+	from := uint32(0)
+	if *blockFrom >= 0 {
+		from = uint32(*blockFrom)
+	}
+	to := bestHeight
+	if *blockUntil >= 0 && uint32(*blockUntil) < to {
+		to = uint32(*blockUntil)
+	}
+	if from > to {
+		return errors.Errorf("rebuildEnsAliases: from block %d is above to block %d", from, to)
+	}
+	glog.Infof("rebuildEnsAliases: rebuilding ENS aliases for blocks [%d, %d]", from, to)
+	return index.RebuildEnsAliases(chain, from, to, *ensRebuildChunk, stop)
 }
 
 func blockbookAppInfoMetric(db *db.RocksDB, chain bchain.BlockChain, txCache *db.TxCache, is *common.InternalState, metrics *common.Metrics) error {

--- a/common/internalstate.go
+++ b/common/internalstate.go
@@ -96,6 +96,10 @@ type InternalState struct {
 	// database migrations
 	UtxoChecked            bool `json:"utxoChecked" ts_doc:"Indicates if UTXO consistency checks have been performed."`
 	SortedAddressContracts bool `json:"sortedAddressContracts" ts_doc:"Indicates if address/contract sorting has been completed."`
+	// EnsRegistrarsFingerprint records the trusted ENS registrar set the address
+	// aliases were last rebuilt against; a mismatch at startup triggers a one-time
+	// self-heal (EthereumType coins). Empty until the first rebuild.
+	EnsRegistrarsFingerprint string `json:"ensRegistrarsFingerprint,omitempty" ts_doc:"Fingerprint of the trusted ENS registrar set the address aliases were last rebuilt against."`
 
 	// golomb filter settings
 	BlockGolombFilterP      uint8  `json:"block_golomb_filter_p" ts_doc:"Parameter P for building Golomb-Rice filters for blocks."`

--- a/configs/coins/bsc_archive.json
+++ b/configs/coins/bsc_archive.json
@@ -67,7 +67,6 @@
                     "maxStallMs": 60000
                 },
                 "address_aliases": true,
-                "ens_registrars": ["*"],
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura-disabled",
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/56/suggestedGasFees\", \"periodSeconds\": 60}",

--- a/configs/coins/bsc_archive.json
+++ b/configs/coins/bsc_archive.json
@@ -67,6 +67,7 @@
                     "maxStallMs": 60000
                 },
                 "address_aliases": true,
+                "ens_registrars": ["*"],
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura-disabled",
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/56/suggestedGasFees\", \"periodSeconds\": 60}",

--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -61,7 +61,7 @@
                 "averageBlockTimeMs": 12000,
                 "consensusNodeVersion": "http://localhost:7536/eth/v1/node/version",
                 "address_aliases": true,
-                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x253553366da8546fc250f225fe3d25d0c782303b", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"],
+                "ens_registrars": ["0xf0ad5cad05e10572efceb849f6ff0c68f9700455", "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x253553366da8546fc250f225fe3d25d0c782303b", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"],
                 "eip1559Fees": true,
                 "mempoolTxTimeoutHours": 48,
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -61,6 +61,7 @@
                 "averageBlockTimeMs": 12000,
                 "consensusNodeVersion": "http://localhost:7536/eth/v1/node/version",
                 "address_aliases": true,
+                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"],
                 "eip1559Fees": true,
                 "mempoolTxTimeoutHours": 48,
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -61,7 +61,7 @@
                 "averageBlockTimeMs": 12000,
                 "consensusNodeVersion": "http://localhost:7536/eth/v1/node/version",
                 "address_aliases": true,
-                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"],
+                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x253553366da8546fc250f225fe3d25d0c782303b", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"],
                 "eip1559Fees": true,
                 "mempoolTxTimeoutHours": 48,
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -68,6 +68,7 @@
                 },
                 "consensusNodeVersion": "http://localhost:7516/eth/v1/node/version",
                 "address_aliases": true,
+                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"],
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "1inch",
                 "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 10}",

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -68,7 +68,7 @@
                 },
                 "consensusNodeVersion": "http://localhost:7516/eth/v1/node/version",
                 "address_aliases": true,
-                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5"],
+                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x253553366da8546fc250f225fe3d25d0c782303b", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"],
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "1inch",
                 "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 10}",

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -68,7 +68,7 @@
                 },
                 "consensusNodeVersion": "http://localhost:7516/eth/v1/node/version",
                 "address_aliases": true,
-                "ens_registrars": ["0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x253553366da8546fc250f225fe3d25d0c782303b", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"],
+                "ens_registrars": ["0xf0ad5cad05e10572efceb849f6ff0c68f9700455", "0x283af0b28c62c092c9727f1ee09c02ca627eb7f5", "0x253553366da8546fc250f225fe3d25d0c782303b", "0x59e16fccd424cc24e280be16e11bcd56fb0ce547"],
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "1inch",
                 "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 10}",

--- a/contrib/scripts/ens-evidence/check_ens_aliases.py
+++ b/contrib/scripts/ens-evidence/check_ens_aliases.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""ENS address-alias regression evidence for Blockbook (Ethereum mainnet).
+
+Queries a running Blockbook's public API and asserts the *correct* (fixed) state
+for a curated set of on-chain cases. Run it BEFORE deploying the ENS-registrar
+fix (and running -rebuildensaliases) to capture evidence the current build is
+wrong, and AFTER to prove it is fixed.
+
+  - "missing"  : a real .eth registered via the current 7-arg ETHRegistrar
+                 controller (0x59e16fcc…), which the old 5-arg-only parser never
+                 recorded. Correct state: owner's alias == the name.
+  - "spoofed"  : an alias written by an untrusted look-alike emitter
+                 (0xeeb9b6bf…). Correct state: no such alias (purged).
+  - "legit"    : a real name via a trusted controller. Correct state: unchanged
+                 (proves the fix does not over-purge).
+
+Exit code 0 => all correct (fixed). Non-zero => at least one case wrong, and the
+failing rows ARE the evidence.
+
+Usage:
+  ./check_ens_aliases.py [--url https://eth.trezor.io] [--verbose]
+
+No third-party deps (stdlib only). The API path used is
+  /api/v2/address/<addr>?details=txs&pageSize=1
+whose `addressAliases[<addr>]` carries the queried address's own alias.
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+# Cases captured live against eth.trezor.io (gitCommit 2ede49f) on 2026-07-30.
+# kind: "missing" | "spoofed" | "legit"
+CASES = [
+    # Modern 7-arg controller registrations the old parser dropped.
+    {"kind": "missing", "addr": "0xd55b370335459e5e9dbd9d1c0a4fc5fa341a57b3", "name": "theprism.eth"},
+    {"kind": "missing", "addr": "0x9d56610c9fdabd06a19486ced80cccca00a2866a", "name": "rell.eth"},
+    {"kind": "missing", "addr": "0x29b65c53e48aba1c3692c66544b74ac60235c418", "name": "yasir.eth"},
+    {"kind": "missing", "addr": "0x174976a7bae6bf9abb80a7bd6896a78fbd17386d", "name": "cormaya.eth"},
+    {"kind": "missing", "addr": "0x6bae7f8c2d243cc08ae6ada73a4d728d5595f97b", "name": "samsrep.eth"},
+    {"kind": "missing", "addr": "0x172b3047ad0b5e88718f70258dd0ec1a423d075e", "name": "jesuschristisking.eth"},
+    # Spoofed alias from the untrusted emitter 0xeeb9b6bf5fb68fb726005f7ba549c2f4b32f2dad.
+    {"kind": "spoofed", "addr": "0x0031A2D5EA5B69bcb8e191f5F0aE7919e9c9f0dB", "name": "gizmoimaginarykitten.eth"},
+    # A well-known legit name via a trusted controller; must survive the rebuild.
+    {"kind": "legit", "addr": "0x287740B694CdA65642a3A1CD186C81287E93D802", "name": "liquidnetwork.eth"},
+]
+
+
+def _get_json(url, timeout=30, retries=6):
+    last = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as r:
+                return json.load(r)
+        except Exception as e:  # transient network hiccups: retry with backoff
+            last = e
+            time.sleep(1.0 * (attempt + 1))
+    raise last
+
+
+def alias_of(base, addr, timeout=30):
+    d = _get_json(f"{base}/api/v2/address/{addr}?details=txs&pageSize=1", timeout)
+    aliases = d.get("addressAliases", {}) or {}
+    for k, v in aliases.items():
+        if k.lower() == addr.lower():
+            return v.get("Alias", ""), v.get("Type", "")
+    return "", ""
+
+
+def backend_info(base, timeout=30):
+    try:
+        with urllib.request.urlopen(f"{base}/api/v2/api", timeout=timeout) as r:
+            bb = json.load(r).get("blockbook", {})
+        return f"{bb.get('coin')} v{bb.get('version')} @ {bb.get('gitCommit')} (bestHeight {bb.get('bestHeight')})"
+    except Exception as e:
+        return f"<could not read /api/v2/api: {e}>"
+
+
+def evaluate(kind, name, got_alias):
+    """Return (ok, expected_str). ok == True means the FIXED/correct state."""
+    if kind == "spoofed":
+        return (got_alias.lower() != name.lower(), f"absent (not {name})")
+    return (got_alias == name, name)  # missing + legit both expect the name
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="https://eth.trezor.io", help="Blockbook base URL")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+    base = args.url.rstrip("/")
+
+    print(f"Blockbook: {backend_info(base)}")
+    print(f"{'KIND':8} {'ADDRESS':44} {'EXPECTED':26} {'GOT':26} STATUS")
+    print("-" * 118)
+    failures = 0
+    for c in CASES:
+        try:
+            got, gtype = alias_of(base, c["addr"])
+        except Exception as e:
+            print(f"{c['kind']:8} {c['addr']:44} {'<request error>':26} {str(e)[:24]:26} ERROR")
+            failures += 1
+            continue
+        ok, expected = evaluate(c["kind"], c["name"], got)
+        status = "OK" if ok else "WRONG"
+        if not ok:
+            failures += 1
+        shown = got if got else "<none>"
+        print(f"{c['kind']:8} {c['addr']:44} {expected:26} {shown:26} {status}")
+
+    print("-" * 118)
+    total = len(CASES)
+    if failures:
+        print(f"RESULT: {failures}/{total} case(s) WRONG — this build's ENS aliases are incorrect.")
+        print("        (Run after deploying the fix + `-rebuildensaliases` to confirm all OK.)")
+        sys.exit(1)
+    print(f"RESULT: all {total} case(s) correct — ENS aliases are fixed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/db/address_alias_cache.go
+++ b/db/address_alias_cache.go
@@ -69,3 +69,15 @@ func (c *addressAliasLRU) add(key, value string) {
 	c.order.Remove(oldest)
 	delete(c.items, oldest.Value.(*addressAliasLRUEntry).key)
 }
+
+// purge drops every entry from the cache. Used after the address-alias column
+// family is wiped so stale formatted aliases are not served from memory.
+func (c *addressAliasLRU) purge() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.order.Init()
+	c.items = make(map[string]*list.Element, c.capacity)
+}

--- a/db/address_alias_rebuild_test.go
+++ b/db/address_alias_rebuild_test.go
@@ -8,42 +8,98 @@ import (
 	"github.com/trezor/blockbook/bchain"
 )
 
-// Test_deleteAllAddressAliases verifies that wiping the alias column family also
-// clears the in-memory cache, so a stale alias is not served after the wipe.
-func Test_deleteAllAddressAliases(t *testing.T) {
+// fakeEnsRebuilder is a minimal EnsAliasRebuilder for exercising the db-side
+// RebuildEnsAliases orchestration without a real EthereumRPC.
+type fakeEnsRebuilder struct {
+	records []bchain.AddressAliasRecord
+	called  bool
+}
+
+func (f *fakeEnsRebuilder) RebuildEnsAliases(_, _ uint32, _ int, _ func() bool, store func([]bchain.AddressAliasRecord) error) error {
+	f.called = true
+	return store(f.records)
+}
+
+// Test_replaceAddressAliases verifies the atomic swap: listed keys are written,
+// keys absent from the new set are dropped, and the in-memory cache is cleared.
+func Test_replaceAddressAliases(t *testing.T) {
 	d := setupRocksDB(t, &testEthereumParser{EthereumParser: ethereumTestnetParser()})
 	defer closeAndDestroyRocksDB(t, d)
 
-	records := []bchain.AddressAliasRecord{
-		{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
-		{Address: "0x1111111111111111111111111111111111111111", Name: "foo"},
-	}
-	if err := d.storeAddressAliasRecordsBatch(records); err != nil {
+	const (
+		keep  = "0x2C630b16Aa53ae0189880e15C23323688acb607c"
+		spoof = "0x1111111111111111111111111111111111111111"
+		fresh = "0x2222222222222222222222222222222222222222"
+	)
+	// Seed a "kept" and a "spoofed" alias, and prime the cache for both.
+	if err := d.replaceAddressAliases(map[string]string{keep: "old", spoof: "ransomware"}); err != nil {
 		t.Fatal(err)
 	}
-	// Reading through GetAddressAlias also seeds the LRU cache, so the wipe has to
-	// clear both the column family and the cache to return empty afterwards.
-	for _, r := range records {
-		if got := d.GetAddressAlias(r.Address); got == "" {
-			t.Fatalf("GetAddressAlias(%s) empty before wipe, expected a value", r.Address)
-		}
+	if got := d.GetAddressAlias(spoof); got == "" {
+		t.Fatalf("GetAddressAlias(spoof) empty before swap, expected a value")
 	}
-	if err := d.deleteAllAddressAliases(); err != nil {
+
+	// New set drops the spoofed key, updates keep, adds fresh.
+	if err := d.replaceAddressAliases(map[string]string{keep: "new", fresh: "vitalik"}); err != nil {
 		t.Fatal(err)
 	}
-	for _, r := range records {
-		if got := d.GetAddressAlias(r.Address); got != "" {
-			t.Errorf("GetAddressAlias(%s) = %q after wipe, want empty (CF + cache cleared)", r.Address, got)
-		}
+	if got := d.GetAddressAlias(spoof); got != "" {
+		t.Errorf("GetAddressAlias(spoof) = %q after swap, want empty (dropped + cache cleared)", got)
+	}
+	if got, want := d.GetAddressAlias(keep), d.chainParser.FormatAddressAlias(keep, "new"); got != want {
+		t.Errorf("GetAddressAlias(keep) = %q after swap, want %q", got, want)
+	}
+	if got, want := d.GetAddressAlias(fresh), d.chainParser.FormatAddressAlias(fresh, "vitalik"); got != want {
+		t.Errorf("GetAddressAlias(fresh) = %q after swap, want %q", got, want)
 	}
 }
 
-// Test_storeAddressAliasRecordsBatch_Empty verifies the batch writer is a no-op
-// for an empty slice (no write, no panic).
-func Test_storeAddressAliasRecordsBatch_Empty(t *testing.T) {
+// Test_RebuildEnsAliases_EmptyScanWipes documents the deliberate purge: running
+// the flag when the scan yields nothing (e.g. no ens_registrars) wipes the CF.
+func Test_RebuildEnsAliases_EmptyScanWipes(t *testing.T) {
 	d := setupRocksDB(t, &testEthereumParser{EthereumParser: ethereumTestnetParser()})
 	defer closeAndDestroyRocksDB(t, d)
-	if err := d.storeAddressAliasRecordsBatch(nil); err != nil {
+
+	const existing = "0x2C630b16Aa53ae0189880e15C23323688acb607c"
+	if err := d.replaceAddressAliases(map[string]string{existing: "legacy"}); err != nil {
 		t.Fatal(err)
+	}
+	f := &fakeEnsRebuilder{records: nil} // scan finds nothing (trust-none coin)
+	if err := d.RebuildEnsAliases(f, 0, 100, 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called {
+		t.Error("scan did not run")
+	}
+	if got := d.GetAddressAlias(existing); got != "" {
+		t.Errorf("GetAddressAlias(existing) = %q after empty rebuild, want empty (flag wipes)", got)
+	}
+}
+
+// Test_RebuildEnsAliases_Swaps verifies the full path: with registrars present,
+// the scanned set replaces the CF (old, unlisted aliases are purged).
+func Test_RebuildEnsAliases_Swaps(t *testing.T) {
+	d := setupRocksDB(t, &testEthereumParser{EthereumParser: ethereumTestnetParser()})
+	defer closeAndDestroyRocksDB(t, d)
+
+	const (
+		stale = "0x1111111111111111111111111111111111111111"
+		want  = "0x2C630b16Aa53ae0189880e15C23323688acb607c"
+	)
+	if err := d.replaceAddressAliases(map[string]string{stale: "spoofed"}); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeEnsRebuilder{records: []bchain.AddressAliasRecord{{Address: want, Name: "unraveled"}}}
+	if err := d.RebuildEnsAliases(f, 0, 100, 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called {
+		t.Error("scan did not run despite registrars present")
+	}
+	if got := d.GetAddressAlias(stale); got != "" {
+		t.Errorf("GetAddressAlias(stale) = %q, want empty (should be purged by swap)", got)
+	}
+	if got, wantAlias := d.GetAddressAlias(want), d.chainParser.FormatAddressAlias(want, "unraveled"); got != wantAlias {
+		t.Errorf("GetAddressAlias(want) = %q, want %q", got, wantAlias)
 	}
 }

--- a/db/address_alias_rebuild_test.go
+++ b/db/address_alias_rebuild_test.go
@@ -1,0 +1,49 @@
+//go:build unittest
+
+package db
+
+import (
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+// Test_deleteAllAddressAliases verifies that wiping the alias column family also
+// clears the in-memory cache, so a stale alias is not served after the wipe.
+func Test_deleteAllAddressAliases(t *testing.T) {
+	d := setupRocksDB(t, &testEthereumParser{EthereumParser: ethereumTestnetParser()})
+	defer closeAndDestroyRocksDB(t, d)
+
+	records := []bchain.AddressAliasRecord{
+		{Address: "0x2C630b16Aa53ae0189880e15C23323688acb607c", Name: "unraveled"},
+		{Address: "0x1111111111111111111111111111111111111111", Name: "foo"},
+	}
+	if err := d.storeAddressAliasRecordsBatch(records); err != nil {
+		t.Fatal(err)
+	}
+	// Reading through GetAddressAlias also seeds the LRU cache, so the wipe has to
+	// clear both the column family and the cache to return empty afterwards.
+	for _, r := range records {
+		if got := d.GetAddressAlias(r.Address); got == "" {
+			t.Fatalf("GetAddressAlias(%s) empty before wipe, expected a value", r.Address)
+		}
+	}
+	if err := d.deleteAllAddressAliases(); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range records {
+		if got := d.GetAddressAlias(r.Address); got != "" {
+			t.Errorf("GetAddressAlias(%s) = %q after wipe, want empty (CF + cache cleared)", r.Address, got)
+		}
+	}
+}
+
+// Test_storeAddressAliasRecordsBatch_Empty verifies the batch writer is a no-op
+// for an empty slice (no write, no panic).
+func Test_storeAddressAliasRecordsBatch_Empty(t *testing.T) {
+	d := setupRocksDB(t, &testEthereumParser{EthereumParser: ethereumTestnetParser()})
+	defer closeAndDestroyRocksDB(t, d)
+	if err := d.storeAddressAliasRecordsBatch(nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -1923,31 +1923,30 @@ func (d *RocksDB) storeAddressAliasRecords(wb *grocksdb.WriteBatch, records []bc
 	return nil
 }
 
-// deleteAllAddressAliases wipes the address-alias column family and clears the
-// in-memory alias cache. Used by the -rebuildensaliases maintenance path before
-// re-deriving aliases from NameRegistered logs. The column family is a pure
-// projection of those logs, so this loses no data that the rebuild cannot
-// reproduce (contract/token names live in a separate column family).
-func (d *RocksDB) deleteAllAddressAliases() error {
-	if err := d.db.DeleteRangeCF(d.wo, d.cfh[cfAddressAliases], []byte{0}, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}); err != nil {
+// replaceAddressAliases atomically swaps the entire address-alias column family
+// for the given set in a single write batch: a range delete followed by the puts,
+// so keys absent from the new set (e.g. spoofed aliases) drop out while the rest
+// are (re)written. Within one batch the puts are sequenced after the range
+// tombstone and therefore win, so readers see either the old set or the complete
+// new one, never an empty or partial CF. The alias cache is cleared afterward so
+// stale formatted aliases are not served. Used by the -rebuildensaliases path.
+//
+// The column family is a pure projection of NameRegistered logs, so this loses no
+// data the rebuild cannot reproduce (contract/token names live in a separate CF).
+func (d *RocksDB) replaceAddressAliases(aliases map[string]string) error {
+	wb := grocksdb.NewWriteBatch()
+	defer wb.Destroy()
+	wb.DeleteRangeCF(d.cfh[cfAddressAliases], []byte{0}, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	for addr, name := range aliases {
+		if len(name) > 0 {
+			wb.PutCF(d.cfh[cfAddressAliases], []byte(addr), []byte(name))
+		}
+	}
+	if err := d.db.Write(d.wo, wb); err != nil {
 		return err
 	}
 	cachedAddressAliasRecords.purge()
 	return nil
-}
-
-// storeAddressAliasRecordsBatch writes a batch of address-alias records in a
-// single RocksDB write. Used by the -rebuildensaliases maintenance path.
-func (d *RocksDB) storeAddressAliasRecordsBatch(records []bchain.AddressAliasRecord) error {
-	if len(records) == 0 {
-		return nil
-	}
-	wb := grocksdb.NewWriteBatch()
-	defer wb.Destroy()
-	if err := d.storeAddressAliasRecords(wb, records); err != nil {
-		return err
-	}
-	return d.db.Write(d.wo, wb)
 }
 
 // Disconnect blocks

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -1923,6 +1923,33 @@ func (d *RocksDB) storeAddressAliasRecords(wb *grocksdb.WriteBatch, records []bc
 	return nil
 }
 
+// deleteAllAddressAliases wipes the address-alias column family and clears the
+// in-memory alias cache. Used by the -rebuildensaliases maintenance path before
+// re-deriving aliases from NameRegistered logs. The column family is a pure
+// projection of those logs, so this loses no data that the rebuild cannot
+// reproduce (contract/token names live in a separate column family).
+func (d *RocksDB) deleteAllAddressAliases() error {
+	if err := d.db.DeleteRangeCF(d.wo, d.cfh[cfAddressAliases], []byte{0}, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}); err != nil {
+		return err
+	}
+	cachedAddressAliasRecords.purge()
+	return nil
+}
+
+// storeAddressAliasRecordsBatch writes a batch of address-alias records in a
+// single RocksDB write. Used by the -rebuildensaliases maintenance path.
+func (d *RocksDB) storeAddressAliasRecordsBatch(records []bchain.AddressAliasRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	wb := grocksdb.NewWriteBatch()
+	defer wb.Destroy()
+	if err := d.storeAddressAliasRecords(wb, records); err != nil {
+		return err
+	}
+	return d.db.Write(d.wo, wb)
+}
+
 // Disconnect blocks
 
 func (d *RocksDB) disconnectTxAddressesInputs(wb *grocksdb.WriteBatch, btxID []byte, inputs []outpoint, txa *TxAddresses, txAddressesToUpdate map[string]*TxAddresses,

--- a/db/rocksdb_ethereumtype.go
+++ b/db/rocksdb_ethereumtype.go
@@ -1954,30 +1954,29 @@ func (d *RocksDB) periodicStoreAddrContractsCache() {
 	}
 }
 
-// ensAliasRebuilder is implemented by EthereumType RPC backends that can rescan
+// EnsAliasRebuilder is implemented by EthereumType RPC backends that can rescan
 // ENS NameRegistered logs. It decouples RebuildEnsAliases from the concrete
 // EthereumRPC type so coins that embed it (e.g. BSC) qualify as well.
-type ensAliasRebuilder interface {
+type EnsAliasRebuilder interface {
 	RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks int, isInterrupted func() bool, store func([]bchain.AddressAliasRecord) error) error
 }
 
-// RebuildEnsAliases wipes the address-alias column family (purging aliases the
-// old accept-any parser wrote) and rebuilds it from the chain's NameRegistered
-// logs emitted by the trusted registrars, without a full reindex. It is a
-// one-shot maintenance operation backing the -rebuildensaliases flag and expects
-// to hold the DB exclusively; chain must be an EthereumType RPC. stop, if
-// non-nil, aborts the scan between chunks (returns ErrOperationInterrupted).
-func (d *RocksDB) RebuildEnsAliases(chain bchain.BlockChain, fromBlock, toBlock uint32, chunkBlocks int, stop chan os.Signal) error {
+// RebuildEnsAliases rebuilds the address-alias column family from the chain's
+// NameRegistered logs emitted by the trusted registrars, without a full reindex.
+// It is a one-shot maintenance operation backing the -rebuildensaliases flag and
+// expects to hold the DB exclusively.
+//
+// Running the flag intentionally replaces the whole CF: the freshly scanned set
+// is swapped in atomically (see replaceAddressAliases), purging spoofed aliases
+// the old accept-any parser wrote. When no ens_registrars are configured the scan
+// yields nothing and the CF is wiped — a deliberate purge, since the operator ran
+// the flag; the outcome is logged loudly. The swap is atomic, so a failed or
+// interrupted scan leaves the live CF untouched rather than half-wiped.
+//
+// stop, if non-nil, aborts the scan between chunks (returns ErrOperationInterrupted).
+func (d *RocksDB) RebuildEnsAliases(rebuilder EnsAliasRebuilder, fromBlock, toBlock uint32, chunkBlocks int, stop chan os.Signal) error {
 	if !d.chainParser.UseAddressAliases() {
 		return errors.New("RebuildEnsAliases: address_aliases is disabled for this coin")
-	}
-	rebuilder, ok := chain.(ensAliasRebuilder)
-	if !ok {
-		return errors.New("RebuildEnsAliases: coin does not support ENS alias rebuild")
-	}
-	glog.Info("RebuildEnsAliases: wiping existing address aliases")
-	if err := d.deleteAllAddressAliases(); err != nil {
-		return errors.Annotatef(err, "deleteAllAddressAliases")
 	}
 	interrupted := func() bool {
 		if stop == nil {
@@ -1990,9 +1989,29 @@ func (d *RocksDB) RebuildEnsAliases(chain bchain.BlockChain, fromBlock, toBlock 
 			return false
 		}
 	}
-	err := rebuilder.RebuildEnsAliases(fromBlock, toBlock, chunkBlocks, interrupted, d.storeAddressAliasRecordsBatch)
-	if err == eth.ErrEnsRebuildInterrupted {
-		return ErrOperationInterrupted
+	// Collect the whole new set before touching the CF, then swap atomically.
+	newAliases := make(map[string]string)
+	collect := func(records []bchain.AddressAliasRecord) error {
+		for i := range records {
+			if r := &records[i]; len(r.Name) > 0 {
+				newAliases[r.Address] = r.Name // ascending scan: last write wins
+			}
+		}
+		return nil
 	}
-	return err
+	if err := rebuilder.RebuildEnsAliases(fromBlock, toBlock, chunkBlocks, interrupted, collect); err != nil {
+		if err == eth.ErrEnsRebuildInterrupted {
+			return ErrOperationInterrupted
+		}
+		return err
+	}
+	if err := d.replaceAddressAliases(newAliases); err != nil {
+		return errors.Annotatef(err, "replaceAddressAliases")
+	}
+	if len(newAliases) == 0 {
+		glog.Warning("RebuildEnsAliases: scan produced no aliases (no ens_registrars or none matched); address aliases were WIPED")
+	} else {
+		glog.Infof("RebuildEnsAliases: replaced address aliases with %d records", len(newAliases))
+	}
+	return nil
 }

--- a/db/rocksdb_ethereumtype.go
+++ b/db/rocksdb_ethereumtype.go
@@ -1953,3 +1953,46 @@ func (d *RocksDB) periodicStoreAddrContractsCache() {
 		d.storeAddrContractsCache()
 	}
 }
+
+// ensAliasRebuilder is implemented by EthereumType RPC backends that can rescan
+// ENS NameRegistered logs. It decouples RebuildEnsAliases from the concrete
+// EthereumRPC type so coins that embed it (e.g. BSC) qualify as well.
+type ensAliasRebuilder interface {
+	RebuildEnsAliases(fromBlock, toBlock uint32, chunkBlocks int, isInterrupted func() bool, store func([]bchain.AddressAliasRecord) error) error
+}
+
+// RebuildEnsAliases wipes the address-alias column family (purging aliases the
+// old accept-any parser wrote) and rebuilds it from the chain's NameRegistered
+// logs emitted by the trusted registrars, without a full reindex. It is a
+// one-shot maintenance operation backing the -rebuildensaliases flag and expects
+// to hold the DB exclusively; chain must be an EthereumType RPC. stop, if
+// non-nil, aborts the scan between chunks (returns ErrOperationInterrupted).
+func (d *RocksDB) RebuildEnsAliases(chain bchain.BlockChain, fromBlock, toBlock uint32, chunkBlocks int, stop chan os.Signal) error {
+	if !d.chainParser.UseAddressAliases() {
+		return errors.New("RebuildEnsAliases: address_aliases is disabled for this coin")
+	}
+	rebuilder, ok := chain.(ensAliasRebuilder)
+	if !ok {
+		return errors.New("RebuildEnsAliases: coin does not support ENS alias rebuild")
+	}
+	glog.Info("RebuildEnsAliases: wiping existing address aliases")
+	if err := d.deleteAllAddressAliases(); err != nil {
+		return errors.Annotatef(err, "deleteAllAddressAliases")
+	}
+	interrupted := func() bool {
+		if stop == nil {
+			return false
+		}
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
+	err := rebuilder.RebuildEnsAliases(fromBlock, toBlock, chunkBlocks, interrupted, d.storeAddressAliasRecordsBatch)
+	if err == eth.ErrEnsRebuildInterrupted {
+		return ErrOperationInterrupted
+	}
+	return err
+}


### PR DESCRIPTION
## Summary

Makes ENS address-alias handling correct and comprehensive.

`getEnsRecord` recorded an alias from any `NameRegistered` event, matching only the event signature and never the emitting contract. Any contract that emitted a look-alike event — with `topics[2]` set to an arbitrary address — had its alias written to the DB and later served by the API and explorer as if it were a genuine ENS name, so the stored aliases were unreliable.

## Changes

- **Emitter allowlist** — `getEnsRecord` now only accepts events from contracts in a per-chain trusted set (new `ens_registrars` config key). Semantics are **trust-none by default**: absent/empty records nothing, an address list restricts to those emitters, and `"*"` accepts any (explicit opt-in). Ethereum pins all four ENS `ETHRegistrarController` addresses (2019, 2020, 6-arg, current 7-arg).
- **Full controller coverage** — match the original 5-arg `NameRegistered`, the 6-arg (baseCost + premium, `0x69e37f15…`) and the **current 7-arg** event (referrer, `0xc224…`) emitted by the live mainnet controller. The name is parsed via its ABI offset word, so all layouts work uniformly. Without the 7-arg match, every registration through the live controller was silently dropped.
- **Name validation** — decoded alias names are rejected if empty, over-long, non-UTF-8, or carry control characters, bidirectional overrides, invisible format characters (`Cf`, except ZWJ/ZWNJ), or line/paragraph separators, so a stored/displayed alias can't hide or misrepresent its true content.
- **Config validation** — malformed `ens_registrars` entries are logged and dropped so a typo doesn't silently disable a controller.
- **BSC `.bnb`** — the Space ID `.bnb` name service is non-functional in practice, so no new aliases are recorded (trust-none); the `.bnb` suffix is kept so any legacy records render with their original label rather than a misleading `.eth` one. `address_aliases` stays on (it also drives contract/token-name display).
- **Internal** — the trusted-emitter set lives on `EthereumRPC` (not the parser), keeping it out of the `EthereumLikeParser` interface.

## Client compatibility

The API response shape (`AddressAliasesMap` / `AddressAlias{Type, Alias}`) is **unchanged** — trezor-suite keeps receiving the same JSON; only which aliases are recorded changes.

## Operational notes / known limitations

- **Applies to newly synced data — refresh existing data with `-rebuildensaliases` (no full reindex needed).** The emitter allowlist gates parsing during sync and does not retroactively touch aliases the old accept-any code wrote. Because `cfAddressAliases` is a pure projection of `NameRegistered` logs (nothing else writes it; contract/token names live in a separate CF), the one-shot `-rebuildensaliases` flag rebuilds just that column family: it runs at startup holding the DB exclusively, wipes `cfAddressAliases` + the alias cache, then rescans `NameRegistered` logs from the trusted registrars via chunked `eth_getLogs` (filtered by `address` + the three `NameRegistered` topics) and re-derives aliases through the same `getEnsRecord` path used in sync. This both **purges** spoofed aliases the old code stored and **backfills** the modern 6-/7-arg registrations it never matched. Scans block 0 → backend tip by default (`-blockheight`/`-blockuntil` to bound); tune the per-request span with `-ensrebuildchunk` (default 100000) for nodes that cap `getLogs` ranges. A trust-none chain (empty `ens_registrars`, e.g. BSC) is wiped but records nothing. A full reindex is no longer required for alias correctness.
- **Non-mainnet chains index no ENS aliases** unless their `ens_registrars` is populated (e.g. Sepolia has a real ENS deployment but is intentionally left empty here). This is by design — `address_aliases` on those chains still serves contract/token names — so there is deliberately no startup warning for the `address_aliases && empty ens_registrars` combination, which is a valid "contract-names-only" configuration.
- **Alias name length is capped at 256 bytes.** Real ENS names are far shorter; a longer name (unconfirmed to exist on mainnet) would be dropped on a fresh sync.

## Testing

Unit tests cover the 5-/6-/7-arg event layouts, untrusted-emitter rejection, trust-none and wildcard sets, and the name-validation matrix (including invisible-character cases). `go build` + ENS tests pass; configs valid JSON; `gofmt` clean.

> Note: branch is based on `981d3d65` and is ~8 commits behind `master`; two touched files (`ethparser.go`, `ethrpc.go`) also changed in master's recent L2-fee work, so a rebase may be needed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

