### PR TITLE
fix(eth): treat balanceOf reverts as benign in single-call path

### DIFF
--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -495,11 +495,10 @@ func (b *EthereumRPC) GetContractInfo(contractDesc bchain.AddressDescriptor) (*b
 	return b.fetchContractInfo(address)
 }
 
-// ErrInvalidErc20Balance is returned when a balanceOf eth_call succeeds but returns data that
-// cannot be parsed as a 32-byte integer (empty "0x" or non-conforming output). It is benign and
-// common for dead/self-destructed or non-ERC20-conforming tokens that linger in holders' contract
-// lists; callers should treat it as "no balance" and must not log it at warning level (it is already
-// tracked via the observeEthCallError "invalid" metric).
+// ErrInvalidErc20Balance means a balanceOf eth_call yielded no usable balance: either it returned
+// unparseable data (empty "0x" or non-32-byte output) or it reverted deterministically. Both are
+// benign and common for dead/non-conforming/rebasing tokens; callers treat it as "no balance" and
+// must not log it at warning level (tracked via the observeEthCallError "invalid"/"reverted" metrics).
 var ErrInvalidErc20Balance = errors.New("Invalid balance")
 
 // EthereumTypeGetErc20ContractBalance returns balance of ERC20 contract for given address
@@ -513,6 +512,12 @@ func (b *EthereumRPC) EthereumTypeGetErc20ContractBalanceAtBlock(addrDesc, contr
 	req := erc20BalanceOfCallData(addrDesc)
 	data, err := b.EthereumTypeRpcCallAtBlock(req, contract, "", blockNumber)
 	if err != nil {
+		// A deterministic revert (balanceOf reverts for this holder) is benign: no usable
+		// balance. Match the batch path and treat it as ErrInvalidErc20Balance
+		if isNonRetriableEthCallError(err) {
+			b.observeEthCallError("single", "reverted")
+			return nil, ErrInvalidErc20Balance
+		}
 		return nil, err
 	}
 	r := parseSimpleNumericProperty(data)

--- a/bchain/coins/eth/contract_batch_test.go
+++ b/bchain/coins/eth/contract_batch_test.go
@@ -428,6 +428,70 @@ func TestEthereumTypeGetErc20ContractBalances(t *testing.T) {
 	}
 }
 
+func TestEthereumTypeGetErc20ContractBalanceReverted(t *testing.T) {
+	// A deterministic balanceOf revert must map to the benign ErrInvalidErc20Balance,
+	// matching the batch path, so callers log it at V(2) instead of warning.
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000011")
+	for _, revertMsg := range []string{
+		"execution reverted: division or modulo by zero",
+		"execution reverted",
+		"invalid opcode: INVALID",
+		"out of gas",
+	} {
+		contract := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+		contractKey := hexutil.Encode(contract.Bytes())
+		mock := &mockBatchCallRPC{
+			callErrors: map[string]error{
+				contractKey: errors.New(revertMsg),
+			},
+		}
+		rpcClient := &EthereumRPC{
+			RPC:     mock,
+			Timeout: time.Second,
+		}
+		balance, err := rpcClient.EthereumTypeGetErc20ContractBalance(
+			bchain.AddressDescriptor(addr.Bytes()),
+			bchain.AddressDescriptor(contract.Bytes()),
+		)
+		if balance != nil {
+			t.Fatalf("%q: expected nil balance, got %v", revertMsg, balance)
+		}
+		if err != ErrInvalidErc20Balance {
+			t.Fatalf("%q: expected ErrInvalidErc20Balance, got %v", revertMsg, err)
+		}
+	}
+}
+
+func TestEthereumTypeGetErc20ContractBalanceRPCError(t *testing.T) {
+	// A genuine (non-revert) RPC error must surface unchanged so it stays visible at warning level.
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000011")
+	contract := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	contractKey := hexutil.Encode(contract.Bytes())
+	rpcErr := errors.New("connection refused")
+	mock := &mockBatchCallRPC{
+		callErrors: map[string]error{
+			contractKey: rpcErr,
+		},
+	}
+	rpcClient := &EthereumRPC{
+		RPC:     mock,
+		Timeout: time.Second,
+	}
+	balance, err := rpcClient.EthereumTypeGetErc20ContractBalance(
+		bchain.AddressDescriptor(addr.Bytes()),
+		bchain.AddressDescriptor(contract.Bytes()),
+	)
+	if balance != nil {
+		t.Fatalf("expected nil balance, got %v", balance)
+	}
+	if err != rpcErr {
+		t.Fatalf("expected raw RPC error to surface unchanged, got %v", err)
+	}
+	if err == ErrInvalidErc20Balance {
+		t.Fatalf("genuine RPC error must not be classified as ErrInvalidErc20Balance")
+	}
+}
+
 func TestEthereumTypeGetErc20ContractBalancesBatchSize(t *testing.T) {
 	addr := common.HexToAddress("0x0000000000000000000000000000000000000011")
 	contractA := common.HexToAddress("0x00000000000000000000000000000000000000aa")


### PR DESCRIPTION
## Summary

The ERC20 balance batch path already classified deterministic `balanceOf` reverts (`execution reverted`, `division or modulo by zero`, `out of gas`, `invalid opcode`) as benign via `isNonRetriableEthCallError` and left them nil without warning. The standalone single-call path did not — it returned the raw error, which `worker.go` then logged at **warning** level, flooding logs for holders of dead/non-conforming/rebasing tokens (e.g. `EthereumTypeGetErc20ContractBalance ... execution reverted: division or modulo by zero`).

This change makes the single-call path consistent: deterministic reverts are classified as `ErrInvalidErc20Balance` and logged at `V(2)`. Genuine RPC/transport errors still surface unchanged and remain visible at warning level.

The balance result is unaffected in all cases (these tokens already yielded no balance) — only the log level changes.

## Changes
- `EthereumTypeGetErc20ContractBalanceAtBlock` runs RPC errors through `isNonRetriableEthCallError`; reverts return `ErrInvalidErc20Balance` and increment a new `observeEthCallError("single", "reverted")` metric.
- Broadened the `ErrInvalidErc20Balance` doc comment.
- Added tests for both the benign-revert and genuine-RPC-error cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)