### PR TITLE
chore(eth): update Erigon 3.5.2->3.5.5

### DIFF
--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -23,10 +23,10 @@
         "package_name": "backend-ethereum",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "3.5.2",
-        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_amd64.tar.gz",
+        "version": "3.5.5",
+        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_amd64.tar.gz",
         "verification_type": "sha256",
-        "verification_source": "cf35a980f7e59a514803def5d21de7aeb6a1b9e5c4b1a35adb3dc59acc2413bc",
+        "verification_source": "2e875794234dc06fdcd0c716b38e936b8c820e90e16cee2d43fdfaf74df09ced",
         "extract_command": "tar -C backend --strip-components=1 -xf",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/erigon --chain mainnet --snap.keepblocks --db.size.limit 15TB --db.pagesize 16KB --prune.mode full --externalcl --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/erigon --port {{.Ports.BackendP2P}} --discovery.v4 --ws --ws.port {{.Ports.BackendRPC}} --http --http.port {{.Ports.BackendRPC}} --http.addr {{.Env.RPCBindHost}} --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --rpc.logs.maxresults 200000 --authrpc.port {{.Ports.BackendAuthRpc}} --private.api.addr \"\" --torrent.port {{.Ports.BackendHttp}} --log.dir.path {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --log.dir.prefix {{.Coin.Alias}}'",
@@ -40,8 +40,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_arm64.tar.gz",
-                "verification_source": "383b9b5030eb99abd62bc7eac8ca24242aa5a6cf5ee19a24733d4c33b642c3b1"
+                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_arm64.tar.gz",
+                "verification_source": "1e2e917b15338047f4a41cfd2cfd486b272c856fd549a68e3fe63d64762f8113"
             }
         }
     },

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -24,10 +24,10 @@
         "package_name": "backend-ethereum-archive",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "3.5.2",
-        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_amd64.tar.gz",
+        "version": "3.5.5",
+        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_amd64.tar.gz",
         "verification_type": "sha256",
-        "verification_source": "cf35a980f7e59a514803def5d21de7aeb6a1b9e5c4b1a35adb3dc59acc2413bc",
+        "verification_source": "2e875794234dc06fdcd0c716b38e936b8c820e90e16cee2d43fdfaf74df09ced",
         "extract_command": "tar -C backend --strip-components=1 -xf",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/erigon --chain mainnet --snap.keepblocks --db.size.limit 15TB --db.pagesize 16KB --prune.mode archive --externalcl --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/erigon --port {{.Ports.BackendP2P}} --discovery.v4 --ws --ws.port {{.Ports.BackendRPC}} --http --http.port {{.Ports.BackendRPC}} --http.addr {{.Env.RPCBindHost}} --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --rpc.logs.maxresults 200000 --authrpc.port {{.Ports.BackendAuthRpc}} --private.api.addr \"\" --torrent.port {{.Ports.BackendHttp}} --log.dir.path {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --log.dir.prefix {{.Coin.Alias}}'",
@@ -41,8 +41,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_arm64.tar.gz",
-                "verification_source": "383b9b5030eb99abd62bc7eac8ca24242aa5a6cf5ee19a24733d4c33b642c3b1"
+                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_arm64.tar.gz",
+                "verification_source": "1e2e917b15338047f4a41cfd2cfd486b272c856fd549a68e3fe63d64762f8113"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_hoodi.json
+++ b/configs/coins/ethereum_testnet_hoodi.json
@@ -23,10 +23,10 @@
         "package_name": "backend-ethereum-testnet-hoodi",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "3.5.2",
-        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_amd64.tar.gz",
+        "version": "3.5.5",
+        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_amd64.tar.gz",
         "verification_type": "sha256",
-        "verification_source": "cf35a980f7e59a514803def5d21de7aeb6a1b9e5c4b1a35adb3dc59acc2413bc",
+        "verification_source": "2e875794234dc06fdcd0c716b38e936b8c820e90e16cee2d43fdfaf74df09ced",
         "extract_command": "tar -C backend --strip-components=1 -xf",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/erigon --chain hoodi --snap.keepblocks --db.size.limit 15TB --db.pagesize 16KB --prune.mode full --externalcl --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/erigon --port {{.Ports.BackendP2P}} --discovery.v4 --ws --ws.port {{.Ports.BackendRPC}} --http --http.port {{.Ports.BackendRPC}} --http.addr {{.Env.RPCBindHost}} --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --rpc.logs.maxresults 200000 --authrpc.port {{.Ports.BackendAuthRpc}} --private.api.addr \"\" --torrent.port {{.Ports.BackendHttp}} --log.dir.path {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --log.dir.prefix {{.Coin.Alias}}'",
