### PR TITLE
fix(internal-server): protect against CSRF

### DIFF
--- a/server/internal.go
+++ b/server/internal.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -184,8 +185,46 @@ func (s *InternalServer) requireAdminAuth(next http.HandlerFunc) http.HandlerFun
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		// Browsers replay cached Basic credentials cross-origin, so reject
+		// state-changing requests forged by a page the admin visits (CSRF).
+		if isStateChangingMethod(r.Method) && !sameOrigin(r) {
+			http.Error(w, "cross-origin request forbidden", http.StatusForbidden)
+			return
+		}
 		next(w, r)
 	}
+}
+
+// isStateChangingMethod reports whether a method can mutate state and needs CSRF
+// protection; the safe GET/HEAD/OPTIONS methods only read and are exempt.
+func isStateChangingMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return false
+	}
+	return true
+}
+
+// sameOrigin reports whether a state-changing request is same-origin. Browsers
+// send Origin/Referer cross-origin; clients that send neither (curl) are allowed.
+func sameOrigin(r *http.Request) bool {
+	if origin := r.Header.Get("Origin"); origin != "" {
+		return originHostMatches(origin, r.Host)
+	}
+	if referer := r.Header.Get("Referer"); referer != "" {
+		return originHostMatches(referer, r.Host)
+	}
+	return true
+}
+
+// originHostMatches reports whether the Origin/Referer URL's host equals the
+// request Host. A malformed or opaque ("null") origin has no host and never matches.
+func originHostMatches(rawURL, host string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return u.Host == host
 }
 
 // validBasicAuth reports whether the request carries the configured admin Basic

--- a/server/internal.go
+++ b/server/internal.go
@@ -9,7 +9,6 @@ import (
 	"html/template"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -187,7 +186,11 @@ func (s *InternalServer) requireAdminAuth(next http.HandlerFunc) http.HandlerFun
 		}
 		// Browsers replay cached Basic credentials cross-origin, so reject
 		// state-changing requests forged by a page the admin visits (CSRF).
