### PR TITLE
chore(hoodi): bump prysm 7.1.0 -> 7.1.8

### DIFF
--- a/configs/coins/ethereum_testnet_hoodi_archive_consensus.json
+++ b/configs/coins/ethereum_testnet_hoodi_archive_consensus.json
@@ -24,10 +24,10 @@
         "package_name": "backend-ethereum-testnet-hoodi-archive-consensus",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "7.1.0",
-        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.0/beacon-chain-v7.1.0-linux-amd64",
+        "version": "7.1.8",
+        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-amd64",
         "verification_type": "sha256",
-        "verification_source": "a5402ea516d055f8ce150fff2ab4b73adbd8213789789e74c0e0a33eed3397ce",
+        "verification_source": "16c701e32bd27d7f0bdf43160318ef75844da9137667c28748c44f266ed13be7",
         "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --hoodi --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17526 --rpc-port=17527 --monitoring-port=17528 --p2p-tcp-port=13626 --p2p-udp-port=12626 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_hoodi_archive/backend/erigon/jwt.hex --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
@@ -41,8 +41,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.0/beacon-chain-v7.1.0-linux-arm64",
-                "verification_source": "afc18b5d0810ec6ba716bfc41b7bd574962214688be4ab71afac91d03d46826c"
+                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-arm64",
+                "verification_source": "f806344e07dd44c5266cb536bf5ca7e87a749a3c0d531c4201c4896cdfe970f7"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_hoodi_consensus.json
+++ b/configs/coins/ethereum_testnet_hoodi_consensus.json
@@ -24,10 +24,10 @@
         "package_name": "backend-ethereum-testnet-hoodi-consensus",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "7.1.0",
-        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.0/beacon-chain-v7.1.0-linux-amd64",
+        "version": "7.1.8",
+        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-amd64",
         "verification_type": "sha256",
-        "verification_source": "a5402ea516d055f8ce150fff2ab4b73adbd8213789789e74c0e0a33eed3397ce",
+        "verification_source": "16c701e32bd27d7f0bdf43160318ef75844da9137667c28748c44f266ed13be7",
         "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --hoodi --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17506 --rpc-port=17507 --monitoring-port=17508 --p2p-tcp-port=13506 --p2p-udp-port=12506 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_hoodi/backend/erigon/jwt.hex --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
@@ -41,8 +41,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.0/beacon-chain-v7.1.0-linux-arm64",
-                "verification_source": "afc18b5d0810ec6ba716bfc41b7bd574962214688be4ab71afac91d03d46826c"
+                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-arm64",
+                "verification_source": "f806344e07dd44c5266cb536bf5ca7e87a749a3c0d531c4201c4896cdfe970f7"
             }
         }
     },


### PR DESCRIPTION
Hoodi's beacon node cannot hold chain tip. Observed live on `hoodi.trezor.io` (archive instance, `Prysm/v7.1.0`): the backend freezes for minutes, then bursts to catch up, then freezes again — 11:28 frozen 55 s, 11:56–12:02 frozen 11 min behind with `inSync: false`, 12:19 back to 82 s behind after importing 60 blocks in ~3 min.

Erigon is not at fault. Its log shows only `[WARN] flag --externalcl was provided, but no CL requests to engine-api in 1m41s`, with 21 peers, `[Downloader] Idle 100%` and a txpool committing fresh transactions — i.e. it is idle waiting for `engine_forkchoiceUpdated`, which arrives every 1.5–2.5 min instead of once per 12 s slot.

Cause: Prysm ≤ 7.1.1 re-processes enqueued aggregated attestations for every block once it falls out of sync (~10 s each, over the 12 s slot budget), so it can never close a gap once one opens — https://github.com/OffchainLabs/prysm/issues/16160, fixed in 7.1.2 (PR 16153), with further catch-up and gossip fixes in 7.1.6–7.1.8. Mainnet and Sepolia were moved to 7.1.3 in ba7099ee / cafcadaf; Hoodi was left on 7.1.0.

Both checksums were verified by downloading the release binaries, not only the published `.sha256` files, and `go run build/templates/generate.go ethereum_testnet_hoodi_consensus` emits `backend (7.1.8-satoshilabs-1)`.

Deploy note: restarting Prysm 7.1.0 does not help — a restart lands it in the "synced to finalized, not to head" state, which is the trigger. If the upgraded node still cannot close the existing gap, wipe the beacon datadir and checkpoint-sync.

Follow-up worth queuing separately: mainnet and Sepolia are on 7.1.3 (March). They are past the #16160 fix, so not exposed to this, but 7.1.7's unknown-parent-recovery and 7.1.8's libp2p propagation fixes matter for any node that falls behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)