### PR TITLE
fix(api): match the outpoint when resolving a spending transaction

### DIFF
--- a/api/spending_txid_test.go
+++ b/api/spending_txid_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
+	"github.com/trezor/blockbook/common"
+	"github.com/trezor/blockbook/db"
+	"github.com/trezor/blockbook/tests/dbtestdata"
+)
+
+// setupSpendingWorker builds a worker over the two-block Fakecoin fixture. The
+// fixture already contains the shape this test needs: TxidB1T1 pays the same
+// SatB1T1A2 to Addr2 twice (vout 1 and vout 2) and only vout 1 is ever spent.
+func setupSpendingWorker(t *testing.T, extendedIndex bool) (*Worker, func()) {
+	t.Helper()
+	parser := btc.NewBitcoinParser(
+		btc.GetChainParams("test"),
+		&btc.Configuration{
+			BlockAddressesToKeep:  1,
+			XPubMagic:             70617039,
+			XPubMagicSegwitP2sh:   71979618,
+			XPubMagicSegwitNative: 73342198,
+			Slip44:                1,
+		})
+	chain, err := dbtestdata.NewFakeBlockChain(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp, err := os.MkdirTemp("", "testdb-spending")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.NewRocksDB(tmp, 100000, -1, parser, nil, extendedIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup := func() {
+		d.Close()
+		os.RemoveAll(tmp)
+	}
+	config := &common.Config{CoinName: "Fakecoin", CoinShortcut: "FAKE"}
+	is, err := d.LoadInternalState(config)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	d.SetInternalState(is)
+
+	bestHeight, err := chain.GetBestBlockHeight()
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	block1, err := chain.GetBlock("", bestHeight-1)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	for i := uint32(0); i < block1.Height; i++ {
+		is.BlockTimes = append(is.BlockTimes, 0)
+	}
+	if err := d.ConnectBlock(block1); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	block2, err := chain.GetBlock("", bestHeight)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := d.ConnectBlock(block2); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	is.FinishedSync(block2.Height)
+
+	// the tx cache dereferences metrics unconditionally, so they must be real;
+	// the name must be unique or the prometheus registration collides
+	m, err := common.GetMetrics("Fakecoin-api-spending-" + t.Name())
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	// caching disabled, as in server/public_test.go: the fixture txs carry no Hex,
+	// which BitcoinLikeParser.PackTx needs, so a cached tx cannot be read back
+	txCache, err := db.NewTxCache(d, chain, m, is, false)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	w, err := NewWorker(d, chain, bchain.NewMempoolBitcoinType(chain, 1, 1, 0, "", false, 1), txCache, m, is, nil)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	return w, cleanup
+}
+
+// TestGetSpendingTxid covers trezor/blockbook#1029: an output must not inherit
+// the spender of a sibling output that happens to share its address and value.
+func TestGetSpendingTxid(t *testing.T) {
+	for _, extendedIndex := range []bool{false, true} {
+		name := "legacyIndex"
+		if extendedIndex {
+			name = "extendedIndex"
+		}
+		t.Run(name, func(t *testing.T) {
+			w, cleanup := setupSpendingWorker(t, extendedIndex)
+			defer cleanup()
+
+			tests := []struct {
+				name string
+				txid string
+				n    int
+				want string
+			}{
+				{
+					// spent by TxidB2T1 input 1
+					name: "spent output resolves to its spender",
+					txid: dbtestdata.TxidB1T1,
+					n:    1,
+					want: dbtestdata.TxidB2T1,
+				},
+				{
+					// same address and same value as vout 1, but unspent: the
+					// address+value scan used to match TxidB2T1 here
+					name: "unspent sibling of a spent output is not spent",
+					txid: dbtestdata.TxidB1T1,
+					n:    2,
+					want: "",
+				},
+				{
+					name: "unspent output of another tx is not spent",
+					txid: dbtestdata.TxidB1T1,
+					n:    0,
+					want: "",
+				},
+			}
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					got, err := w.GetSpendingTxid(tt.txid, tt.n)
+					if err != nil {
+						t.Fatalf("GetSpendingTxid(%s, %d) error %v", tt.txid, tt.n, err)
+					}
+					if got != tt.want {
+						t.Errorf("GetSpendingTxid(%s, %d) = %q, want %q", tt.txid, tt.n, got, tt.want)
+					}
+				})
+			}
+
+			if _, err := w.GetSpendingTxid(dbtestdata.TxidB1T1, 99); err == nil {
+				t.Error("GetSpendingTxid with out-of-range vout: expected an error")
+			}
+		})
+	}
+}