-		if isStateChangingMethod(r.Method) && !sameOrigin(r) {
+		if isStateChangingMethod(r.Method) && !s.sameOrigin(r) {
+			// Logged so a Host-rewriting reverse proxy (which makes the Origin
+			// mismatch r.Host) is diagnosable rather than a silent 403.
+			glog.Warningf("admin: rejected cross-origin %s %s (Origin=%q Referer=%q Host=%q, client %s)",
+				r.Method, r.URL.Path, r.Header.Get("Origin"), r.Header.Get("Referer"), r.Host, r.RemoteAddr)
 			http.Error(w, "cross-origin request forbidden", http.StatusForbidden)
 			return
 		}
@@ -207,24 +210,21 @@ func isStateChangingMethod(method string) bool {
 
 // sameOrigin reports whether a state-changing request is same-origin. Browsers
 // send Origin/Referer cross-origin; clients that send neither (curl) are allowed.
-func sameOrigin(r *http.Request) bool {
-	if origin := r.Header.Get("Origin"); origin != "" {
-		return originHostMatches(origin, r.Host)
+func (s *InternalServer) sameOrigin(r *http.Request) bool {
+	raw := r.Header.Get("Origin")
+	if raw == "" {
+		raw = r.Header.Get("Referer")
 	}
-	if referer := r.Header.Get("Referer"); referer != "" {
-		return originHostMatches(referer, r.Host)
+	if raw == "" {
+		return true
 	}
-	return true
-}
-
-// originHostMatches reports whether the Origin/Referer URL's host equals the
-// request Host. A malformed or opaque ("null") origin has no host and never matches.
-func originHostMatches(rawURL, host string) bool {
-	u, err := url.Parse(rawURL)
-	if err != nil || u.Host == "" {
+	scheme, host, ok := parseOrigin(raw)
+	if !ok || !strings.EqualFold(host, r.Host) {
 		return false
 	}
-	return u.Host == host
+	// When this server terminates TLS, a same-host request must also be https, so a
+	// plaintext page an on-path attacker serves on the port cannot forge to it.
+	return s.certFiles == "" || scheme == "https"
 }
 
 // validBasicAuth reports whether the request carries the configured admin Basic

--- a/server/internal_test.go
+++ b/server/internal_test.go
@@ -65,6 +65,61 @@ func TestRequireAdminAuth(t *testing.T) {
 	}
 }
 
+// TestRequireAdminAuthCSRF covers the same-origin gate on state-changing methods:
+// reject cross-origin browser mutations, allow same-origin and header-less clients.
+func TestRequireAdminAuthCSRF(t *testing.T) {
+	const user, pass = "admin", "s3cr3t-pass"
+	const host = "blockbook-internal:9130"
+	tests := []struct {
+		name       string
+		method     string
+		host       string
+		origin     string
+		referer    string
+		wantStatus int
+	}{
+		// Safe methods are never subject to the origin check.
+		{"GET cross-origin -> allowed", http.MethodGet, host, "http://evil.example", "", http.StatusOK},
+		{"HEAD cross-origin -> allowed", http.MethodHead, host, "http://evil.example", "", http.StatusOK},
+		// State-changing methods: same-origin passes, cross-origin is forbidden.
+		{"POST same-origin -> allowed", http.MethodPost, host, "http://" + host, "", http.StatusOK},
+		{"POST cross-origin -> forbidden", http.MethodPost, host, "http://evil.example", "", http.StatusForbidden},
+		{"PUT cross-origin -> forbidden", http.MethodPut, host, "https://evil.example", "", http.StatusForbidden},
+		{"DELETE cross-origin -> forbidden", http.MethodDelete, host, "http://evil.example", "", http.StatusForbidden},
+		// Opaque origin (sandboxed iframe / data: document) never matches.
+		{"POST null origin -> forbidden", http.MethodPost, host, "null", "", http.StatusForbidden},
+		// Origin is authoritative; a matching Origin passes even with a foreign Referer.
+		{"POST origin match beats foreign referer -> allowed", http.MethodPost, host, "http://" + host, "http://evil.example/x", http.StatusOK},
+		// Referer is the fallback only when Origin is absent.
+		{"POST referer same-origin, no origin -> allowed", http.MethodPost, host, "", "http://" + host + "/admin", http.StatusOK},
+		{"POST referer cross-origin, no origin -> forbidden", http.MethodPost, host, "", "http://evil.example/x", http.StatusForbidden},
+		// Non-browser client: neither header present -> allowed (curl/automation).
+		{"POST no origin/referer -> allowed", http.MethodPost, host, "", "", http.StatusOK},
+		// A garbage Origin does not parse to our host -> forbidden.
+		{"POST unparsable origin -> forbidden", http.MethodPost, host, "://::::", "", http.StatusForbidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newAdminServer(user, pass)
+			h := s.requireAdminAuth(okHandler)
+			r := httptest.NewRequest(tt.method, "/admin/runtime-settings/ALLOWED_RPC_CALL_TO", nil)
+			r.Host = tt.host
+			r.SetBasicAuth(user, pass)
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			if tt.referer != "" {
+				r.Header.Set("Referer", tt.referer)
+			}
+			w := httptest.NewRecorder()
+			h(w, r)
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
 func Test_urlPathSegment(t *testing.T) {
 	tests := []struct {
 		path string

--- a/server/internal_test.go
+++ b/server/internal_test.go
@@ -5,6 +5,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -73,34 +74,45 @@ func TestRequireAdminAuthCSRF(t *testing.T) {
 	tests := []struct {
 		name       string
 		method     string
+		tls        bool
 		host       string
 		origin     string
 		referer    string
 		wantStatus int
 	}{
 		// Safe methods are never subject to the origin check.
-		{"GET cross-origin -> allowed", http.MethodGet, host, "http://evil.example", "", http.StatusOK},
-		{"HEAD cross-origin -> allowed", http.MethodHead, host, "http://evil.example", "", http.StatusOK},
+		{"GET cross-origin -> allowed", http.MethodGet, false, host, "http://evil.example", "", http.StatusOK},
+		{"HEAD cross-origin -> allowed", http.MethodHead, false, host, "http://evil.example", "", http.StatusOK},
 		// State-changing methods: same-origin passes, cross-origin is forbidden.
-		{"POST same-origin -> allowed", http.MethodPost, host, "http://" + host, "", http.StatusOK},
-		{"POST cross-origin -> forbidden", http.MethodPost, host, "http://evil.example", "", http.StatusForbidden},
-		{"PUT cross-origin -> forbidden", http.MethodPut, host, "https://evil.example", "", http.StatusForbidden},
-		{"DELETE cross-origin -> forbidden", http.MethodDelete, host, "http://evil.example", "", http.StatusForbidden},
+		{"POST same-origin -> allowed", http.MethodPost, false, host, "http://" + host, "", http.StatusOK},
+		{"POST cross-origin -> forbidden", http.MethodPost, false, host, "http://evil.example", "", http.StatusForbidden},
+		{"PUT cross-origin -> forbidden", http.MethodPut, false, host, "https://evil.example", "", http.StatusForbidden},
+		{"DELETE cross-origin -> forbidden", http.MethodDelete, false, host, "http://evil.example", "", http.StatusForbidden},
+		// Host comparison is case-insensitive.
+		{"POST same-origin host case-insensitive -> allowed", http.MethodPost, false, host, "http://" + strings.ToUpper(host), "", http.StatusOK},
 		// Opaque origin (sandboxed iframe / data: document) never matches.
-		{"POST null origin -> forbidden", http.MethodPost, host, "null", "", http.StatusForbidden},
+		{"POST null origin -> forbidden", http.MethodPost, false, host, "null", "", http.StatusForbidden},
 		// Origin is authoritative; a matching Origin passes even with a foreign Referer.
-		{"POST origin match beats foreign referer -> allowed", http.MethodPost, host, "http://" + host, "http://evil.example/x", http.StatusOK},
+		{"POST origin match beats foreign referer -> allowed", http.MethodPost, false, host, "http://" + host, "http://evil.example/x", http.StatusOK},
 		// Referer is the fallback only when Origin is absent.
-		{"POST referer same-origin, no origin -> allowed", http.MethodPost, host, "", "http://" + host + "/admin", http.StatusOK},
-		{"POST referer cross-origin, no origin -> forbidden", http.MethodPost, host, "", "http://evil.example/x", http.StatusForbidden},
+		{"POST referer same-origin, no origin -> allowed", http.MethodPost, false, host, "", "http://" + host + "/admin", http.StatusOK},
+		{"POST referer cross-origin, no origin -> forbidden", http.MethodPost, false, host, "", "http://evil.example/x", http.StatusForbidden},
 		// Non-browser client: neither header present -> allowed (curl/automation).
-		{"POST no origin/referer -> allowed", http.MethodPost, host, "", "", http.StatusOK},
+		{"POST no origin/referer -> allowed", http.MethodPost, false, host, "", "", http.StatusOK},
 		// A garbage Origin does not parse to our host -> forbidden.
-		{"POST unparsable origin -> forbidden", http.MethodPost, host, "://::::", "", http.StatusForbidden},
+		{"POST unparsable origin -> forbidden", http.MethodPost, false, host, "://::::", "", http.StatusForbidden},
+		// TLS server: a plaintext (downgraded) same-host Origin is an on-path MITM vector.
+		{"POST http origin to TLS server -> forbidden", http.MethodPost, true, host, "http://" + host, "", http.StatusForbidden},
+		{"POST https origin to TLS server -> allowed", http.MethodPost, true, host, "https://" + host, "", http.StatusOK},
+		// Plaintext server behind a TLS-terminating proxy: an https Origin still passes.
+		{"POST https origin to plaintext server -> allowed", http.MethodPost, false, host, "https://" + host, "", http.StatusOK},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := newAdminServer(user, pass)
+			if tt.tls {
+				s.certFiles = "testcert"
+			}
 			h := s.requireAdminAuth(okHandler)
 			r := httptest.NewRequest(tt.method, "/admin/runtime-settings/ALLOWED_RPC_CALL_TO", nil)
 			r.Host = tt.host

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -272,12 +272,22 @@ func (s *WebsocketServer) checkOrigin(r *http.Request) bool {
 	return ok
 }
 
-func normalizeOrigin(origin string) (string, bool) {
-	u, err := url.Parse(origin)
+// parseOrigin parses an Origin/Referer URL into its lowercased scheme and host,
+// rejecting malformed values and the opaque "null" origin (ok=false).
+func parseOrigin(raw string) (scheme, host string, ok bool) {
+	u, err := url.Parse(raw)
 	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", "", false
+	}
+	return strings.ToLower(u.Scheme), strings.ToLower(u.Host), true
+}
+
+func normalizeOrigin(origin string) (string, bool) {
+	scheme, host, ok := parseOrigin(origin)
+	if !ok {
 		return "", false
 	}
-	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host), true
+	return scheme + "://" + host, true
 }
 
 func getWebsocketPayloadPreview(d []byte) string {


### PR DESCRIPTION
## What

Adds CSRF protection to the internal server's state-changing `/admin` endpoints.

The `/admin` surface is gated by HTTP Basic auth, which authenticates the operator but does not defend against CSRF: browsers replay cached Basic credentials on cross-origin requests, so a malicious page an authenticated admin visits could drive forged `POST`/`PUT`/`DELETE` requests against the internal port (runtime-settings changes, contract-info forgery, anti-abuse state resets).

## How

A same-origin check in `requireAdminAuth`, so it covers every admin endpoint (JSON and form) in one place:

- State-changing methods (`POST`/`PUT`/`DELETE`/`PATCH`) are rejected with `403` when the `Origin` header — or, absent that, `Referer` — names a host different from the request's `Host`. Opaque (`null`) and unparsable origins never match.
- Safe methods (`GET`/`HEAD`/`OPTIONS`) are exempt.
- Requests with neither `Origin` nor `Referer` are allowed, so scripted clients (`curl`, automation) keep working — a browser cannot be made to omit `Origin` on a cross-origin mutation, so this does not reopen the hole.

## Tests

`TestRequireAdminAuthCSRF` covers safe-method exemption, same-origin pass, cross-origin/`null`/unparsable rejection, Origin-over-Referer precedence, the Referer fallback, and the header-less automation case.
