### PR TITLE
fix(api): serialize xpub cache updates to prevent data race

### DIFF
--- a/api/xpub.go
+++ b/api/xpub.go
@@ -431,6 +431,39 @@ func setIsOwnAddresses(txs []*Tx, xpubAddresses map[string]struct{}) {
 	}
 }
 
+// getXpubDataCached returns the published snapshot without taking the
+// per-descriptor lock when the request cannot mutate it: same tip, same gap,
+// nothing to load. Keeps warm reads of a hot descriptor parallel.
+func (w *Worker) getXpubDataCached(xd *bchain.XpubDescriptor, option AccountDetails, filter *AddressFilter, gap int) (*xpubData, uint32, bool) {
+	cachedXpubsMux.Lock()
+	data, inCache := cachedXpubs[xd.XpubDescriptor]
+	cachedXpubsMux.Unlock()
+	if !inCache || data.gap != gap {
+		return nil, 0, false
+	}
+	bestheight, besthash, err := w.db.GetBestBlock()
+	if err != nil || besthash != data.dataHash {
+		return nil, 0, false
+	}
+	if option >= AccountDetailsTxidHistory {
+		if xpubTxidLoadNeeded(&data) {
+			return nil, 0, false
+		}
+		if data.mergedTxids == nil && isUnfilteredXpubTxidFilter(filter) {
+			return nil, 0, false
+		}
+	}
+	// bump accessed so the evictor does not drop a hot entry served fast-path only
+	now := time.Now().Unix()
+	cachedXpubsMux.Lock()
+	if current, ok := cachedXpubs[xd.XpubDescriptor]; ok {
+		current.accessed = now
+		cachedXpubs[xd.XpubDescriptor] = current
+	}
+	cachedXpubsMux.Unlock()
+	return &data, bestheight, true
+}
+
 func (w *Worker) getXpubData(xd *bchain.XpubDescriptor, page int, txsOnPage int, option AccountDetails, filter *AddressFilter, gap int) (*xpubData, uint32, bool, error) {
 	if w.chainType != bchain.ChainBitcoinType {
 		return nil, 0, false, ErrUnsupportedXpub
@@ -450,6 +483,9 @@ func (w *Worker) getXpubData(xd *bchain.XpubDescriptor, page int, txsOnPage int,
 	gap++
 	if err := validateXpubScanLimits(xd, gap, w.xpubConfig.MaxAddressDerivations); err != nil {
 		return nil, 0, false, err
+	}
+	if data, bestheight, ok := w.getXpubDataCached(xd, option, filter, gap); ok {
+		return data, bestheight, true, nil
 	}
 	// Serialize updates for this descriptor; the expensive per-tx response
 	// building in the caller runs after this returns and stays concurrent.
@@ -492,13 +528,14 @@ func (w *Worker) getXpubData(xd *bchain.XpubDescriptor, page int, txsOnPage int,
 			}
 		}
 		processedHash = besthash
+		needsRescan := data.dataHeight < bestheight || fork
 		// Copy-on-write before any mutation so a concurrent reader holding the
 		// previously published snapshot never has its arrays changed underneath.
-		if !owned && (data.dataHeight < bestheight || fork || option >= AccountDetailsTxidHistory) {
+		if !owned && (needsRescan || (option >= AccountDetailsTxidHistory && xpubTxidLoadNeeded(&data))) {
 			data.addresses = cloneXpubAddresses(data.addresses)
 			owned = true
 		}
-		if data.dataHeight < bestheight || fork {
+		if needsRescan {
 			data.dataHeight = bestheight
 			data.dataHash = besthash
 			data.balanceSat = *new(big.Int)

--- a/api/xpub.go
+++ b/api/xpub.go
@@ -451,10 +451,16 @@ func (w *Worker) getXpubData(xd *bchain.XpubDescriptor, page int, txsOnPage int,
 	if err := validateXpubScanLimits(xd, gap, w.xpubConfig.MaxAddressDerivations); err != nil {
 		return nil, 0, false, err
 	}
+	// Serialize updates for this descriptor; the expensive per-tx response
+	// building in the caller runs after this returns and stays concurrent.
+	mu := xpubUpdateLock(xd.XpubDescriptor)
+	mu.Lock()
+	defer mu.Unlock()
 	var processedHash string
 	cachedXpubsMux.Lock()
 	data, inCache := cachedXpubs[xd.XpubDescriptor]
 	cachedXpubsMux.Unlock()
+	owned := !inCache // whether data.addresses is a private copy safe to mutate
 	// to load all data for xpub may take some time, do it in a loop to process a possible new block
 	for {
 		bestheight, besthash, err = w.db.GetBestBlock()
@@ -474,6 +480,7 @@ func (w *Worker) getXpubData(xd *bchain.XpubDescriptor, page int, txsOnPage int,
 			if err != nil {
 				return nil, 0, inCache, err
 			}
+			owned = true
 		} else {
 			hash, err := w.db.GetBlockHash(data.dataHeight)
 			if err != nil {
@@ -485,6 +492,12 @@ func (w *Worker) getXpubData(xd *bchain.XpubDescriptor, page int, txsOnPage int,
 			}
 		}
 		processedHash = besthash
+		// Copy-on-write before any mutation so a concurrent reader holding the
+		// previously published snapshot never has its arrays changed underneath.
+		if !owned && (data.dataHeight < bestheight || fork || option >= AccountDetailsTxidHistory) {
+			data.addresses = cloneXpubAddresses(data.addresses)
+			owned = true
+		}
 		if data.dataHeight < bestheight || fork {
 			data.dataHeight = bestheight
 			data.dataHash = besthash

--- a/api/xpub_cache.go
+++ b/api/xpub_cache.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"hash/fnv"
+	"sync"
+)
+
+// Serialize getXpubData per descriptor so concurrent requests for the same xpub
+// never mutate one shared cache entry; sharding keeps distinct xpubs parallel.
+const xpubUpdateShards = 256
+
+var xpubUpdateLocks [xpubUpdateShards]sync.Mutex
+
+func xpubUpdateLock(descriptor string) *sync.Mutex {
+	h := fnv.New32a()
+	h.Write([]byte(descriptor))
+	return &xpubUpdateLocks[h.Sum32()%xpubUpdateShards]
+}
+
+// Private copy of the address slices so the update phase leaves any previously
+// published snapshot immutable for concurrent readers. Shallow is enough: each
+// entry's txids/balance are only ever reassigned, never mutated in place.
+func cloneXpubAddresses(src [][]xpubAddress) [][]xpubAddress {
+	dst := make([][]xpubAddress, len(src))
+	for i, inner := range src {
+		cp := make([]xpubAddress, len(inner))
+		copy(cp, inner)
+		dst[i] = cp
+	}
+	return dst
+}

--- a/api/xpub_cache.go
+++ b/api/xpub_cache.go
@@ -17,6 +17,20 @@ func xpubUpdateLock(descriptor string) *sync.Mutex {
 	return &xpubUpdateLocks[h.Sum32()%xpubUpdateShards]
 }
 
+// xpubTxidLoadNeeded reports whether xpubCheckAndLoadTxids would mutate any
+// address, i.e. some used address has incomplete or stale txids.
+func xpubTxidLoadNeeded(data *xpubData) bool {
+	for _, da := range data.addresses {
+		for i := range da {
+			ad := &da[i]
+			if ad.balance != nil && (!ad.complete || ad.balance.Txs != ad.txs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Private copy of the address slices so the update phase leaves any previously
 // published snapshot immutable for concurrent readers. Shallow is enough: each
 // entry's txids/balance are only ever reassigned, never mutated in place.

--- a/api/xpub_race_test.go
+++ b/api/xpub_race_test.go
@@ -1,0 +1,164 @@
+//go:build unittest
+
+package api
+
+import (
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/trezor/blockbook/bchain/coins/btc"
+	"github.com/trezor/blockbook/common"
+	"github.com/trezor/blockbook/db"
+	"github.com/trezor/blockbook/tests/dbtestdata"
+)
+
+// setupXpubRaceWorker builds a Bitcoin-type worker backed by the shared test
+// fixtures (two connected blocks) so getXpubData exercises the real cache path.
+func setupXpubRaceWorker(t *testing.T) (*Worker, func()) {
+	t.Helper()
+	parser := btc.NewBitcoinParser(
+		btc.GetChainParams("test"),
+		&btc.Configuration{
+			BlockAddressesToKeep:  1,
+			XPubMagic:             70617039,
+			XPubMagicSegwitP2sh:   71979618,
+			XPubMagicSegwitNative: 73342198,
+			Slip44:                1,
+		})
+	chain, err := dbtestdata.NewFakeBlockChain(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp, err := os.MkdirTemp("", "xpubracedb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.NewRocksDB(tmp, 100000, -1, parser, nil, false)
+	if err != nil {
+		os.RemoveAll(tmp)
+		t.Fatal(err)
+	}
+	is, err := d.LoadInternalState(&common.Config{CoinName: "coin-unittest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.SetInternalState(is)
+	block1 := dbtestdata.GetTestBitcoinTypeBlock1(parser)
+	for i := uint32(0); i < block1.Height; i++ {
+		is.BlockTimes = append(is.BlockTimes, 0)
+	}
+	if err := d.ConnectBlock(block1); err != nil {
+		t.Fatal(err)
+	}
+	block2 := dbtestdata.GetTestBitcoinTypeBlock2(parser)
+	if err := d.ConnectBlock(block2); err != nil {
+		t.Fatal(err)
+	}
+	is.FinishedSync(block2.Height)
+
+	metrics, err := common.GetMetrics("Fakecoin-xpubrace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mempool, err := chain.CreateMempool(chain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txCache, err := db.NewTxCache(d, chain, metrics, is, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, err := NewWorker(d, chain, mempool, txCache, metrics, is, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w, func() {
+		d.Close()
+		os.RemoveAll(tmp)
+	}
+}
+
+func resetXpubCache() {
+	cachedXpubsMux.Lock()
+	cachedXpubs = nil
+	cachedXpubsMux.Unlock()
+}
+
+// TestGetXpubAddressConcurrent verifies that concurrent requests for the same
+// descriptor do not race on the shared cache entry and all observe the same
+// txid history. Run with -race: before the copy-on-write / per-descriptor lock
+// fix, the concurrent first-time txid load reported write/write and read/write
+// data races in getXpubData.
+func TestGetXpubAddressConcurrent(t *testing.T) {
+	// the race only manifests with real parallelism; ensure it regardless of
+	// the runner's default GOMAXPROCS.
+	if runtime.GOMAXPROCS(0) < 4 {
+		defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
+	}
+
+	w, cleanup := setupXpubRaceWorker(t)
+	defer cleanup()
+
+	const gap = 1000
+	filter := &AddressFilter{Vout: AddressFilterVoutOff}
+
+	// clean sequential baseline (fully populates then reads the cache)
+	resetXpubCache()
+	base, err := w.GetXpubAddress(dbtestdata.Xpub, 1, 25, AccountDetailsTxidHistory, filter, gap, "")
+	if err != nil {
+		t.Fatalf("baseline GetXpubAddress: %v", err)
+	}
+	if base.Txs == 0 || len(base.Txids) == 0 {
+		t.Fatalf("baseline has no txids (Txs=%d, txids=%d); fixture/derivation changed", base.Txs, len(base.Txids))
+	}
+
+	const (
+		workers = 16
+		rounds  = 8
+	)
+	for r := 0; r < rounds; r++ {
+		// reset and warm only with a basic call: addresses get scanned but txids
+		// are not loaded, so the burst below all races to load them for the first
+		// time.
+		resetXpubCache()
+		if _, err := w.GetXpubAddress(dbtestdata.Xpub, 1, 25, AccountDetailsBasic, filter, gap, ""); err != nil {
+			t.Fatalf("round %d warmup: %v", r, err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		results := make([]*Address, workers)
+		errs := make([]error, workers)
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				results[idx], errs[idx] = w.GetXpubAddress(dbtestdata.Xpub, 1, 25, AccountDetailsTxidHistory, filter, gap, "")
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		for i := 0; i < workers; i++ {
+			if errs[i] != nil {
+				t.Fatalf("round %d worker %d: %v", r, i, errs[i])
+			}
+			got := results[i]
+			if got.Txs != base.Txs {
+				t.Errorf("round %d worker %d: Txs=%d, want %d", r, i, got.Txs, base.Txs)
+			}
+			if len(got.Txids) != len(base.Txids) {
+				t.Errorf("round %d worker %d: %d txids, want %d", r, i, len(got.Txids), len(base.Txids))
+				continue
+			}
+			for j := range got.Txids {
+				if got.Txids[j] != base.Txids[j] {
+					t.Errorf("round %d worker %d txid %d: %s, want %s", r, i, j, got.Txids[j], base.Txids[j])
+				}
+			}
+		}
+	}
+}

--- a/api/xpub_race_test.go
+++ b/api/xpub_race_test.go
@@ -3,7 +3,6 @@
 package api
 
 import (
-	"os"
 	"runtime"
 	"sync"
 	"testing"
@@ -16,7 +15,7 @@ import (
 
 // setupXpubRaceWorker builds a Bitcoin-type worker backed by the shared test
 // fixtures (two connected blocks) so getXpubData exercises the real cache path.
-func setupXpubRaceWorker(t *testing.T) (*Worker, func()) {
+func setupXpubRaceWorker(t *testing.T) *Worker {
 	t.Helper()
 	parser := btc.NewBitcoinParser(
 		btc.GetChainParams("test"),
@@ -31,15 +30,11 @@ func setupXpubRaceWorker(t *testing.T) (*Worker, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmp, err := os.MkdirTemp("", "xpubracedb")
+	d, err := db.NewRocksDB(t.TempDir(), 100000, -1, parser, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, err := db.NewRocksDB(tmp, 100000, -1, parser, nil, false)
-	if err != nil {
-		os.RemoveAll(tmp)
-		t.Fatal(err)
-	}
+	t.Cleanup(func() { d.Close() })
 	is, err := d.LoadInternalState(&common.Config{CoinName: "coin-unittest"})
 	if err != nil {
 		t.Fatal(err)
@@ -74,15 +69,12 @@ func setupXpubRaceWorker(t *testing.T) (*Worker, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return w, func() {
-		d.Close()
-		os.RemoveAll(tmp)
-	}
+	return w
 }
 
 func resetXpubCache() {
 	cachedXpubsMux.Lock()
-	cachedXpubs = nil
+	cachedXpubs = make(map[string]xpubData)
 	cachedXpubsMux.Unlock()
 }
 
@@ -98,8 +90,7 @@ func TestGetXpubAddressConcurrent(t *testing.T) {
 		defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
 	}
 
-	w, cleanup := setupXpubRaceWorker(t)
-	defer cleanup()
+	w := setupXpubRaceWorker(t)
 
 	const gap = 1000
 	filter := &AddressFilter{Vout: AddressFilterVoutOff}


### PR DESCRIPTION
## Problem

The process-wide xpub cache (`cachedXpubs`) stores `xpubData` **by value**, but the value's `addresses [][]xpubAddress` backing arrays are shared. On a cache hit the value is copied out under `cachedXpubsMux`, then the request mutates those shared arrays **outside the lock** (the scan reassigns `data.addresses[i]`, and `xpubCheckAndLoadTxids(&da[i], …)` does a read-modify-write on the per-address struct).

Two concurrent `getAccountInfo` requests with `details >= txids` for the **same descriptor** therefore race. Across a block connect, a straggler can overwrite fresher data, leaving the cached account **missing its newest confirmed txid** with a matching (too-low) `txs` count and a correct balance — a self-consistent but incomplete history served for ~1 block interval. Reachable unauthenticated via `GET /api/v2/xpub/<descriptor>` and WebSocket `getAccountInfo`.

## Fix

- **Per-descriptor serialization**: a 256-way sharded lock around `getXpubData`'s compute/update, so same-descriptor requests can't mutate one cache entry concurrently. Distinct descriptors stay fully parallel, and the caller's expensive per-tx response building runs after `getXpubData` returns, so it stays concurrent.
- **Copy-on-write**: clone the address slices before any mutation, so every published cache entry is an immutable, coherent snapshot and a reader holding a previous snapshot never has its arrays changed underneath.

## Test

`api/xpub_race_test.go` fires concurrent same-xpub `txids` requests over the existing fixtures. It passes under `-race` with the fix; reverting just `xpub.go` reproduces the write/write and read/write races (at `xpub.go:297`/`278`, matching the report).

Note: CI does not currently run `-race`; adding one `-tags 'unittest' -race` job would guard this class going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)