### PR TITLE
chore(litecoin): bump backend to 0.21.5.6

### DIFF
--- a/configs/coins/litecoin.json
+++ b/configs/coins/litecoin.json
@@ -23,10 +23,10 @@
         "package_name": "backend-litecoin",
         "package_revision": "satoshilabs-1",
         "system_user": "litecoin",
-        "version": "0.21.4",
-        "binary_url": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-x86_64-linux-gnu.tar.gz",
+        "version": "0.21.5.6",
+        "binary_url": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-x86_64-linux-gnu.tar.gz",
         "verification_type": "gpg",
-        "verification_source": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-x86_64-linux-gnu.tar.gz.asc",
+        "verification_source": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-x86_64-linux-gnu.tar.gz.asc",
         "extract_command": "tar -C backend --strip 1 -xf",
         "exclude_files": ["bin/litecoin-qt"],
         "exec_command_template": "{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/bin/litecoind -datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend -conf={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/{{.Coin.Alias}}.conf -pid=/run/{{.Coin.Alias}}/{{.Coin.Alias}}.pid",
@@ -43,8 +43,8 @@
         },
         "platforms": {
             "arm64": {
-                "binary_url": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-aarch64-linux-gnu.tar.gz",
-                "verification_source": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-aarch64-linux-gnu.tar.gz.asc"
+                "binary_url": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-aarch64-linux-gnu.tar.gz",
+                "verification_source": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-aarch64-linux-gnu.tar.gz.asc"
             }
         }
     },

--- a/configs/coins/litecoin_testnet.json
+++ b/configs/coins/litecoin_testnet.json
@@ -23,10 +23,10 @@
     "package_name": "backend-litecoin-testnet",
     "package_revision": "satoshilabs-1",
     "system_user": "litecoin",
-    "version": "0.21.4",
-    "binary_url": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-x86_64-linux-gnu.tar.gz",
+    "version": "0.21.5.6",
+    "binary_url": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-x86_64-linux-gnu.tar.gz",
     "verification_type": "gpg",
-    "verification_source": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-x86_64-linux-gnu.tar.gz.asc",
+    "verification_source": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-x86_64-linux-gnu.tar.gz.asc",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/litecoin-qt"
@@ -45,8 +45,8 @@
     },
     "platforms": {
       "arm64": {
-          "binary_url": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-aarch64-linux-gnu.tar.gz",
-          "verification_source": "https://download.litecoin.org/litecoin-0.21.4/linux/litecoin-0.21.4-aarch64-linux-gnu.tar.gz.asc"
+          "binary_url": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-aarch64-linux-gnu.tar.gz",
+          "verification_source": "https://download.litecoin.org/litecoin-0.21.5.6/linux/litecoin-0.21.5.6-aarch64-linux-gnu.tar.gz.asc"
       }
     }
   },


### PR DESCRIPTION
Litecoin Core 0.21.5.6 is an urgent maintenance release hardening MWEB transaction, block and P2P-service validation. It also adds a soft-forking rule at mainnet height 3,154,440 rejecting MWEB kernels that signal a pegout while carrying an empty pegout list, so nodes should be upgraded before activation.

No reindex or Blockbook resync is required: there is no on-disk format change between 0.21.4 and 0.21.5.6, and Blockbook already bypasses the raw-block wire path for Litecoin (getblock verbosity=1 + per-txid getrawtransaction), so the MWEB serialization work does not affect parsing. ZMQ notifications are unchanged.

Artifacts verified: x86_64 tarball sha256 matches the release notes and the detached signature checks out against the bundled litecoin-releases.asc key (D35621D53A1CC6A3456758D03620E9D387E55666), so verification_type "gpg" stays as is.