@@ -40,8 +40,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_arm64.tar.gz",
-                "verification_source": "383b9b5030eb99abd62bc7eac8ca24242aa5a6cf5ee19a24733d4c33b642c3b1"
+                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_arm64.tar.gz",
+                "verification_source": "1e2e917b15338047f4a41cfd2cfd486b272c856fd549a68e3fe63d64762f8113"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_hoodi_archive.json
+++ b/configs/coins/ethereum_testnet_hoodi_archive.json
@@ -25,10 +25,10 @@
         "package_name": "backend-ethereum-testnet-hoodi-archive",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "3.5.2",
-        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_amd64.tar.gz",
+        "version": "3.5.5",
+        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_amd64.tar.gz",
         "verification_type": "sha256",
-        "verification_source": "cf35a980f7e59a514803def5d21de7aeb6a1b9e5c4b1a35adb3dc59acc2413bc",
+        "verification_source": "2e875794234dc06fdcd0c716b38e936b8c820e90e16cee2d43fdfaf74df09ced",
         "extract_command": "tar -C backend --strip-components=1 -xf",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/erigon --chain hoodi --snap.keepblocks --db.size.limit 15TB --db.pagesize 16KB --prune.mode archive --externalcl --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/erigon --port {{.Ports.BackendP2P}} --discovery.v4 --ws --ws.port {{.Ports.BackendRPC}} --http --http.port {{.Ports.BackendRPC}} --http.addr {{.Env.RPCBindHost}} --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --rpc.logs.maxresults 200000 --authrpc.port {{.Ports.BackendAuthRpc}} --private.api.addr \"\" --torrent.port {{.Ports.BackendHttp}} --log.dir.path {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --log.dir.prefix {{.Coin.Alias}}'",
@@ -42,8 +42,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_arm64.tar.gz",
-                "verification_source": "383b9b5030eb99abd62bc7eac8ca24242aa5a6cf5ee19a24733d4c33b642c3b1"
+                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_arm64.tar.gz",
+                "verification_source": "1e2e917b15338047f4a41cfd2cfd486b272c856fd549a68e3fe63d64762f8113"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_sepolia.json
+++ b/configs/coins/ethereum_testnet_sepolia.json
@@ -23,10 +23,10 @@
         "package_name": "backend-ethereum-testnet-sepolia",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "3.5.2",
-        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_amd64.tar.gz",
+        "version": "3.5.5",
+        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_amd64.tar.gz",
         "verification_type": "sha256",
-        "verification_source": "cf35a980f7e59a514803def5d21de7aeb6a1b9e5c4b1a35adb3dc59acc2413bc",
+        "verification_source": "2e875794234dc06fdcd0c716b38e936b8c820e90e16cee2d43fdfaf74df09ced",
         "extract_command": "tar -C backend --strip-components=1 -xf",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/erigon --chain sepolia --snap.keepblocks --db.size.limit 15TB --db.pagesize 16KB --prune.mode full --externalcl --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/erigon --port {{.Ports.BackendP2P}} --discovery.v4 --ws --ws.port {{.Ports.BackendRPC}} --http --http.port {{.Ports.BackendRPC}} --http.addr {{.Env.RPCBindHost}} --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --rpc.logs.maxresults 200000 --authrpc.port {{.Ports.BackendAuthRpc}} --private.api.addr \"\" --torrent.port {{.Ports.BackendHttp}} --log.dir.path {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --log.dir.prefix {{.Coin.Alias}}'",
@@ -40,8 +40,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_arm64.tar.gz",
-                "verification_source": "383b9b5030eb99abd62bc7eac8ca24242aa5a6cf5ee19a24733d4c33b642c3b1"
+                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_arm64.tar.gz",
+                "verification_source": "1e2e917b15338047f4a41cfd2cfd486b272c856fd549a68e3fe63d64762f8113"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_sepolia_archive.json
+++ b/configs/coins/ethereum_testnet_sepolia_archive.json
@@ -25,10 +25,10 @@
         "package_name": "backend-ethereum-testnet-sepolia-archive",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "3.5.2",
-        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_amd64.tar.gz",
+        "version": "3.5.5",
+        "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_amd64.tar.gz",
         "verification_type": "sha256",
