### PR TITLE
feat(grafana): chart websocket IP blocklist metrics

### DIFF
--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -400,11 +400,11 @@ panels:
         legend: '{{coin}} - {{reason}}/min'
   websocket.blocked_ips:
     title: Websocket IPs currently blocked
-    description: '{{help:websocket_blocked_ips}} Every connection attempt from a blocked key is rejected with HTTP 429 before the upgrade, so a sustained non-zero value means real clients are locked out right now; under CGNAT one blocked key can cover many users. Refreshed once per limiter maintenance tick (1 minute). The internal status page lists the blocked keys with expiry and allows resetting the blocklist.'
+    description: '{{help:websocket_blocked_ips}}. Every connection attempt from a blocked key is rejected with HTTP 429 before the upgrade, so a sustained non-zero value means real clients are locked out right now; under CGNAT one blocked key can cover many users. Refreshed once per limiter maintenance tick (1 minute). The internal status page lists the blocked keys with expiry and allows resetting the blocklist.'
     queries:
       blocked_ips:
-        promql: '{{name:websocket_blocked_ips}}{job="blockbook", coin="$coin"}'
-        legend: '{{coin}} - {{instance}}'
+        promql: sum({{name:websocket_blocked_ips}}{job="blockbook", coin="$coin"}) by (coin)
+        legend: '{{coin}} - blocked IPs'
   websocket.blocked_connections:
     title: Websocket blocked-IP rejections per minute
     description: 'Connection attempts rejected because the client key is on the temporary message-rate blocklist (HTTP 429 before the upgrade). Enforcement counterpart of the blocked-IPs gauge: high values mean banned clients are hammering reconnects for the whole block duration. Distinct from connection rejections, which count the per-IP concurrent-connection and attempt-rate caps rather than the message-rate ban.'

--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -398,6 +398,20 @@ panels:
       rejections:
         promql: sum(rate({{name:websocket_connection_rejections}}{job="blockbook", coin="$coin"}[$__rate_interval])) by (coin, reason) * 60
         legend: '{{coin}} - {{reason}}/min'
+  websocket.blocked_ips:
+    title: Websocket IPs currently blocked
+    description: '{{help:websocket_blocked_ips}} Every connection attempt from a blocked key is rejected with HTTP 429 before the upgrade, so a sustained non-zero value means real clients are locked out right now; under CGNAT one blocked key can cover many users. Refreshed once per limiter maintenance tick (1 minute). The internal status page lists the blocked keys with expiry and allows resetting the blocklist.'
+    queries:
+      blocked_ips:
+        promql: '{{name:websocket_blocked_ips}}{job="blockbook", coin="$coin"}'
+        legend: '{{coin}} - {{instance}}'
+  websocket.blocked_connections:
+    title: Websocket blocked-IP rejections per minute
+    description: 'Connection attempts rejected because the client key is on the temporary message-rate blocklist (HTTP 429 before the upgrade). Enforcement counterpart of the blocked-IPs gauge: high values mean banned clients are hammering reconnects for the whole block duration. Distinct from connection rejections, which count the per-IP concurrent-connection and attempt-rate caps rather than the message-rate ban.'
+    queries:
+      blocked_rejections:
+        promql: sum(rate({{name:websocket_blocked_connections}}{job="blockbook", coin="$coin"}[$__rate_interval])) by (coin) * 60
+        legend: '{{coin}} - rejected/min'
   websocket.unique_ips:
     title: Websocket connections vs unique client IPs
     description: Open connections plotted against the number of distinct client IPs holding them; the gap between the two lines is connection clustering. Across the many Suite users a healthy deployment serves, the lines should track closely at roughly one connection per IP. A connections line pulling well above unique IPs means connections are concentrated on few sources.

--- a/configs/grafana/template.json
+++ b/configs/grafana/template.json
@@ -3345,6 +3345,127 @@
         },
         "overrides": []
       },
+      "id": 350,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "blocked_ips"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "websocket.blocked_ips"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "rejects / min",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 351,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "range": true,
+          "refId": "A",
+          "x-query-key": "blocked_rejections"
+        }
+      ],
+      "type": "timeseries",
+      "x-panel-key": "websocket.blocked_connections"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "id": 319,
       "options": {
         "legend": {


### PR DESCRIPTION
## What

Adds two Grafana panels for the websocket IP-blocklist metrics that were registered in `metrics.yaml` when the per-connection message rate limiter shipped, but never got charted:

- **Websocket IPs currently blocked** — `blockbook_websocket_blocked_ips`, the "users locked out right now" gauge
- **Websocket blocked-IP rejections per minute** — `rate(blockbook_websocket_blocked_connections)`, banned clients hammering reconnects

Both sit next to the existing connection-rejections panel so the enforcement panels are grouped together.

## Why

The message-rate limiter's 12 h IP bans currently have zero dashboard visibility: on the Tron backends the blocklist held 24 (backend16) / 2 (backend15) IPs with ~33k rejected reconnect attempts, and the first signal was user reports of "Account discovery error", not a chart. The `message_rate_limit` channel closes are technically visible in the closes panel but are drowned out by ~90k `read_error` closes.

With this change every metric in `metrics.yaml` is referenced by at least one panel (verified both directions: Go `metric:` tags ↔ `metrics.yaml` ↔ `panels.yaml`).

`render_grafana.py --check` passes (106 panels, 87 metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)