### PR TITLE
test(ws): fix race in shutdown in-flight-work assertion

### DIFF
--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1454,8 +1454,11 @@ func TestWebsocketShutdownWaitsForInFlightWork(t *testing.T) {
 	go func() {
 		// Simulate a DB-touching goroutine that takes some time.
 		time.Sleep(50 * time.Millisecond)
-		s.workDone()
+		// Signal completion before workDone(): workDone() is what releases
+		// Shutdown, so closing afterwards races with the check below and the
+		// non-blocking select can observe finished as still open.
 		close(finished)
+		s.workDone()
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
## Problem

`TestWebsocketShutdownWaitsForInFlightWork` is flaky and fails prod builds. It hit run [32830597547](https://github.com/trezor/blockbook/actions/runs/32830597547) (`build ethereum_archive,arbitrum_archive (prod) @ master`), failing `deb-blockbook-arbitrum_archive` at `dh_auto_test`:

```
--- FAIL: TestWebsocketShutdownWaitsForInFlightWork (0.05s)
    websocket_test.go:1474: Shutdown returned before tracked goroutine finished
```

The same suite **passed** for `blockbook-ethereum-archive` two minutes earlier in the same job, on the same commit and machine.

Because packages are staged only after the whole `make` succeeds, this also discarded the `ethereum_archive` debs that had already built cleanly — the job produced no artifacts at all.

## Root cause — test-side race, not a product bug

The assertion that fired is line 1474, **not** the `elapsed < 50ms` check on line 1468, so `Shutdown` did wait the full 50ms. The worker goroutine was:

```go
time.Sleep(50 * time.Millisecond)
s.workDone()      // requestWg.Done() -> releases Shutdown
close(finished)   // ...but the assertion may already have run
```

`workDone()` (`server/websocket.go:493`) calls `requestWg.Done()`, which is exactly what unblocks the `requestWg.Wait()` goroutine, closes `done`, and lets `Shutdown` return nil (`server/websocket.go:524-532`). Between `workDone()` and `close(finished)` the main goroutine can reach the non-blocking `select` and take `default`. On an idle machine the main path (WaitGroup wake, channel close, select, `glog.Info` write to stderr) is slow enough that the goroutine always wins; on a loaded builder it isn't.

Nothing in `Shutdown`/`trackWork`/`workDone` is broken. All four production `workDone()` call sites (`websocket.go:712, 1830, 1867, 2015`) are guarded by a matching `trackWork()`, so there is no unpaired `Done()` that could let `Wait()` return early.

## Fix

Signal completion *before* releasing `Shutdown`, making the ordering the test asserts an invariant rather than a timing bet: `close(finished)` now happens-before `requestWg.Done()`, so if `Shutdown` returned, `finished` is closed.

The `elapsed >= 50ms` assertion still catches a `Shutdown` that fails to wait for in-flight work at all, so the test keeps its power. The sibling `TestWebsocketShutdownTimesOutOnStuckWork` was already safe — its unbuffered `finished <- s.Shutdown(ctx)` cannot complete before `workDone()`.

## Verification

- A throwaway probe ran both orderings with a 1ms delay inserted in the window, standing in for scheduler delay on a loaded builder: **pre-fix ordering missed the signal 20/20, post-fix 0/20.**
- `go test -tags unittest ./server/ -run TestWebsocketShutdown -count=300 -race` passes. (It also passed pre-fix — the window is too narrow to hit on an idle box, which is why the probe above is the actual evidence.)
- `gofmt` clean.

## Two pre-existing issues found while reviewing (not addressed here)

Both reproduce on clean `master`:

1. **A real data race in `db`, masked because CI does not run `-race`.** `go test -tags unittest ./server/ -race` fails ~10 tests with `race detected`; the stack is `db.(*RocksDB).setBlockTimes` (`db/rocksdb.go:2303`) via `LoadInternalState`/`SetInternalState`, entered from the `setupRocksDB` test helper.
2. **`-count>1` over the whole `server` package is not usable as a stress knob.** The WS fixtures are single-use; the second iteration fails with `want already checked, should not check twice` (`public_test.go:1780`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