-        "verification_source": "cf35a980f7e59a514803def5d21de7aeb6a1b9e5c4b1a35adb3dc59acc2413bc",
+        "verification_source": "2e875794234dc06fdcd0c716b38e936b8c820e90e16cee2d43fdfaf74df09ced",
         "extract_command": "tar -C backend --strip-components=1 -xf",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/erigon --chain sepolia --snap.keepblocks --db.size.limit 15TB --db.pagesize 16KB --prune.mode archive --externalcl --nat none --datadir {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/erigon --port {{.Ports.BackendP2P}} --discovery.v4 --ws --ws.port {{.Ports.BackendRPC}} --http --http.port {{.Ports.BackendRPC}} --http.addr {{.Env.RPCBindHost}} --http.corsdomain \"*\" --http.vhosts \"*\" --http.api \"eth,net,web3,debug,txpool\" --rpc.logs.maxresults 200000 --authrpc.port {{.Ports.BackendAuthRpc}} --private.api.addr \"\" --torrent.port {{.Ports.BackendHttp}} --log.dir.path {{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --log.dir.prefix {{.Coin.Alias}}'",
@@ -42,8 +42,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.2/erigon_v3.5.2_linux_arm64.tar.gz",
-                "verification_source": "383b9b5030eb99abd62bc7eac8ca24242aa5a6cf5ee19a24733d4c33b642c3b1"
+                "binary_url": "https://github.com/erigontech/erigon/releases/download/v3.5.5/erigon_v3.5.5_linux_arm64.tar.gz",
+                "verification_source": "1e2e917b15338047f4a41cfd2cfd486b272c856fd549a68e3fe63d64762f8113"
             }
         }
     },


### PR DESCRIPTION
Updates the Erigon pin in all six Ethereum configs (mainnet, mainnet archive, Sepolia, Sepolia archive, Hoodi, Hoodi archive) from 3.5.2 to 3.5.5: `version`, both `binary_url`s (amd64 and the arm64 entry under `platforms`), and both `verification_source` hashes.

## Why 3.5.2 needs to go

Blockbook builds its ERC20 transfer index from `eth_getLogs`, so an Erigon bug that misnumbers or invents logs is written straight into RocksDB and stays there. 3.5.2 is exposed to both known variants, and the fixes for both are in 3.5.5 only:

- **[#23064](https://github.com/erigontech/erigon/pull/23064)** (cherry-pick of #23061 into `release/3.5`) — receipt domains were never rolled back on an in-RAM reorg unwind: `GetDiffset` built a `[kv.DomainLen]` array but filled only the four domains that existed before `ReceiptDomain` was added, so `ReceiptDomain`/`RCacheDomain` came back nil. Small reorgs near the tip then leave `eth_getLogs` serving phantom logs with the wrong `logIndex` while `eth_getBlockReceipts` for the same block stays correct. The corruption survives restarts and gets frozen into the snapshot files. See [erigontech/erigon#23062](https://github.com/erigontech/erigon/issues/23062) — the first reported occurrence was on **v3.5.2**.
- **[#22951](https://github.com/erigontech/erigon/pull/22951)** — wrong `logIndex` on archive nodes, from receipt-domain reads bypassing the overlay `DomainReader`. **Affects v3.5.1–v3.5.4.**

Picked up on the way through 3.5.3/3.5.4:

- **#22459** — JSON-RPC `handleBatch` deadlock; a filtered batch could wedge on `wg.Wait()` and time out. Blockbook batches heavily via `BatchCallContext` (token balances/metadata in `bchain/coins/eth/contract.go`).
- **#22700** — native (C-allocated) memory leak in the RPC gzip path, ~9–15 GiB/day on an archive node with response compression enabled.

## Notes

- Drop-in at every hop, no re-sync required (per each release's own notes).
- Checksums taken from the release's `erigon_v3.5.5_checksums.txt`.
- No `exec_command_template` change needed — nothing in 3.5.3/3.5.4/3.5.5 deprecates a flag we pass. 3.5.3's new `--rpc.logs.querylimit` is a different knob from our `--rpc.logs.maxresults` and its default preserves current behaviour.
- **Upgrading does not repair damage already on disk.** Nodes that ran 3.5.2 should be checked per suspect block by diffing `eth_getLogs` against `eth_getBlockReceipts`; if they disagree, the derived domains need the documented rebuild, and the affected block ranges need a Blockbook reindex.
- erigontech/erigon#23062 is still open (its second defect, reorg paths that skip the on-disk unwind entirely, is milestoned 3.7.0), so this narrows the exposure rather than closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)