### PR TITLE
chore(eth,sepolia): bump prysm 7.1.3 -> 7.1.8

### DIFF
--- a/configs/coins/ethereum_archive_consensus.json
+++ b/configs/coins/ethereum_archive_consensus.json
@@ -19,10 +19,10 @@
         "package_name": "backend-ethereum-archive-consensus",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "7.1.3",
-        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-amd64",
+        "version": "7.1.8",
+        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-amd64",
         "verification_type": "sha256",
-        "verification_source": "6efcd238124e000783f55a4430f0962b324a32599cf33219415f7f6dece8363f",
+        "verification_source": "16c701e32bd27d7f0bdf43160318ef75844da9137667c28748c44f266ed13be7",
         "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --mainnet --accept-terms-of-use --semi-supernode --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=7516 --rpc-port=7517 --monitoring-port=7518 --p2p-tcp-port=3516 --p2p-udp-port=2516 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_archive/backend/erigon/jwt.hex 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
@@ -36,8 +36,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-arm64",
-                "verification_source": "23ec40327ac81925dace24cdcb820632dd1c38031208ca8d1c30ebc884612a0c"
+                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-arm64",
+                "verification_source": "f806344e07dd44c5266cb536bf5ca7e87a749a3c0d531c4201c4896cdfe970f7"
             }
         }
     },

--- a/configs/coins/ethereum_consensus.json
+++ b/configs/coins/ethereum_consensus.json
@@ -19,10 +19,10 @@
         "package_name": "backend-ethereum-consensus",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "7.1.3",
-        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-amd64",
+        "version": "7.1.8",
+        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-amd64",
         "verification_type": "sha256",
-        "verification_source": "6efcd238124e000783f55a4430f0962b324a32599cf33219415f7f6dece8363f",
+        "verification_source": "16c701e32bd27d7f0bdf43160318ef75844da9137667c28748c44f266ed13be7",
         "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --mainnet --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=7536 --rpc-port=7537 --monitoring-port=7538 --p2p-tcp-port=3536 --p2p-udp-port=2536 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum/backend/erigon/jwt.hex 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
@@ -36,8 +36,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-arm64",
-                "verification_source": "23ec40327ac81925dace24cdcb820632dd1c38031208ca8d1c30ebc884612a0c"
+                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-arm64",
+                "verification_source": "f806344e07dd44c5266cb536bf5ca7e87a749a3c0d531c4201c4896cdfe970f7"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_sepolia_archive_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_archive_consensus.json
@@ -24,10 +24,10 @@
         "package_name": "backend-ethereum-testnet-sepolia-archive-consensus",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "7.1.3",
-        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-amd64",
+        "version": "7.1.8",
+        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-amd64",
         "verification_type": "sha256",
-        "verification_source": "6efcd238124e000783f55a4430f0962b324a32599cf33219415f7f6dece8363f",
+        "verification_source": "16c701e32bd27d7f0bdf43160318ef75844da9137667c28748c44f266ed13be7",
         "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --sepolia --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17586 --rpc-port=17587 --monitoring-port=17548 --p2p-tcp-port=13676 --p2p-udp-port=12676 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_sepolia_archive/backend/erigon/jwt.hex --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
@@ -41,8 +41,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-arm64",
-                "verification_source": "23ec40327ac81925dace24cdcb820632dd1c38031208ca8d1c30ebc884612a0c"
+                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-arm64",
+                "verification_source": "f806344e07dd44c5266cb536bf5ca7e87a749a3c0d531c4201c4896cdfe970f7"
             }
         }
     },

--- a/configs/coins/ethereum_testnet_sepolia_consensus.json
+++ b/configs/coins/ethereum_testnet_sepolia_consensus.json
@@ -24,10 +24,10 @@
         "package_name": "backend-ethereum-testnet-sepolia-consensus",
         "package_revision": "satoshilabs-1",
         "system_user": "ethereum",
-        "version": "7.1.3",
-        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-amd64",
+        "version": "7.1.8",
+        "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-amd64",
         "verification_type": "sha256",
