### PR TITLE
fix(evm): pool JSON-RPC connections to prevent port exhaustion

### DIFF
--- a/bchain/coins/avalanche/avalancherpc.go
+++ b/bchain/coins/avalanche/avalancherpc.go
@@ -25,13 +25,7 @@ func dialRPC(rawURL string) (*rpc.Client, error) {
 	if rawURL == "" {
 		return nil, errors.New("empty rpc url")
 	}
-	opts := []rpc.ClientOption{}
-	if parsed, err := url.Parse(rawURL); err == nil {
-		if parsed.Scheme == "ws" || parsed.Scheme == "wss" {
-			opts = append(opts, rpc.WithWebsocketMessageSizeLimit(0))
-		}
-	}
-	return rpc.DialOptions(context.Background(), rawURL, opts...)
+	return rpc.DialOptions(context.Background(), rawURL, eth.RPCDialOptions(rawURL)...)
 }
 
 // OpenRPC opens RPC connections for Avalanche to separate HTTP and WS endpoints.
@@ -98,7 +92,8 @@ func (b *AvalancheRPC) Initialize() error {
 		scheme = "https"
 	}
 
-	infoClient, err := rpc.DialHTTP(fmt.Sprintf("%s://%s/ext/info", scheme, rpcUrl.Host))
+	infoURL := fmt.Sprintf("%s://%s/ext/info", scheme, rpcUrl.Host)
+	infoClient, err := rpc.DialOptions(context.Background(), infoURL, eth.RPCDialOptions(infoURL)...)
 	if err != nil {
 		return err
 	}

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -520,13 +520,9 @@ func dialRPC(rawURL string) (*rpc.Client, error) {
 	if rawURL == "" {
 		return nil, errors.New("empty rpc url")
 	}
-	opts := []rpc.ClientOption{}
-	if strings.HasPrefix(rawURL, "ws://") || strings.HasPrefix(rawURL, "wss://") {
-		opts = append(opts, rpc.WithWebsocketMessageSizeLimit(0))
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 	defer cancel()
-	return rpc.DialOptions(ctx, rawURL, opts...)
+	return rpc.DialOptions(ctx, rawURL, RPCDialOptions(rawURL)...)
 }
 
 // OpenRPC opens RPC connection to ETH backend.

--- a/bchain/coins/eth/rpchttp.go
+++ b/bchain/coins/eth/rpchttp.go
@@ -9,37 +9,28 @@ import (
 )
 
 const (
-	// rpcMaxIdleConnsPerHost sizes the keep-alive pool above the sync worker count
-	// (-workers, 16 on the fastest chains) plus mempool and API callers, so concurrent
-	// calls reuse sockets instead of dialing new ones. go-ethereum otherwise dials with
-	// http.DefaultTransport, whose http.DefaultMaxIdleConnsPerHost of 2 made every extra
-	// in-flight call close its socket: on a sub-second chain that burned ~340 ports/s into
-	// TIME_WAIT, exhausted the host's ephemeral range and failed dials with EADDRNOTAVAIL,
-	// which silently stalled sync (bitcoinrpc.go and tronhttp.go tune this for the same reason).
+	// go-ethereum's default of 2 idle conns per host burns a socket per extra in-flight call
+	// and exhausts the ephemeral range; sized above -workers (16) as bitcoinrpc.go already is.
 	rpcMaxIdleConnsPerHost = 100
-	// rpcMaxIdleConns bounds the pool across hosts; a Blockbook instance talks to one
-	// backend, so this only has to leave room for a redirected or fallback endpoint.
+	// Bounds the pool across hosts, leaving room for a second endpoint.
 	rpcMaxIdleConns = 200
 )
 
-// rpcHTTPClient is shared by all JSON-RPC dials of this process: net/http pools per
-// client, so a client per dial would defeat the reuse this exists for.
+// One client per process: net/http pools per client, so a client per dial would pool nothing.
 var rpcHTTPClient = newRPCHTTPClient()
 
 func newRPCHTTPClient() *http.Client {
-	// Clone keeps DefaultTransport's proxy, dial/TLS timeouts and HTTP/2 settings, which
-	// the CI runners need to reach backends through an egress proxy; only the pool grows.
+	// Clone keeps DefaultTransport's proxy, dial/TLS timeouts and HTTP/2; only the pool grows.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConns = rpcMaxIdleConns
 	transport.MaxIdleConnsPerHost = rpcMaxIdleConnsPerHost
-	// No client-level timeout on purpose: every call carries its own context deadline
-	// (rpc_timeout), and a blanket timeout would also cut long debug_traceBlockByHash reads.
+	// No client timeout: per-call rpc_timeout contexts govern, and a blanket one would cut
+	// long debug_traceBlockByHash reads.
 	return &http.Client{Transport: transport}
 }
 
-// RPCDialOptions returns the go-ethereum dial options for rawURL: the pooled HTTP client
-// for http(s) endpoints, and an unlimited message size for ws(s) ones, which hold a single
-// long-lived socket and so need no pooling. Shared by every EVM coin that dials a backend.
+// RPCDialOptions returns the dial options for rawURL, shared by every EVM coin: the pooled
+// client for http(s), and an unlimited message size for ws(s), which needs no pooling.
 func RPCDialOptions(rawURL string) []rpc.ClientOption {
 	if isWebsocketRPCURL(rawURL) {
 		return []rpc.ClientOption{rpc.WithWebsocketMessageSizeLimit(0)}
@@ -47,8 +38,8 @@ func RPCDialOptions(rawURL string) []rpc.ClientOption {
 	return []rpc.ClientOption{rpc.WithHTTPClient(rpcHTTPClient)}
 }
 
-// isWebsocketRPCURL reports whether rawURL is dialed as a websocket. An unparsable or
-// scheme-less URL falls through to the HTTP client, matching go-ethereum's own dispatch.
+// isWebsocketRPCURL reports whether rawURL is dialed as a websocket; an unparsable or
+// scheme-less URL falls through to HTTP, matching go-ethereum's own dispatch.
 func isWebsocketRPCURL(rawURL string) bool {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {

--- a/bchain/coins/eth/rpchttp.go
+++ b/bchain/coins/eth/rpchttp.go
@@ -1,0 +1,62 @@
+package eth
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const (
+	// rpcMaxIdleConnsPerHost sizes the keep-alive pool above the sync worker count
+	// (-workers, 16 on the fastest chains) plus mempool and API callers, so concurrent
+	// calls reuse sockets instead of dialing new ones. go-ethereum otherwise dials with
+	// http.DefaultTransport, whose http.DefaultMaxIdleConnsPerHost of 2 made every extra
+	// in-flight call close its socket: on a sub-second chain that burned ~340 ports/s into
+	// TIME_WAIT, exhausted the host's ephemeral range and failed dials with EADDRNOTAVAIL,
+	// which silently stalled sync (bitcoinrpc.go and tronhttp.go tune this for the same reason).
+	rpcMaxIdleConnsPerHost = 100
+	// rpcMaxIdleConns bounds the pool across hosts; a Blockbook instance talks to one
+	// backend, so this only has to leave room for a redirected or fallback endpoint.
+	rpcMaxIdleConns = 200
+)
+
+// rpcHTTPClient is shared by all JSON-RPC dials of this process: net/http pools per
+// client, so a client per dial would defeat the reuse this exists for.
+var rpcHTTPClient = newRPCHTTPClient()
+
+func newRPCHTTPClient() *http.Client {
+	// Clone keeps DefaultTransport's proxy, dial/TLS timeouts and HTTP/2 settings, which
+	// the CI runners need to reach backends through an egress proxy; only the pool grows.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = rpcMaxIdleConns
+	transport.MaxIdleConnsPerHost = rpcMaxIdleConnsPerHost
+	// No client-level timeout on purpose: every call carries its own context deadline
+	// (rpc_timeout), and a blanket timeout would also cut long debug_traceBlockByHash reads.
+	return &http.Client{Transport: transport}
+}
+
+// RPCDialOptions returns the go-ethereum dial options for rawURL: the pooled HTTP client
+// for http(s) endpoints, and an unlimited message size for ws(s) ones, which hold a single
+// long-lived socket and so need no pooling. Shared by every EVM coin that dials a backend.
+func RPCDialOptions(rawURL string) []rpc.ClientOption {
+	if isWebsocketRPCURL(rawURL) {
+		return []rpc.ClientOption{rpc.WithWebsocketMessageSizeLimit(0)}
+	}
+	return []rpc.ClientOption{rpc.WithHTTPClient(rpcHTTPClient)}
+}
+
+// isWebsocketRPCURL reports whether rawURL is dialed as a websocket. An unparsable or
+// scheme-less URL falls through to the HTTP client, matching go-ethereum's own dispatch.
+func isWebsocketRPCURL(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "ws", "wss":
+		return true
+	}
+	return false
+}

--- a/bchain/coins/eth/rpchttp_test.go
+++ b/bchain/coins/eth/rpchttp_test.go
@@ -1,0 +1,88 @@
+//go:build unittest
+
+package eth
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The pool sizing is the whole point of the client, and losing DefaultTransport's proxy
+// would break the CI runners that reach backends through an egress proxy.
+func TestNewRPCHTTPClientPoolsConnections(t *testing.T) {
+	client := newRPCHTTPClient()
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if transport.MaxIdleConnsPerHost != rpcMaxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", transport.MaxIdleConnsPerHost, rpcMaxIdleConnsPerHost)
+	}
+	if transport.MaxIdleConnsPerHost <= http.DefaultMaxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost = %d does not improve on the default %d",
+			transport.MaxIdleConnsPerHost, http.DefaultMaxIdleConnsPerHost)
+	}
+	if transport.MaxIdleConns != rpcMaxIdleConns {
+		t.Errorf("MaxIdleConns = %d, want %d", transport.MaxIdleConns, rpcMaxIdleConns)
+	}
+
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	if transport.Proxy == nil {
+		t.Error("Proxy must be inherited from DefaultTransport")
+	}
+	if transport.IdleConnTimeout != defaultTransport.IdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %s, want inherited %s", transport.IdleConnTimeout, defaultTransport.IdleConnTimeout)
+	}
+	if transport.TLSHandshakeTimeout != defaultTransport.TLSHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %s, want inherited %s", transport.TLSHandshakeTimeout, defaultTransport.TLSHandshakeTimeout)
+	}
+	// A blanket client timeout would cut long debug_traceBlockByHash reads that the
+	// per-call rpc_timeout context is meant to govern.
+	if client.Timeout != 0 {
+		t.Errorf("Timeout = %s, want 0 (per-call contexts govern)", client.Timeout)
+	}
+}
+
+// One client for the whole process: net/http pools per client, so a fresh client per
+// dial would reuse nothing.
+func TestRPCHTTPClientIsShared(t *testing.T) {
+	if rpcHTTPClient == nil {
+		t.Fatal("rpcHTTPClient must be initialized")
+	}
+	if rpcHTTPClient.Transport == http.DefaultTransport {
+		t.Error("rpcHTTPClient must not fall back to http.DefaultTransport")
+	}
+}
+
+func TestIsWebsocketRPCURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"ws://backend:8213", true},
+		{"wss://backend:8213", true},
+		{"WSS://backend:8213", true},
+		{"  ws://backend:8213  ", true},
+		{"http://backend:8313", false},
+		{"https://backend:8313", false},
+		{"HTTP://backend:8313", false},
+		{"backend:8313", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isWebsocketRPCURL(tt.url); got != tt.want {
+			t.Errorf("isWebsocketRPCURL(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+// Every dial must carry an option: an empty slice for the HTTP branch would silently
+// restore go-ethereum's unpooled default client.
+func TestRPCDialOptionsAlwaysConfigureTheDial(t *testing.T) {
+	for _, rawURL := range []string{"http://backend:8313", "https://backend:8313", "ws://backend:8213", "wss://backend:8213"} {
+		if got := len(RPCDialOptions(rawURL)); got != 1 {
+			t.Errorf("RPCDialOptions(%q) returned %d options, want 1", rawURL, got)
+		}
+	}
+}

--- a/bchain/coins/tron/tronrpc.go
+++ b/bchain/coins/tron/tronrpc.go
@@ -219,10 +219,7 @@ func resolveTronHTTPURL(explicitURL, rpcURL, defaultPort string) (string, error)
 
 // OpenRPC opens an RPC connection to the Tron backend (wsURL is unused – Tron has no WS subscriptions)
 var OpenRPC = func(url, _ string) (bchain.EVMRPCClient, bchain.EVMClient, error) {
-	opts := []rpc.ClientOption{}
-	opts = append(opts, rpc.WithWebsocketMessageSizeLimit(0))
-
-	r, err := rpc.DialOptions(context.Background(), url, opts...)
+	r, err := rpc.DialOptions(context.Background(), url, eth.RPCDialOptions(url)...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Problem

EVM dials passed no HTTP client to `rpc.DialOptions`, so go-ethereum falls back to `http.DefaultTransport` and its `DefaultMaxIdleConnsPerHost = 2`. With `-workers=16` and ~4 HTTP calls per block (`eth_getBlockByNumber` for the hash, `eth_getBlockByHash` full, `eth_getLogs`, `debug_traceBlockByHash`), a sub-second chain closes a socket per call instead of reusing one.

Observed on `blockbook-dev2` (robinhood_archive) while syncing at ~130 blk/s:

```
$ ss -tan | awk '$5 ~ /<backend>:8313/ {print $1}' | sort | uniq -c
     11 ESTAB
  20326 TIME-WAIT
```

≈340 new sockets/s against a 28,232-port default `ip_local_port_range`. On 2026-08-07 22:05 it tipped over and dials started failing:

```
getBlockWorker 3 connect block error eth_getLogs blockNumber 0x1d12843: Post "http://<backend>:8313":
dial tcp <ip>:8313: connect: cannot assign requested address. Exiting...
```

Sync then stayed dead for 10 days: every recovery path (the 15-min `syncIndexLoop` retry, the `tipWatchdog` tip poll, `reconnectRPC`) needs a new socket too, while the public API kept answering HTTP 200 from RocksDB, so nothing surfaced until a deploy restarted the process into an 8-day catch-up.

## Change

`eth.RPCDialOptions(rawURL)` becomes the single dial-option source for EVM coins:

- http(s) → one process-wide `*http.Client` cloned from `DefaultTransport` (keeps proxy, dial/TLS timeouts, HTTP/2) with `MaxIdleConnsPerHost = 100`, `MaxIdleConns = 200`, and no client-level timeout so per-call `rpc_timeout` contexts still govern long `debug_traceBlockByHash` reads
- ws(s) → the existing unlimited message size; a websocket holds one long-lived socket and needs no pooling

Applied to `eth.dialRPC`, both Avalanche dials (including the `/ext/info` client that used bare `rpc.DialHTTP`) and Tron's JSON-RPC dial. This mirrors what btc, nuls, dcr and the Tron REST client already do — each carrying the comment *"necessary to not to deplete ports"*. go-ethereum drains response bodies (`cleanlyCloseBody`), so the raised pool actually gets reuse.

## Trade-off

Keep-alive can hand a request to a connection the peer just closed. The common case is transparent: `net/http` retries when nothing was written and `GetBody` is set, which go-ethereum does set. A failure after bytes are written surfaces as a one-off `EOF`/reset that the sync loop already retries. In exchange, per-call TCP (and TLS, for cloud endpoints) handshakes disappear.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean
- new `bchain/coins/eth/rpchttp_test.go`: pool sizing, inherited proxy/timeouts, no client timeout, ws/http scheme dispatch
- eth (minus tests that bind a socket, which the local sandbox blocks with or without this change), tron and avalanche unit tests pass

After deploy, TIME-WAIT toward the backend port should drop to double digits with ~16 ESTAB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)