--- a/api/spending_txid_test.go
+++ b/api/spending_txid_test.go
@@ -1,10 +1,10 @@
+//go:build unittest
+
 package api
 
 import (
-	"os"
 	"testing"
 
-	"github.com/trezor/blockbook/bchain"
 	"github.com/trezor/blockbook/bchain/coins/btc"
 	"github.com/trezor/blockbook/common"
 	"github.com/trezor/blockbook/db"
@@ -14,7 +14,7 @@ import (
 // setupSpendingWorker builds a worker over the two-block Fakecoin fixture. The
 // fixture already contains the shape this test needs: TxidB1T1 pays the same
 // SatB1T1A2 to Addr2 twice (vout 1 and vout 2) and only vout 1 is ever spent.
-func setupSpendingWorker(t *testing.T, extendedIndex bool) (*Worker, func()) {
+func setupSpendingWorker(t *testing.T, extendedIndex bool) *Worker {
 	t.Helper()
 	parser := btc.NewBitcoinParser(
 		btc.GetChainParams("test"),
@@ -29,74 +29,42 @@ func setupSpendingWorker(t *testing.T, extendedIndex bool) (*Worker, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmp, err := os.MkdirTemp("", "testdb-spending")
+	d, err := db.NewRocksDB(t.TempDir(), 100000, -1, parser, nil, extendedIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, err := db.NewRocksDB(tmp, 100000, -1, parser, nil, extendedIndex)
+	t.Cleanup(func() { d.Close() })
+	is, err := d.LoadInternalState(&common.Config{CoinName: "Fakecoin", CoinShortcut: "FAKE"})
 	if err != nil {
-		t.Fatal(err)
-	}
-	cleanup := func() {
-		d.Close()
-		os.RemoveAll(tmp)
-	}
-	config := &common.Config{CoinName: "Fakecoin", CoinShortcut: "FAKE"}
-	is, err := d.LoadInternalState(config)
-	if err != nil {
-		cleanup()
 		t.Fatal(err)
 	}
 	d.SetInternalState(is)
 
-	bestHeight, err := chain.GetBestBlockHeight()
-	if err != nil {
-		cleanup()
-		t.Fatal(err)
-	}
-	block1, err := chain.GetBlock("", bestHeight-1)
-	if err != nil {
-		cleanup()
-		t.Fatal(err)
-	}
-	for i := uint32(0); i < block1.Height; i++ {
-		is.BlockTimes = append(is.BlockTimes, 0)
-	}
+	block1 := dbtestdata.GetTestBitcoinTypeBlock1(parser)
+	block2 := dbtestdata.GetTestBitcoinTypeBlock2(parser)
+	// BlockTimes is indexed by height, so pad up to the first fixture block
+	is.BlockTimes = make([]uint32, block1.Height)
 	if err := d.ConnectBlock(block1); err != nil {
-		cleanup()
-		t.Fatal(err)
-	}
-	block2, err := chain.GetBlock("", bestHeight)
-	if err != nil {
-		cleanup()
 		t.Fatal(err)
 	}
 	if err := d.ConnectBlock(block2); err != nil {
-		cleanup()
 		t.Fatal(err)
 	}
 	is.FinishedSync(block2.Height)
 
-	// the tx cache dereferences metrics unconditionally, so they must be real;
-	// the name must be unique or the prometheus registration collides
-	m, err := common.GetMetrics("Fakecoin-api-spending-" + t.Name())
-	if err != nil {
-		cleanup()
-		t.Fatal(err)
-	}
+	m := newRefreshTestMetrics(t)
 	// caching disabled, as in server/public_test.go: the fixture txs carry no Hex,
 	// which BitcoinLikeParser.PackTx needs, so a cached tx cannot be read back
 	txCache, err := db.NewTxCache(d, chain, m, is, false)
 	if err != nil {
-		cleanup()
 		t.Fatal(err)
 	}
-	w, err := NewWorker(d, chain, bchain.NewMempoolBitcoinType(chain, 1, 1, 0, "", false, 1), txCache, m, is, nil)
+	// nil mempool: GetSpendingTxid never touches it for confirmed transactions
+	w, err := NewWorker(d, chain, nil, txCache, m, is, nil)
 	if err != nil {
-		cleanup()
 		t.Fatal(err)
 	}
-	return w, cleanup
+	return w
 }
 
 // TestGetSpendingTxid covers trezor/blockbook#1029: an output must not inherit
@@ -108,8 +76,7 @@ func TestGetSpendingTxid(t *testing.T) {
 			name = "extendedIndex"
 		}
 		t.Run(name, func(t *testing.T) {
-			w, cleanup := setupSpendingWorker(t, extendedIndex)
-			defer cleanup()
+			w := setupSpendingWorker(t, extendedIndex)
 
 			tests := []struct {
 				name string
@@ -132,12 +99,6 @@ func TestGetSpendingTxid(t *testing.T) {
 					n:    2,
 					want: "",
 				},
-				{
-					name: "unspent output of another tx is not spent",
-					txid: dbtestdata.TxidB1T1,
-					n:    0,
-					want: "",
-				},
 			}
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
@@ -151,9 +112,21 @@ func TestGetSpendingTxid(t *testing.T) {
 				})
 			}
 
-			if _, err := w.GetSpendingTxid(dbtestdata.TxidB1T1, 99); err == nil {
-				t.Error("GetSpendingTxid with out-of-range vout: expected an error")
-			}
+			// bypass the unspent guard in GetSpendingTxid to pin the outpoint match
+			// itself: TxidB2T1's input matches vout 2 on txid, address and value, and
+			// only its outpoint (vout 1) tells the two sibling outputs apart
+			t.Run("scan rejects a candidate spending a sibling outpoint", func(t *testing.T) {
+				tx, err := w.getTransaction(dbtestdata.TxidB1T1, false, false, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := w.setSpendingTxToVout(&tx.Vout[2], tx.Txid, uint32(tx.Blockheight)); err != nil {
+					t.Fatal(err)
+				}
+				if tx.Vout[2].SpentTxID != "" {
+					t.Errorf("setSpendingTxToVout matched %q for unspent vout 2, want no match", tx.Vout[2].SpentTxID)
+				}
+			})
 		})
 	}
 }

--- a/api/worker.go
+++ b/api/worker.go
@@ -112,7 +112,9 @@ func (w *Worker) setSpendingTxToVout(vout *Vout, txid string, height uint32) err
 							glog.Warning("Tx ", t, ": not found")
 						} else {
 							if len(spentTx.Vin) > int(index) {
-								if spentTx.Vin[index].Txid == txid {
+								// the outpoint must match, not just the tx: sibling outputs
+								// sharing this address and value would match on txid alone
+								if spentTx.Vin[index].Txid == txid && spentTx.Vin[index].Vout == uint32(vout.N) {
 									vout.SpentTxID = t
 									vout.SpentHeight = int(spentHeight)
 									vout.SpentIndex = int(index)
@@ -151,6 +153,11 @@ func (w *Worker) GetSpendingTxid(txid string, n int) (string, error) {
 	}
 	if n >= len(tx.Vout) || n < 0 {
 		return "", NewAPIError(fmt.Sprintf("Passed incorrect vout index %v for tx %v, len vout %v", n, tx.Txid, len(tx.Vout)), false)
+	}
+	// an unspent output has no spender, and the scan below has no early exit for
+	// that case - it would walk the address index all the way to the chain tip
+	if !tx.Vout[n].Spent {
+		return "", nil
 	}
 	err = w.setSpendingTxToVout(&tx.Vout[n], tx.Txid, uint32(tx.Blockheight))
 	if err != nil {


### PR DESCRIPTION
Fixes #1029.

## Problem

Without `-extendedindex` there is no direct output → spender index, so `setSpendingTxToVout` finds the spender by walking the address index and matching on address, value and spending txid. It never checked *which* output the candidate input references.

So when one transaction pays the same value to the same address more than once, every one of those outputs resolves to whichever spender is found first. `/spending/:txid/:n` redirects to a transaction that does not spend that output, `spentTxId` on `/api/v2/tx/:txid?spending=true` names the wrong transaction, and `spentIndex` is equally arbitrary.

Reproduced on a public instance: LTC `d4864ba920c13213ac966b6cefc39021d2668d11d7e242e6c10e159ac5ebceeb` pays 800 LTC to `LMXrCNv5EmEpGNxXLJxq6KSoNzNRnRAQz7` at both vout 0 and vout 1. Both resolved to `0cdb7e5ffa9e8b6790762f9e28e53a853b296b381ddf62585c7a516fa6ed823e`, which has a single input and spends vout 0 only.

## Changes

- Require the candidate input to reference this vout, not just this transaction. This also fixes `spentIndex`, since the matched `index` is then really the input that spent this output.
- Return early from `GetSpendingTxid` for an unspent output. It has no spender and the scan has no early exit for that case, so it would walk the address index to the chain tip — and the change above removes the accidental early termination that a false match used to provide. `GetTransactionFromBchainTx` already guards the same call this way.

## Scope

Instances built with `-extendedindex` read the exact per-output `SpentTxid` and were never affected. The per-output `spent` flag is written by exact vout index and was always correct, so this never affected balances or UTXO selection — only which spender was named.

## Test

`api/spending_txid_test.go` runs against both index modes. The existing Fakecoin fixture already had the required shape: `TxidB1T1` pays `SatB1T1A2` to `Addr2` at both vout 1 and vout 2, and only vout 1 is spent. Before the change:

```
--- FAIL: TestGetSpendingTxid/legacyIndex/unspent_sibling_of_a_spent_output_is_not_spent
    GetSpendingTxid(00b2c060...3840, 2) = "7c3be240...9d25", want ""
```

After: pass. Every `extendedIndex` subtest passed both before and after, confirming the fault was isolated to the legacy path.

The test lives in `api` rather than `server` because it exercises the worker directly, and its tx cache is constructed with caching disabled, mirroring `server/public_test.go` — the fixture transactions carry no `Hex`, which `BitcoinLikeParser.PackTx` needs.

## Note for reviewers

Not changed here: `explorerSpendingTx` (`server/public.go`) shadows `err` with `spendingTx, err := s.api.GetSpendingTxid(...)`, so genuine errors from that call are discarded and always reported as "Transaction not found". Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)