### PR TITLE
chore(eth):  change alternative mempool tx timeout to 3 hours to alig…

### DIFF
--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -63,6 +63,8 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "mempoolTxTimeoutHours": 48,
+                "mempoolTxTimeout": "3h",
+                "alternativeMempoolTxTimeout": "3h",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",

--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -63,7 +63,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "mempoolTxTimeoutHours": 48,
-                "mempoolTxTimeout": "3h",
+                "mempoolTxTimeout": "48h",
                 "alternativeMempoolTxTimeout": "3h",
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -72,7 +72,7 @@
                 "alternative_estimate_fee": "1inch",
                 "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 48,
-                "mempoolTxTimeout": "3h",
+                "mempoolTxTimeout": "48h",
                 "alternativeMempoolTxTimeout": "3h",
                 "processInternalTransactions": true,
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -72,6 +72,8 @@
                 "alternative_estimate_fee": "1inch",
                 "alternative_estimate_fee_params": "{\"url\": \"https://api.1inch.dev/gas-price/v1.5/1\", \"periodSeconds\": 10}",
                 "mempoolTxTimeoutHours": 48,
+                "mempoolTxTimeout": "3h",
+                "alternativeMempoolTxTimeout": "3h",
                 "processInternalTransactions": true,
                 "queryBackendOnMempoolResync": false,
                 "fiat_rates": "coingecko",


### PR DESCRIPTION
## What

Sets `alternativeMempoolTxTimeout: "3h"` and `mempoolTxTimeout: "48h"` in `ethereum.json` and `ethereum_archive.json`. Config-only change; the options themselves already exist on master.

## Why

Blink's MEV pool keeps a private transaction mineable for up to 3 hours. With an alternative send-tx provider enabled, Blockbook's defaults (5 min alternative cache, 10 min mempool retention) evict the transaction long before Blink stops trying to mine it — it disappears from the pending view and stops raising the sender's pending-nonce floor while still in flight.

`mempoolTxTimeout` must be set explicitly alongside the cache value: with an alternative provider enabled and no explicit value, mempool retention falls back to the 10-minute default — below the 3-hour cache — and the mempool would evict a Blink transaction while the cache still holds it and keeps raising the pending-nonce floor for a tx no longer shown as pending. `"48h"` satisfies mempool ≥ cache while preserving the current public-tx retention.

## Effects

- **Blink-enabled deployments** (`ETH_ALTERNATIVE_SENDTX_URLS` set): private transactions stay visible as pending, resolvable via `getTransaction`, and counted in the pending nonce for up to 3 hours, matching Blink's own retention. Their lifecycle is bounded by the alternative cache — cache eviction (mined, nonce superseded, timeout) also removes the tx from the mempool — so the 48h mempool ceiling never applies to them. Deterministic early evictions still apply.
- **Public (non-private) transactions**: no behavior change — retention stays at 48 hours, now via the explicit duration instead of `mempoolTxTimeoutHours`.
- `mempoolTxTimeoutHours: 48` is kept as a fallback in case the duration override is ever removed.

## Notes

- A transaction the relay silently drops (never mined, nonce never consumed) now stays visible as pending for the full 3 hours instead of 5 minutes — reconciliation deliberately does not evict on a not-found probe (see #1573). Until it expires, the sender's next send is built on top of its nonce; users can replace/cancel it manually. Watch `EthAlternativeMempoolTxResidence{action="timeout"}` after deploy — evictions clustering at the full 3h would mean the cache is mostly holding dead transactions.
- The reconcile loop probes each cached transaction against the provider once per minute for its whole lifetime, so Blink RPC usage grows with the longer window (bounded by private send volume). Nonce-lookup routing to Blink also holds for up to 3 hours per sender.
- Testnet configs are unchanged; Blink runs on mainnet only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
