### PR TITLE
Robinhood - turn off backend memory protection

### DIFF
--- a/configs/coins/robinhood_archive.json
+++ b/configs/coins/robinhood_archive.json
@@ -34,7 +34,7 @@
         "postinst_script_template": "openssl rand -hex 32 > {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/jwtsecret",
         "service_type": "simple",
         "service_additional_params_template": "",
-        "protect_memory": true,
+        "protect_memory": false,
         "mainnet": true,
         "server_config_file": "robinhood_genesis.json",
         "client_config_file": ""

--- a/configs/coins/robinhood_testnet.json
+++ b/configs/coins/robinhood_testnet.json
@@ -34,7 +34,7 @@
         "postinst_script_template": "openssl rand -hex 32 > {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/jwtsecret",
         "service_type": "simple",
         "service_additional_params_template": "",
-        "protect_memory": true,
+        "protect_memory": false,
         "mainnet": false,
         "server_config_file": "",
         "client_config_file": ""


### PR DESCRIPTION
## What

Set `protect_memory: false` for `robinhood_archive` and `robinhood_testnet`, so the generated backend systemd unit no longer emits `MemoryDenyWriteExecute=true`.

## Why

Robinhood Chain is an Arbitrum Nitro (Orbit) chain with **Stylus** (WASM) contracts. Executing a Stylus contract makes Nitro JIT-compile WASM to native code via Wasmer, which needs a W^X `mprotect(PROT_EXEC)`. `MemoryDenyWriteExecute=true` (rendered from `protect_memory`) installs a seccomp filter that makes that syscall return `EPERM`, aborting the whole node:

```
wasmer .../code_memory.rs:173 unable to make memory readonly and executable:
  PermissionDenied (os code 13)   ← arbos/programs.stylus_compile → SIGABRT
```

In production this was a deterministic crash loop pinned at the first L2 block requiring an uncached native Stylus compile: each restart rolled the execution head back to the last flushed state, re-executed up to that block, and crashed again — leaving the backend stuck far below the chain tip and freezing the Blockbook index.

Nitro/Stylus is a JIT and is fundamentally incompatible with `MemoryDenyWriteExecute`, so it must be off for these chains.

## Impact

- Only the two Robinhood backend units change; all other coins keep `protect_memory` as-is.
- Trade-off: gives up the `MemoryDenyWriteExecute` hardening on the Robinhood nodes — unavoidable for a WASM-JIT backend.
- Already-running nodes can be fixed without a redeploy via a systemd drop-in (`[Service]\nMemoryDenyWriteExecute=false`) + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
