### PR TITLE
feat(eth): poll alternative fee providers eagerly (10s) with a configurable stale window

### DIFF
--- a/bchain/coins/eth/alternativefeeprovider.go
+++ b/bchain/coins/eth/alternativefeeprovider.go
@@ -1,12 +1,32 @@
 package eth
 
 import (
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/common"
 )
+
+// feeProviderParams is the shared config for the EVM alternative fee providers
+// (Infura and 1inch). The two were field-for-field identical and had already
+// drifted once, so they share one struct to keep parsing and validation in sync.
+type feeProviderParams struct {
+	URL           string `json:"url"`
+	PeriodSeconds int    `json:"periodSeconds"`
+	// StaleSeconds is how long a cached estimate stays usable after the last
+	// successful refresh before it is considered stale (falls back to node
+	// estimation). It is independent of the poll cadence. Optional; defaults to
+	// defaultFeeStaleSeconds when unset.
+	StaleSeconds int `json:"staleSeconds"`
+}
+
+// feeHTTPClient is shared by the fee pollers. The timeout bounds each poll well
+// under the poll cadence so a blackholed connection (accepted, headers never
+// sent) can't block the single poller goroutine forever and silently freeze
+// fee refreshes; http.DefaultClient has no timeout.
+var feeHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 type alternativeFeeProvider struct {
 	eip1559Fees       *bchain.Eip1559Fees
@@ -42,10 +62,37 @@ type alternativeFeeProviderInterface interface {
 	GetEip1559Fees() (*bchain.Eip1559Fees, error)
 }
 
+// defaultFeeStaleSeconds is the cached-estimate stale window (10 minutes) used
+// by the EVM alternative fee providers when the config omits "staleSeconds".
+const defaultFeeStaleSeconds = 600
+
+// feeStaleDuration returns the stale window for cached estimates: the configured
+// staleSeconds (falling back to the 10-minute default when unset or non-positive),
+// clamped up to periodSeconds. The clamp guarantees the window can never be
+// shorter than the poll cadence — otherwise a config like {periodSeconds:60,
+// staleSeconds:30} would flap provider→node once per poll on a healthy provider,
+// a trap the old periodSeconds*30 formula made structurally impossible.
+func feeStaleDuration(periodSeconds, staleSeconds int) time.Duration {
+	if staleSeconds <= 0 {
+		staleSeconds = defaultFeeStaleSeconds
+	}
+	if staleSeconds < periodSeconds {
+		staleSeconds = periodSeconds
+	}
+	return time.Duration(staleSeconds) * time.Second
+}
+
 func (p *alternativeFeeProvider) GetEip1559Fees() (*bchain.Eip1559Fees, error) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
-	if p.lastSync.Add(p.staleSyncDuration).Before(time.Now()) {
+	// Treat an unset staleSyncDuration as the default rather than 0, so a future
+	// provider that forgets to initialize it degrades to the 10-minute window
+	// instead of a silent no-op (lastSync.Add(0) is always in the past).
+	stale := p.staleSyncDuration
+	if stale <= 0 {
+		stale = defaultFeeStaleSeconds * time.Second
+	}
+	if p.lastSync.Add(stale).Before(time.Now()) {
 		return nil, nil
 	}
 	return p.eip1559Fees, nil

--- a/bchain/coins/eth/alternativefeeprovider_test.go
+++ b/bchain/coins/eth/alternativefeeprovider_test.go
@@ -7,8 +7,8 @@ import "testing"
 // var is missing, initialization fails fast instead of silently reverting to
 // default fee estimation. An unset provider stays a no-op.
 func TestInitAlternativeFeeProviderFailFast(t *testing.T) {
-	const infuraParams = `{"url":"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees","periodSeconds":60}`
-	const oneInchParams = `{"url":"https://api.1inch.dev/gas-price/v1.5/1","periodSeconds":60}`
+	const infuraParams = `{"url":"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees","periodSeconds":10}`
+	const oneInchParams = `{"url":"https://api.1inch.dev/gas-price/v1.5/1","periodSeconds":10}`
 
 	tests := []struct {
 		name        string

--- a/bchain/coins/eth/infurafees.go
+++ b/bchain/coins/eth/infurafees.go
@@ -75,18 +75,11 @@ type infuraFeesResult struct {
 	BaseFeeTrend               string          `json:"baseFeeTrend"`
 }
 
-type infuraFeeParams struct {
-	URL           string `json:"url"`
-	PeriodSeconds int    `json:"periodSeconds"`
-}
-
 type infuraFeeProvider struct {
 	*alternativeFeeProvider
-	params infuraFeeParams
+	params feeProviderParams
 	apiKey string
 }
-
-const infuraFeeStalePeriods = 30
 
 // NewInfuraFeesProvider initializes https://gas.api.infura.io provider
 func NewInfuraFeesProvider(chain bchain.BlockChain, params string, metrics *common.Metrics) (alternativeFeeProviderInterface, error) {
@@ -104,15 +97,11 @@ func NewInfuraFeesProvider(chain bchain.BlockChain, params string, metrics *comm
 	}
 	p.params.URL = strings.Replace(p.params.URL, "${api_key}", p.apiKey, -1)
 	p.chain = chain
-	// Keep cached Infura fees through throttling bursts.
-	// Current archive configs poll every 60s, which gives a 30-minute window.
-	p.staleSyncDuration = infuraFeeStaleDuration(p.params.PeriodSeconds)
+	// Keep cached Infura fees through throttling bursts for the configured stale
+	// window (defaults to 10 minutes), independent of the poll cadence.
+	p.staleSyncDuration = feeStaleDuration(p.params.PeriodSeconds, p.params.StaleSeconds)
 	go p.FeeDownloader()
 	return p, nil
-}
-
-func infuraFeeStaleDuration(periodSeconds int) time.Duration {
-	return time.Duration(periodSeconds*infuraFeeStalePeriods) * time.Second
 }
 
 func (p *infuraFeeProvider) FeeDownloader() {
@@ -185,7 +174,7 @@ func (p *infuraFeeProvider) getData(res interface{}) error {
 		return err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpRes, err := http.DefaultClient.Do(httpReq)
+	httpRes, err := feeHTTPClient.Do(httpReq)
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}

--- a/bchain/coins/eth/infurafees_test.go
+++ b/bchain/coins/eth/infurafees_test.go
@@ -5,18 +5,34 @@ import (
 	"time"
 )
 
-func TestInfuraFeeStaleDuration(t *testing.T) {
-	got := infuraFeeStaleDuration(60)
-	want := 30 * time.Minute
+func TestFeeStaleDurationDefaultsToTenMinutes(t *testing.T) {
+	got := feeStaleDuration(10, 0)
+	want := 10 * time.Minute
 	if got != want {
-		t.Fatalf("infuraFeeStaleDuration(60) = %s, want %s", got, want)
+		t.Fatalf("feeStaleDuration(10, 0) = %s, want %s", got, want)
+	}
+}
+
+func TestFeeStaleDurationHonorsConfig(t *testing.T) {
+	got := feeStaleDuration(10, 90)
+	want := 90 * time.Second
+	if got != want {
+		t.Fatalf("feeStaleDuration(10, 90) = %s, want %s", got, want)
+	}
+}
+
+func TestFeeStaleDurationClampsToPeriod(t *testing.T) {
+	got := feeStaleDuration(60, 30)
+	want := 60 * time.Second
+	if got != want {
+		t.Fatalf("feeStaleDuration(60, 30) = %s, want %s (must not be shorter than the poll period)", got, want)
 	}
 }
 
 func TestInfuraFeeProviderUsesCachedFeesDuringStaleWindow(t *testing.T) {
 	provider := &infuraFeeProvider{
 		alternativeFeeProvider: &alternativeFeeProvider{
-			staleSyncDuration: infuraFeeStaleDuration(60),
+			staleSyncDuration: feeStaleDuration(10, 0),
 		},
 	}
 
@@ -37,7 +53,7 @@ func TestInfuraFeeProviderUsesCachedFeesDuringStaleWindow(t *testing.T) {
 	})
 
 	provider.mux.Lock()
-	provider.lastSync = time.Now().Add(-29 * time.Minute)
+	provider.lastSync = time.Now().Add(-9 * time.Minute)
 	provider.mux.Unlock()
 
 	fees, err := provider.GetEip1559Fees()
@@ -49,7 +65,7 @@ func TestInfuraFeeProviderUsesCachedFeesDuringStaleWindow(t *testing.T) {
 	}
 
 	provider.mux.Lock()
-	provider.lastSync = time.Now().Add(-31 * time.Minute)
+	provider.lastSync = time.Now().Add(-11 * time.Minute)
 	provider.mux.Unlock()
 
 	fees, err = provider.GetEip1559Fees()

--- a/bchain/coins/eth/oneinchfees.go
+++ b/bchain/coins/eth/oneinchfees.go
@@ -49,21 +49,10 @@ type oneInchFeeFeesResult struct {
 	Instant oneInchFeeFeeResult `json:"instant"`
 }
 
-type oneInchFeeParams struct {
-	URL           string `json:"url"`
-	PeriodSeconds int    `json:"periodSeconds"`
-}
-
 type oneInchFeeProvider struct {
 	*alternativeFeeProvider
-	params oneInchFeeParams
+	params feeProviderParams
 	apiKey string
-}
-
-const oneInchFeeStalePeriods = 30
-
-func oneInchFeeStaleDuration(periodSeconds int) time.Duration {
-	return time.Duration(periodSeconds*oneInchFeeStalePeriods) * time.Second
 }
 
 // NewOneInchFeesProvider initializes https://api.1inch.dev provider
@@ -73,7 +62,7 @@ func NewOneInchFeesProvider(chain bchain.BlockChain, params string, metrics *com
 	if err != nil {
 		return nil, err
 	}
-	if p.params.URL == "" || p.params.PeriodSeconds == 0 {
+	if p.params.URL == "" || p.params.PeriodSeconds <= 0 {
 		return nil, errors.New("NewOneInchFeesProvider: missing config parameters 'url' or 'periodSeconds'.")
 	}
 	p.apiKey = os.Getenv("ONE_INCH_API_KEY")
@@ -81,7 +70,7 @@ func NewOneInchFeesProvider(chain bchain.BlockChain, params string, metrics *com
 		return nil, errors.New("NewOneInchFeesProvider: missing ONE_INCH_API_KEY env variable.")
 	}
 	p.chain = chain
-	p.staleSyncDuration = oneInchFeeStaleDuration(p.params.PeriodSeconds)
+	p.staleSyncDuration = feeStaleDuration(p.params.PeriodSeconds, p.params.StaleSeconds)
 	go p.FeeDownloader()
 	return p, nil
 }
@@ -142,7 +131,7 @@ func (p *oneInchFeeProvider) getData(res interface{}) error {
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", " Bearer "+p.apiKey)
-	httpRes, err := http.DefaultClient.Do(httpReq)
+	httpRes, err := feeHTTPClient.Do(httpReq)
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}

--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -62,7 +62,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/avalanche.json
+++ b/configs/coins/avalanche.json
@@ -58,7 +58,7 @@
                 "averageBlockTimeMs": 2000,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 12,
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",

--- a/configs/coins/avalanche_archive.json
+++ b/configs/coins/avalanche_archive.json
@@ -66,7 +66,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -64,7 +64,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -70,7 +70,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "1inch",
-                "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 48,
                 "processInternalTransactions": true,
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -64,7 +64,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/polygon_archive.json
+++ b/configs/coins/polygon_archive.json
@@ -69,7 +69,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/137/suggestedGasFees\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/137/suggestedGasFees\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -726,14 +726,14 @@ panels:
         legend: balance point (50%)
   fees.alt_fee_provider_cache_age:
     title: Alternative fee provider cache age
-    description: 'Age of the cached provider fees (time() - last successful refresh), per provider. The pull path keeps serving the cache until it crosses the provider''s stale window, after which estimateFee falls back to on-chain (visible as onchain_fallback in the fee-source panel). Both Infura and 1inch use a 30x stale window (e.g. 30 minutes for a 60s poll); the dashed line marks this default cutoff, so adjust it if a coin polls with a different period. A sawtooth that resets each poll is healthy; a line climbing past the cutoff is a wedged provider.'
+    description: 'Age of the cached provider fees (time() - last successful refresh), per provider. The pull path keeps serving the cache until it crosses the provider''s stale window, after which estimateFee falls back to on-chain (visible as onchain_fallback in the fee-source panel). Both Infura and 1inch use a default stale window of 600s (10 minutes), configurable per coin via staleSeconds and independent of the poll cadence; the dashed line marks this default cutoff, so adjust it if a coin sets a different staleSeconds. A sawtooth that resets each poll is healthy; a line climbing past the cutoff is a wedged provider.'
     queries:
       age:
         promql: (time() - {{name:alternative_fee_provider_last_sync_timestamp_seconds}}{job="blockbook", coin="$coin"})
         legend: '{{coin}} - {{instance}} - {{provider}}'
       cutoff:
-        promql: vector(1800)
-        legend: default stale cutoff (30x 60s = 30m)
+        promql: vector(600)
+        legend: default stale cutoff (600s = 10m)
   fees.eip1559_fee_source:
     title: EIP-1559 fee source (served estimates/s)
     description: 'Where each served estimate came from, at the serve boundary: provider = alternative provider (Infura/1inch) cache hit; onchain_fallback = provider configured but its cache was stale/unready, so eth_feeHistory was used; onchain = no provider configured. Healthy state is provider dominating on provider-backed coins; a burst of onchain_fallback at startup is cold-cache warmup, not an incident (the cache-age panel disambiguates). Sustained onchain_fallback means the provider is wedged.'

--- a/configs/metrics.yaml
+++ b/configs/metrics.yaml
@@ -381,7 +381,7 @@ metrics:
   alternative_fee_provider_last_sync_timestamp_seconds:
     name: blockbook_alternative_fee_provider_last_sync_timestamp_seconds
     type: gauge_vec
-    help: Unix time of the last successful refresh of the cached EVM alternative-provider fees, labeled by provider (infura or 1inch). Plot time() - this for cache age; the pull path falls back to on-chain once the cache is older than the provider's stale window (for infura, 30x the poll period, e.g. 30m at a 60s poll). Exported as a timestamp rather than a computed *_age_seconds gauge on purpose - it is only written on a successful refresh, so age keeps rising when a provider wedges and it is restart-safe
+    help: Unix time of the last successful refresh of the cached EVM alternative-provider fees, labeled by provider (infura or 1inch). Plot time() - this for cache age; the pull path falls back to on-chain once the cache is older than the provider's stale window (default 600s / 10m, configurable per coin via staleSeconds, independent of the poll period). Exported as a timestamp rather than a computed *_age_seconds gauge on purpose - it is only written on a successful refresh, so age keeps rising when a provider wedges and it is restart-safe
     labels: [provider]
   eth_eip1559_fee:
     name: blockbook_eth_eip1559_fee

--- a/docs/config.md
+++ b/docs/config.md
@@ -101,10 +101,10 @@ Good examples of coin configuration are
         * `block_addresses_to_keep` – Number of blocks that are to be kept in blockaddresses column.
         * `additional_params` – Object of coin-specific params.
           * Tron-specific endpoint configuration is documented in [Tron Config](/docs/tron-config.md).
-          * Infura alternative EIP-1559 fee provider configuration:
-            * `alternative_estimate_fee` – Set to `infura` to use Infura Gas API fee suggestions instead of native node fee estimation.
-            * `alternative_estimate_fee_params` – JSON string with `url` and `periodSeconds`. `periodSeconds` controls how often Blockbook polls Infura.
-              Cached Infura fees remain usable for 30 failed polling periods, so `periodSeconds: 60` keeps the last successful fees for up to 30 minutes before native fallback.
+          * Alternative EIP-1559 fee provider configuration:
+            * `alternative_estimate_fee` – Set to `infura` (Infura Gas API, requires `INFURA_API_KEY`) or `1inch` (1inch gas-price API, requires `ONE_INCH_API_KEY`) to use provider fee suggestions instead of native node fee estimation. Startup fails fast if the selected provider's API-key env var is missing.
+            * `alternative_estimate_fee_params` – JSON string with `url`, `periodSeconds` and optional `staleSeconds`. `periodSeconds` controls how often Blockbook polls the provider.
+              `staleSeconds` is how long the last successfully fetched fees stay usable before native fallback, independent of the poll cadence; it defaults to 600 (10 minutes) when omitted and is clamped up to `periodSeconds` so the window is never shorter than the poll cadence.
           * Ethereum mempool timeout configuration:
             * `mempoolTxTimeoutHours` – Legacy Blockbook-side EVM mempool retention in whole hours. It is used when `mempoolTxTimeout` is not set and no alternative send transaction provider is enabled.
             * `mempoolTxTimeout` – Optional Blockbook-side EVM mempool retention as a Go duration string such as `"10m"`; `"0s"` preserves the legacy zero-retention setting. If omitted and an alternative send transaction provider is enabled, Blockbook uses **10 minutes** instead of the legacy hour-based value.

--- a/docs/env.md
+++ b/docs/env.md
@@ -73,7 +73,9 @@ Blockbook reads these from its process environment. When installed from the Debi
 
 -   `<coin shortcut>_STAKING_POOL_CONTRACT` - The pool name and contract used for Ethereum staking. The format of the variable is `<pool name>/<pool contract>`. If missing, staking support is disabled.
 
--   `INFURA_API_KEY` - API key for the Infura alternative EIP-1559 fee provider. Archive EVM configs using Infura poll once per minute and keep serving the last successful fee data for up to 30 failed polls before falling back to native fee estimation.
+-   `INFURA_API_KEY` - API key for the Infura alternative EIP-1559 fee provider. Archive EVM configs using Infura poll every `periodSeconds` (a required config value; the shipped archive configs set it to 10s) and keep serving the last successful fee data for the configured `staleSeconds` stale window (default 600s / 10 minutes) before falling back to native fee estimation.
+
+-   `ONE_INCH_API_KEY` - API key for the 1inch alternative EIP-1559 fee provider (used by `ethereum_archive`). Required at startup when a config selects `alternative_estimate_fee: 1inch`; the provider polls and caches fees on the same `periodSeconds`/`staleSeconds` schedule as Infura.
 
 -   `COINGECKO_API_KEY`, `<network>_COINGECKO_API_KEY`, or `<coin shortcut>_COINGECKO_API_KEY` - API key for making requests to CoinGecko in the paid tier.
     If any of these variables is set, it must be non-empty (empty value is treated as a configuration error and Blockbook fails on startup).


### PR DESCRIPTION
## Summary

- Reduce the EVM 1inch/Infura EIP-1559 fee refresh cadence from **60s → 10s** for every EVM provider config (arbitrum/base/optimism/polygon/ethereum archive + avalanche[_archive]) so fee estimates track the chain more closely.
- Make the cache staleness tolerance a **first-class, absolute config value** (`staleSeconds`) instead of a poll-period multiplier. It defaults to **600s (10 minutes)** and is independent of the poll cadence, via a shared `defaultFeeStaleSeconds` / `feeStaleDuration` helper living in the shared `alternativefeeprovider.go`.

## Why

The previous design coupled the stale window to the poll cadence (`window = periodSeconds × stalePeriods`), so changing one silently moved the other. Decoupling means:
- the 10s-poll coins keep a clean 10-minute window;
- `bsc_archive` (still 60s poll, intentionally not switched to 10s) now also gets the same 10-minute window via the default, instead of the accidental 60 minutes the old shared multiplier would have produced.

## Notes

- 10s polling is ~6× the request volume against 1inch/Infura; the API plan must tolerate it. Fees still fall back to node estimation past the stale window.
- Data lifecycle is unchanged: fetched by a background goroutine into an in-memory cache (not persisted to the DB); consumers read the cache.
- `docs/config.md` updated to document `staleSeconds`; fee-provider tests cover the default and an explicit override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)