### PR TITLE
feat(eth): tune per-coin alternative fee poll cadence

### DIFF
--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -62,7 +62,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 10}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 30}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/avalanche.json
+++ b/configs/coins/avalanche.json
@@ -58,7 +58,7 @@
                 "averageBlockTimeMs": 2000,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 10}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 15}",
                 "mempoolTxTimeoutHours": 12,
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",

--- a/configs/coins/avalanche_archive.json
+++ b/configs/coins/avalanche_archive.json
@@ -66,7 +66,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 10}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/43114/suggestedGasFees\", \"periodSeconds\": 15}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -64,7 +64,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 10}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 5}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -64,7 +64,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "alternative_estimate_fee": "infura",
-                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 10}",
+                "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/10/suggestedGasFees\", \"periodSeconds\": 15}",
                 "mempoolTxTimeoutHours": 12,
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",


### PR DESCRIPTION
## Summary

The prior blanket **10s** alternative-fee poll cadence was too uniform. Set per-coin poll intervals that better match each chain's block time and fee volatility:

| Coin config | Poll before | Poll after |
|---|---|---|
| `arbitrum_archive` | 10s | **30s** |
| `base_archive` | 10s | **5s** |
| `optimism_archive` | 10s | **15s** |
| `avalanche` | 10s | **15s** |
| `avalanche_archive` | 10s | **15s** |

Only the `periodSeconds` field inside `alternative_estimate_fee_params` changes. The stale window is untouched — it's the absolute `staleSeconds` (default 10 minutes) and is independent of the poll cadence.

## Intentionally NOT touched

- **sepolia / hoodi** (ethereum testnets): still on **native node fee estimation** — they have no `alternative_estimate_fee` provider at all. Setting them to a poll interval would mean *adding* the Infura provider block, and hoodi (chain 560048) is likely not covered by the Infura Gas API. Left out of scope.
- **bsc**: alternative provider stays **disabled** via the `"infura-disabled"` sentinel (`initAlternativeFeeProvider` only matches `"infura"`/`"1inch"`, so the provider is never constructed). BSC has no meaningful EIP-1559 base-fee market and uses native estimation.
- **ethereum_archive**: 1inch provider stays at 10s (out of scope for this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)