### PR TITLE
fix(websocket): log bounded payload preview in onRequest error paths

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -997,7 +997,7 @@ func (s *WebsocketServer) onRequest(c *websocketChannel, req *WsReq) {
 			s.metrics.WebsocketRequests.With(common.Labels{"method": methodLabel, "status": "success"}).Inc()
 		} else {
 			if apiErr, ok := err.(*api.APIError); !ok || !apiErr.Public {
-				glog.Error("Client ", c.id, " onMessage ", req.Method, ": ", errors.ErrorStack(err), ", data ", string(req.Params))
+				glog.Error("Client ", c.id, " onMessage ", req.Method, ": ", errors.ErrorStack(err), ", data len ", len(req.Params), ", preview ", getWebsocketPayloadPreview(req.Params))
 			}
 			s.metrics.WebsocketRequests.With(common.Labels{"method": methodLabel, "status": "failure"}).Inc()
 			e := resultError{}
@@ -1007,7 +1007,7 @@ func (s *WebsocketServer) onRequest(c *websocketChannel, req *WsReq) {
 	} else {
 		s.metrics.WebsocketUnknownMethods.With(common.Labels{"method": methodLabel}).Inc()
 		s.metrics.WebsocketRequests.With(common.Labels{"method": methodLabel, "status": "failure"}).Inc()
-		glog.V(1).Info("Client ", c.id, " onMessage ", req.Method, ": unknown method, data ", string(req.Params))
+		glog.V(1).Info("Client ", c.id, " onMessage ", getWebsocketPayloadPreview([]byte(req.Method)), ": unknown method, data len ", len(req.Params), ", preview ", getWebsocketPayloadPreview(req.Params))
 	}
 }
 


### PR DESCRIPTION
## Description

The websocket `onRequest` error paths (handler error and unknown method) logged the complete `req.Params`, so a single log entry could grow to the full websocket message limit (4 MiB). This made log volume unpredictable and inconsistent with the parse-error log in `inputLoop`, which already logs only a bounded preview.

This change logs the payload length plus a 256-byte preview via the existing `getWebsocketPayloadPreview` helper. The unknown-method log also previews the client-supplied method name, which is likewise unbounded.

No functional changes — log formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)