### PR TITLE
chore(evm): set explicit mempool tx timeouts for Arbitrum, Base and BSC archive

### DIFF
--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -64,6 +64,8 @@
                 "alternative_estimate_fee": "infura",
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/42161/suggestedGasFees\", \"periodSeconds\": 30}",
                 "mempoolTxTimeoutHours": 12,
+                "mempoolTxTimeout": "12h",
+                "alternativeMempoolTxTimeout": "3h",
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -66,6 +66,8 @@
                 "alternative_estimate_fee": "infura",
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/8453/suggestedGasFees\", \"periodSeconds\": 5}",
                 "mempoolTxTimeoutHours": 12,
+                "mempoolTxTimeout": "12h",
+                "alternativeMempoolTxTimeout": "3h",
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,

--- a/configs/coins/bsc_archive.json
+++ b/configs/coins/bsc_archive.json
@@ -71,6 +71,8 @@
                 "alternative_estimate_fee": "infura-disabled",
                 "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/56/suggestedGasFees\", \"periodSeconds\": 60}",
                 "mempoolTxTimeoutHours": 12,
+                "mempoolTxTimeout": "12h",
+                "alternativeMempoolTxTimeout": "3h",
                 "processInternalTransactions": true,
                 "trace_timeout": "10s",
                 "queryBackendOnMempoolResync": false,


### PR DESCRIPTION
## What

Adds explicit `mempoolTxTimeout: "12h"` and `alternativeMempoolTxTimeout: "3h"` to `arbitrum_archive.json`, `base_archive.json` and `bsc_archive.json`. Config-only change; follow-up to #1706, which did the same for Ethereum.

## Why

These deployments run with `*_ALTERNATIVE_SENDTX_URLS` set. With an alternative provider enabled and no explicit `mempoolTxTimeout`, the `mempoolTxTimeoutHours: 12` value in these configs is silently bypassed: mempool retention falls back to a 10-minute default and the alternative cache runs at 5 minutes. A transaction submitted through the private relay therefore disappears from the user's pending view (and stops raising the pending-nonce floor) after 5–10 minutes, even while the relay may still mine it.

- `alternativeMempoolTxTimeout: "3h"` aligns the private-tx visibility window with the 3h used on Ethereum (#1706).
- `mempoolTxTimeout: "12h"` makes the 12-hour intent of `mempoolTxTimeoutHours` apply again and keeps the required invariant mempool retention ≥ alternative cache retention.

## Effects

- Relay-submitted transactions stay visible as pending, resolvable via `getTransaction`, and counted in the pending nonce for up to 3 hours (bounded by the alternative cache; mined and nonce-superseded evictions still apply early and also remove the tx from the mempool).
- These chains all run `disableMempoolSync: true`, so the mempool only ever holds transactions submitted through Blockbook itself — the 12h value changes nothing for network transactions.
- A transaction the relay silently drops now lingers as pending for up to 3 hours instead of 5 minutes before timing out. On these fast chains (250ms–3s blocks) anything unmined after a few minutes is almost certainly dead, so expect `EthAlternativeMempoolTxResidence{action="timeout"}` evictions to cluster at the full window; worth watching after deploy.

## Notes

- The non-archive siblings (`arbitrum.json`, `base.json`, `bsc.json`) have the same shape but are left unchanged — update them too if any deployment built from them runs an alternative provider.
- The 3h value mirrors Ethereum/Blink; if the relay used on these chains documents a different retention window, the cache value should follow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