-        "verification_source": "6efcd238124e000783f55a4430f0962b324a32599cf33219415f7f6dece8363f",
+        "verification_source": "16c701e32bd27d7f0bdf43160318ef75844da9137667c28748c44f266ed13be7",
         "extract_command": "mv ${ARCHIVE} backend/beacon-chain && chmod +x backend/beacon-chain && echo",
         "exclude_files": [],
         "exec_command_template": "/bin/sh -c '{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/beacon-chain --sepolia --accept-terms-of-use --execution-endpoint=http://localhost:{{.Ports.BackendAuthRpc}} --grpc-gateway-port=17576 --rpc-port=17577 --monitoring-port=17578 --p2p-tcp-port=13576 --p2p-udp-port=12576 --datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend --jwt-secret={{.Env.BackendDataPath}}/ethereum_testnet_sepolia/backend/erigon/jwt.hex --genesis-state={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/genesis.ssz 2>>{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/{{.Coin.Alias}}.log'",
@@ -41,8 +41,8 @@
         "client_config_file": "",
         "platforms": {
             "arm64": {
-                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.3/beacon-chain-v7.1.3-linux-arm64",
-                "verification_source": "23ec40327ac81925dace24cdcb820632dd1c38031208ca8d1c30ebc884612a0c"
+                "binary_url": "https://github.com/OffchainLabs/prysm/releases/download/v7.1.8/beacon-chain-v7.1.8-linux-arm64",
+                "verification_source": "f806344e07dd44c5266cb536bf5ca7e87a749a3c0d531c4201c4896cdfe970f7"
             }
         }
     },


### PR DESCRIPTION
Follow-up to #1740 (Hoodi, 7.1.0 → 7.1.8). Mainnet and Sepolia — both regular and archive — are on 7.1.3 from March.

7.1.3 is **not** exposed to [prysm#16160](https://github.com/OffchainLabs/prysm/issues/16160), the attestation-replay bug that stops Hoodi from re-reaching tip; that was fixed in 7.1.2. So the Hoodi failure mode cannot occur here. But 7.1.4–7.1.8 fix several other ways a beacon node stops making progress. Most of the sync fixes in those releases are Gloas/ePBS-only and therefore dormant until that fork activates; these are not:

- **7.1.6** — payload attributes were computed while the node was syncing, replaying thousands of slots per block and dropping sync to ~0.1 blocks/s. This is the closest analogue to the Hoodi symptom: fall behind, then be unable to catch up.
- **7.1.5** — `concurrent map iteration and write` fatal in the data-column/blob data-availability wait. A Go fatal is unrecoverable, so the process dies. Also data races on head state (`s.head.full`, `computePayloadWithdrawals`) and a TOCTOU in `stategen.latestAncestor`.
- **7.1.7** — `BeaconDB.Block` returns a nil block with no error when the root is missing, and the old nil check still segfaulted the node **at startup**, i.e. a wedge that survives restarts. Also `engine_exchangeCapabilities` growing its method list on every EL reconnect (7.1.6).
- **7.1.8** — initial sync waited indefinitely on missing custody columns instead of failing and retrying, stalling checkpoint sync.
- **7.1.4** — nil panic in `fetchOriginSidecars` when the origin checkpoint block has been pruned from the DB; also ~300–450 MB less heap on mainnet and no more periodic CPU spikes from sync-committee state replays.

`ethereum_archive_consensus` runs `--semi-supernode`, so it custodies more data columns than a default node and is the most exposed of the four to the column paths above. The flag still exists in 7.1.8 (which adds `GET /prysm/v1/node/custody` reporting supernode/semi-supernode status); no flag changes are needed.

Checksums were verified by downloading the release binaries, not only the published `.sha256` files, and are the same artifacts as #1740: `16c701e3…3be7` (linux-amd64), `f806344e…70f7` (linux-arm64). `go run build/templates/generate.go` on all four coins emits `backend (7.1.8-satoshilabs-1)`.

Kept separate from #1740 on purpose: Hoodi is a live incident and can ship immediately, while a mainnet CL upgrade should get normal deploy scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)