### PR TITLE
fix(tron): stop fabricating confirmed nonce

### DIFF
--- a/bchain/coins/tron/tronrpc.go
+++ b/bchain/coins/tron/tronrpc.go
@@ -1184,20 +1184,11 @@ func (b *TronRPC) normalizeMulticallCalls(calls []bchain.EthereumMulticallCall) 
 	return normalizedCalls, nil
 }
 
-// EthereumTypeGetNonces returns the account nonce. Tron exposes only the latest
-// (confirmed) nonce via NonceAt in a single call, so the pending and confirmed
-// values are identical and the withConfirmed flag carries no extra cost here.
-// Tron has no alternative send-tx relay, so the privatePendingNonces hint is ignored.
+// EthereumTypeGetNonces: Tron has no account nonces (replay protection is
+// ref-block + expiration); pending is reported as 0 to mirror java-tron's
+// eth_getTransactionCount stub and a confirmed nonce is never claimed.
 func (b *TronRPC) EthereumTypeGetNonces(addrDesc bchain.AddressDescriptor, withConfirmed bool, privatePendingNonces ...uint64) (uint64, uint64, bool, error) {
-	ctx, cancel := context.WithTimeout(b.requestContext(), b.Timeout)
-	defer cancel()
-	n, err := b.Client.NonceAt(ctx, addrDesc, nil)
-	if err != nil {
-		return 0, 0, false, err
-	}
-	// the single NonceAt call already yields the latest nonce, so confirmed is
-	// available whenever it was requested
-	return n, n, withConfirmed, nil
+	return 0, 0, false, nil
 }
 
 // GetContractInfo returns information about a contract


### PR DESCRIPTION
Tron has no account nonces — replay protection uses a ref-block reference plus expiration, and java-tron's `eth_getTransactionCount` is a stub that always returns `0x0`. Blockbook's `TronClient.NonceAt` mirrors that as a local no-op, so `EthereumTypeGetNonces` never had a real value to report; it nevertheless returned `confirmedOK=true`, making the API fabricate `confirmedNonce: "0"` whenever a client requested a confirmed nonce.

This change turns `TronRPC.EthereumTypeGetNonces` into an honest constant stub (`0, 0, false, nil`): `nonce` stays `"0"` in responses (matching the backend's own stub), while `confirmedNonce` is no longer claimed. No wire traffic is affected — the old path never made an RPC call. Suite's Tron outdated check reads only balance + tronResources, so nothing consumes this field today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)