### PR TITLE
fix(signet): decode base58 addresses on signet

### DIFF
--- a/bchain/coins/btc/bitcoinparser.go
+++ b/bchain/coins/btc/bitcoinparser.go
@@ -19,11 +19,17 @@ const (
 // chain parameters
 var (
 	TestNet4Params chaincfg.Params
+	SigNetParams   chaincfg.Params
 )
 
 func init() {
 	TestNet4Params = chaincfg.TestNet3Params
 	TestNet4Params.Net = Testnet4Magic
+
+	// chaincfg builds signet params from a challenge and leaves AddressMagicLen
+	// zero, which makes base58 address decoding fail on the version byte.
+	SigNetParams = chaincfg.SigNetParams
+	SigNetParams.AddressMagicLen = 1
 }
 
 // BitcoinParser handle
@@ -55,7 +61,7 @@ func GetChainParams(chain string) *chaincfg.Params {
 	case "regtest":
 		return &chaincfg.RegressionNetParams
 	case "signet":
-		return &chaincfg.SigNetParams
+		return &SigNetParams
 	}
 	return &chaincfg.MainNetParams
 }

--- a/bchain/coins/btc/bitcoinparser_test.go
+++ b/bchain/coins/btc/bitcoinparser_test.go
@@ -165,6 +165,66 @@ func TestGetAddrDescFromAddressTestnet(t *testing.T) {
 	}
 }
 
+// signet shares the testnet address magics, so the same vectors must decode there
+func TestGetAddrDescFromAddressSignet(t *testing.T) {
+	type args struct {
+		address string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "pubkeyhash",
+			args:    args{address: "mtkbaiLiUH3fvGJeSzuN3kUgmJzqinLejJ"},
+			want:    "76a914912e2b234f941f30b18afbb4fa46171214bf66c888ac",
+			wantErr: false,
+		},
+		{
+			name:    "scripthash",
+			args:    args{address: "2Mv28xcUJdFXBTfGMtja6fVBMCEbsH3r2AW"},
+			want:    "a9141e6ec5a1d12912b396d77d98dcb000e91f517fa487",
+			wantErr: false,
+		},
+		{
+			// address from https://github.com/trezor/blockbook/issues/1305
+			name:    "scripthash_p2wpkh",
+			args:    args{address: "2MzoQhv5qzNFybSnMMN6uuueywkRV64Kirj"},
+			want:    "a91452df2355d174c913bccbf6319335d29b5a1d17d487",
+			wantErr: false,
+		},
+		{
+			name:    "witness_v0_keyhash",
+			args:    args{address: "tb1qupjdck20as3y4l95cd5wepkv0grcz0p7d8rd5s"},
+			want:    "0014e064dc594fec224afcb4c368ec86cc7a07813c3e",
+			wantErr: false,
+		},
+		{
+			name:    "witness_v1_taproot",
+			args:    args{address: "tb1pqsv2qyp8hsma46422ecfd3ek02jayumkkzjx7vkf3cqpmfd4ucpsx0cc9h"},
+			want:    "51200418a01027bc37daeaaa567096c7367aa5d27376b0a46f32c98e001da5b5e603",
+			wantErr: false,
+		},
+	}
+	parser := NewBitcoinParser(GetChainParams("signet"), &Configuration{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.GetAddrDescFromAddress(tt.args.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddrDescFromAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			h := hex.EncodeToString(got)
+			if !reflect.DeepEqual(h, tt.want) {
+				t.Errorf("GetAddrDescFromAddress() = %v, want %v", h, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetAddrDescFromVout(t *testing.T) {
 	type args struct {
 		vout bchain.Vout

--- a/bchain/coins/grs/grsparser.go
+++ b/bchain/coins/grs/grsparser.go
@@ -56,6 +56,8 @@ func init() {
 	SigNetParams.Net = SignetMagic
 
 	// Address encoding magics
+	// chaincfg leaves AddressMagicLen zero in signet params, which breaks base58 decoding
+	SigNetParams.AddressMagicLen = 1
 	SigNetParams.PubKeyHashAddrID = []byte{111}
 	SigNetParams.ScriptHashAddrID = []byte{196}
 	SigNetParams.Bech32HRPSegwit = "tgrs"

--- a/bchain/coins/grs/grsparser_test.go
+++ b/bchain/coins/grs/grsparser_test.go
@@ -123,6 +123,14 @@ func TestGetAddrDesc(t *testing.T) {
 				parser: NewGroestlcoinParser(GetChainParams("test"), &btc.Configuration{}),
 			},
 		},
+		{
+			// signet shares the testnet address magics, so the same vectors must decode there
+			name: "grs-signet",
+			args: args{
+				tx:     testTx2,
+				parser: NewGroestlcoinParser(GetChainParams("signet"), &btc.Configuration{}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1305.

`chaincfg.SigNetParams` is built by `CustomSignetParams`, which never sets `AddressMagicLen`. With the zero value, `btcutil.DecodeAddress` doesn't strip the version byte, so the decoded payload is 21 bytes instead of 20 and every base58 address fails with `decoded address is of unknown size`. Bech32 addresses were unaffected — they take a separate code path — which is why the explorer rendered signet addresses in transaction detail but errored when you clicked one.

Both signet configs were affected (`bitcoin_signet`, `groestlcoin_signet`); no other coin is, since every other params struct inherits or explicitly sets the field.

## Changes

- `btc`: package-level `SigNetParams` copy with `AddressMagicLen = 1`, following the existing `TestNet4Params` pattern
- `grs`: same one-liner in the existing signet address-magics block

## Tests

- `TestGetAddrDescFromAddressSignet` — P2PKH, P2SH (including `2MzoQhv5qzNFybSnMMN6uuueywkRV64Kirj` from the issue), and bech32 v0/v1 as controls
- `grs-signet` case in `TestGetAddrDesc` — base58 P2SH and `tgrs1` bech32 round-trip

Both fail without the fix and pass with it. Decoding only — address encoding and the on-disk index format are unchanged, so no reindex is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)