### PR TITLE
Update Firo daemon 0.14.17.2

### DIFF
--- a/configs/coins/firo.json
+++ b/configs/coins/firo.json
@@ -23,10 +23,10 @@
     "package_name": "backend-firo",
     "package_revision": "satoshilabs-1",
     "system_user": "firo",
-    "version": "0.14.16.1",
-    "binary_url": "https://github.com/firoorg/firo/releases/download/v0.14.16.1/firo-0.14.16.1-linux64.tar.gz",
+    "version": "0.14.17.2",
+    "binary_url": "https://github.com/firoorg/firo/releases/download/v0.14.17.2/firo-0.14.17.2-linux64.tar.gz",
     "verification_type": "sha256",
-    "verification_source": "f2b7dba9adfbfebaf4812ca96c39f4f94fdb03ea7e1a7e5c346f8d2f626594e0",
+    "verification_source": "153d165de6f0c0fdc20f68561711d05ac6925df143fbc2d0212b9f27e9aaabec",
     "extract_command": "tar -C backend --strip 1 -xf",
     "exclude_files": [
       "bin/firo-qt",


### PR DESCRIPTION
This is a mandatory release.

https://github.com/firoorg/firo/releases/tag/v0.14.17.2