### PR TITLE
feat(eth): bound input-data decoding to a max calldata size

### DIFF
--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -96,6 +96,11 @@ func GetSignatureFromData(data string) uint32 {
 
 const ErrorTy byte = 255
 
+// maxParseInputDataLen bounds the hex length of calldata that ParseInputData will
+// decode. Real calls rarely exceed a few KB; ~64 KB of calldata is generous while
+// keeping parse work and per-signature allocations away from the chain gas limit.
+const maxParseInputDataLen = 128 * 1024
+
 func processParam(data string, index int, dataOffset int, t *abi.Type, processed []bool) ([]string, int, bool) {
 	var retval []string
 	d := index << 6
@@ -259,6 +264,13 @@ func (p *EthereumParser) ParseInputData(signatures *[]bchain.FourByteSignature, 
 	}
 	parsed := bchain.EthereumParsedInputData{
 		MethodId: data[:10],
+	}
+	// Decode work grows with calldata length, which is bounded only by chain gas;
+	// cap it here so a single large-array tx cannot force unbounded parsing on
+	// every unauthenticated detail request.
+	if len(data) > maxParseInputDataLen {
+		parsed.Truncated = true
+		return &parsed
 	}
 	defer func() {
 		if r := recover(); r != nil {

--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -96,9 +96,8 @@ func GetSignatureFromData(data string) uint32 {
 
 const ErrorTy byte = 255
 
-// maxParseInputDataLen bounds the hex length of calldata that ParseInputData will
-// decode. Real calls rarely exceed a few KB; ~64 KB of calldata is generous while
-// keeping parse work and per-signature allocations away from the chain gas limit.
+// maxParseInputDataLen bounds the hex length of calldata that ParseInputData will decode;
+// real calls rarely exceed a few KB, so ~64 KB keeps parse work off the chain gas limit.
 const maxParseInputDataLen = 128 * 1024
 
 func processParam(data string, index int, dataOffset int, t *abi.Type, processed []bool) ([]string, int, bool) {
@@ -265,9 +264,7 @@ func (p *EthereumParser) ParseInputData(signatures *[]bchain.FourByteSignature, 
 	parsed := bchain.EthereumParsedInputData{
 		MethodId: data[:10],
 	}
-	// Decode work grows with calldata length, which is bounded only by chain gas;
-	// cap it here so a single large-array tx cannot force unbounded parsing on
-	// every unauthenticated detail request.
+	// skip decoding oversized calldata; see maxParseInputDataLen for the budget rationale
 	if len(data) > maxParseInputDataLen {
 		parsed.Truncated = true
 		return &parsed

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -3,7 +3,9 @@
 package eth
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/trezor/blockbook/bchain"
@@ -588,5 +590,43 @@ func Test_getEnsRecord(t *testing.T) {
 				t.Errorf("getEnsRecord() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseInputDataTruncatesOversizedCalldata(t *testing.T) {
+	parser := NewEthereumParser(1, false)
+	signatures := []bchain.FourByteSignature{
+		{Name: "cancelMultipleMakerOrders", Parameters: []string{"uint256[]"}},
+	}
+	// Build canonical ABI calldata for a uint256[] of zero elements: selector,
+	// offset word (0x20), count word, then `count` zero words. With enough
+	// elements the hex length exceeds maxParseInputDataLen and the parser must
+	// return the method id only, flagged Truncated, without materializing values.
+	buildCalldata := func(count int) string {
+		var b strings.Builder
+		b.WriteString("0x9e53a69a")
+		b.WriteString(fmt.Sprintf("%064x", 0x20)) // offset to the array
+		b.WriteString(fmt.Sprintf("%064x", count)) // element count
+		b.WriteString(strings.Repeat(strings.Repeat("0", 64), count))
+		return b.String()
+	}
+
+	oversized := buildCalldata(3000)
+	if len(oversized) <= maxParseInputDataLen {
+		t.Fatalf("test calldata not oversized: len=%d, limit=%d", len(oversized), maxParseInputDataLen)
+	}
+	got := parser.ParseInputData(&signatures, oversized)
+	want := &bchain.EthereumParsedInputData{MethodId: "0x9e53a69a", Truncated: true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseInputData(oversized) = %#v, want %#v", got, want)
+	}
+
+	// Negative control: a small array under the budget still decodes every value.
+	small := parser.ParseInputData(&signatures, buildCalldata(2))
+	if small.Truncated {
+		t.Errorf("ParseInputData(small) unexpectedly truncated: %#v", small)
+	}
+	if len(small.Params) != 1 || len(small.Params[0].Values) != 2 {
+		t.Errorf("ParseInputData(small) = %#v, want 1 param with 2 values", small)
 	}
 }

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -598,17 +598,10 @@ func TestParseInputDataTruncatesOversizedCalldata(t *testing.T) {
 	signatures := []bchain.FourByteSignature{
 		{Name: "cancelMultipleMakerOrders", Parameters: []string{"uint256[]"}},
 	}
-	// Build canonical ABI calldata for a uint256[] of zero elements: selector,
-	// offset word (0x20), count word, then `count` zero words. With enough
-	// elements the hex length exceeds maxParseInputDataLen and the parser must
-	// return the method id only, flagged Truncated, without materializing values.
+	// Canonical ABI calldata for a uint256[] of zero elements: selector,
+	// offset word (0x20), count word, then `count` zero-value words.
 	buildCalldata := func(count int) string {
-		var b strings.Builder
-		b.WriteString("0x9e53a69a")
-		b.WriteString(fmt.Sprintf("%064x", 0x20)) // offset to the array
-		b.WriteString(fmt.Sprintf("%064x", count)) // element count
-		b.WriteString(strings.Repeat(strings.Repeat("0", 64), count))
-		return b.String()
+		return fmt.Sprintf("0x9e53a69a%064x%064x%s", 0x20, count, strings.Repeat("0", 64*count))
 	}
 
 	oversized := buildCalldata(3000)

--- a/bchain/types_ethereum_type.go
+++ b/bchain/types_ethereum_type.go
@@ -49,9 +49,7 @@ type EthereumParsedInputData struct {
 	Name     string                     `json:"name" ts_doc:"Parsed function name if recognized."`
 	Function string                     `json:"function,omitempty" ts_doc:"Full function signature (including parameter types)."`
 	Params   []EthereumParsedInputParam `json:"params,omitempty" ts_doc:"List of parsed parameters for this function call."`
-	// Truncated is set when the input data was too large to decode within the
-	// parse budget; only MethodId is populated so clients can tell an elided
-	// decode from an unknown selector.
+	// Truncated: parse budget exceeded, only MethodId is populated
 	Truncated bool `json:"parsedDataTruncated,omitempty" ts_doc:"True when input data exceeded the parse-size budget and parameters were not decoded."`
 }
 

--- a/bchain/types_ethereum_type.go
+++ b/bchain/types_ethereum_type.go
@@ -49,6 +49,10 @@ type EthereumParsedInputData struct {
 	Name     string                     `json:"name" ts_doc:"Parsed function name if recognized."`
 	Function string                     `json:"function,omitempty" ts_doc:"Full function signature (including parameter types)."`
 	Params   []EthereumParsedInputParam `json:"params,omitempty" ts_doc:"List of parsed parameters for this function call."`
+	// Truncated is set when the input data was too large to decode within the
+	// parse budget; only MethodId is populated so clients can tell an elided
+	// decode from an unknown selector.
+	Truncated bool `json:"parsedDataTruncated,omitempty" ts_doc:"True when input data exceeded the parse-size budget and parameters were not decoded."`
 }
 
 // EthereumInternalTransactionType - type of ethereum transaction from internal data

--- a/blockbook-api.ts
+++ b/blockbook-api.ts
@@ -97,6 +97,8 @@ export interface EthereumParsedInputData {
     function?: string;
     /** List of parsed parameters for this function call. */
     params?: EthereumParsedInputParam[];
+    /** True when input data exceeded the parse-size budget and parameters were not decoded. */
+    parsedDataTruncated?: boolean;
 }
 export interface EthereumSpecific {
     /** High-level type of the Ethereum tx (e.g., 'call', 'create'). */

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2002,6 +2002,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EthereumParsedInputParam"
+        parsedDataTruncated:
+          type: boolean
+          description: True when input data exceeded the parse-size budget and parameters were not decoded.
 
     EthereumSpecific:
       type: object


### PR DESCRIPTION
## Summary

`ParseInputData` decodes EVM transaction calldata into `ethereumSpecific.parsedData` on every transaction-detail response. The decode work (and per-signature allocations) grows linearly with the calldata length, which is bounded only by chain gas — a single transaction carrying a large dynamic array (e.g. `uint256[]`) can materialize one output value per element, costing tens of MB of transient allocation and hundreds of ms of CPU per request.

This adds a size budget so parsing cost is bounded by an operator-controlled limit rather than by the maximum calldata a chain can include.

## Changes

- Add `maxParseInputDataLen` (~64 KB calldata) and short-circuit `ParseInputData` above it, before the signature loop. Oversized input returns only the method id.
- Add a `Truncated` field to `EthereumParsedInputData`, serialized as `parsedDataTruncated`, so clients can tell an elided decode from an unknown selector.
- Add a regression test covering the oversized (truncated) and small (fully decoded) cases.

## Compatibility

The threshold is far above any normal call (transfers, swaps, stake/unstake are a few KB at most), so only pathological large-array inputs are affected. The truncated response — method id only, empty `name`, no `params` — is the same shape already returned for an unrecognized selector, and the raw `data` field is unchanged, so downstream clients degrade gracefully. The new field is additive and optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)