### PR TITLE
feat(btc): serve mempool.space precise recommended fees

### DIFF
--- a/bchain/coins/btc/bitcoinrpc.go
+++ b/bchain/coins/btc/bitcoinrpc.go
@@ -243,6 +243,13 @@ func (b *BitcoinRPC) Initialize() error {
 			// disable AlternativeEstimateFee logic
 			b.alternativeFeeProvider = nil
 		}
+	} else if b.ChainConfig.AlternativeEstimateFee == "mempoolspaceprecise" {
+		glog.Info("Using MempoolSpacePreciseFee")
+		if b.alternativeFeeProvider, err = NewMempoolSpacePreciseFee(b, b.ChainConfig.AlternativeEstimateFeeParams, b.metrics); err != nil {
+			glog.Error("MempoolSpacePreciseFee error ", err, " Reverting to default estimateFee functionality")
+			// disable AlternativeEstimateFee logic
+			b.alternativeFeeProvider = nil
+		}
 	} else if b.ChainConfig.AlternativeEstimateFee == "mempoolspaceblock" {
 		glog.Info("Using MempoolSpaceBlockFee")
 		if b.alternativeFeeProvider, err = NewMempoolSpaceBlockFee(b, b.ChainConfig.AlternativeEstimateFeeParams, b.metrics); err != nil {

--- a/bchain/coins/btc/mempoolspaceprecise.go
+++ b/bchain/coins/btc/mempoolspaceprecise.go
@@ -95,29 +95,40 @@ func (p *mempoolSpacePreciseFeeProvider) downloader() {
 }
 
 func (p *mempoolSpacePreciseFeeProvider) processData(data *mempoolSpacePreciseFeeResult) bool {
-	if data.MinimumFee <= 0 || data.EconomyFee <= 0 || data.HourFee <= 0 || data.HalfHourFee <= 0 || data.FastestFee <= 0 {
-		glog.Errorf("processData: invalid data %+v", data)
-		return false
-	}
-	p.mux.Lock()
-	defer p.mux.Unlock()
 	// Block targets follow the mempool.space UI semantics, so Suite's targets 1/3/6/36
 	// map to fastest/halfHour/hour/economy and users see the same numbers as on mempool.space
-	p.fees = []alternativeFeeProviderFee{
+	fees := []alternativeFeeProviderFee{
 		{blocks: 1, feePerKB: feePerVBToFeePerKB(data.FastestFee)},    // ~10 minutes
 		{blocks: 3, feePerKB: feePerVBToFeePerKB(data.HalfHourFee)},   // ~30 minutes
 		{blocks: 6, feePerKB: feePerVBToFeePerKB(data.HourFee)},       // ~1 hour
 		{blocks: 500, feePerKB: feePerVBToFeePerKB(data.EconomyFee)},  // no priority
 		{blocks: 1008, feePerKB: feePerVBToFeePerKB(data.MinimumFee)}, // purge floor
 	}
+	// Validate after conversion and keep the previous table on a malformed poll,
+	// so the node fallback kicks in once the last good data goes stale
+	for _, fee := range fees {
+		if fee.feePerKB <= 0 {
+			glog.Errorf("processData: invalid data %+v", data)
+			return false
+		}
+	}
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	p.fees = fees
 	p.lastSync = time.Now()
 	return true
 }
 
 // feePerVBToFeePerKB converts exactly, without rounding to significant digits,
-// so that the served values are identical to the ones on mempool.space
+// so that the served values are identical to the ones on mempool.space.
+// Returns 0 for values that are not sane positive fees (negative, NaN, Inf or huge),
+// as their float to int conversion is implementation-dependent.
 func feePerVBToFeePerKB(fee float64) int {
-	return int(math.Round(fee * 1000))
+	feePerKB := math.Round(fee * 1000)
+	if !(feePerKB >= 1 && feePerKB <= 1e9) {
+		return 0
+	}
+	return int(feePerKB)
 }
 
 func (p *mempoolSpacePreciseFeeProvider) getData(res interface{}) error {

--- a/bchain/coins/btc/mempoolspaceprecise.go
+++ b/bchain/coins/btc/mempoolspaceprecise.go
@@ -1,0 +1,146 @@
+package btc
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/juju/errors"
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/common"
+)
+
+// https://mempool.space/api/v1/fees/precise returns the recommended fees with sub-sat/vB precision.
+// Example response:
+// {"fastestFee":2.605,"halfHourFee":1.603,"hourFee":0.843,"economyFee":0.2,"minimumFee":0.1}
+
+type mempoolSpacePreciseFeeResult struct {
+	FastestFee  float64 `json:"fastestFee"`
+	HalfHourFee float64 `json:"halfHourFee"`
+	HourFee     float64 `json:"hourFee"`
+	EconomyFee  float64 `json:"economyFee"`
+	MinimumFee  float64 `json:"minimumFee"`
+}
+
+type mempoolSpacePreciseFeeParams struct {
+	URL           string `json:"url"`
+	PeriodSeconds int    `json:"periodSeconds"`
+}
+
+type mempoolSpacePreciseFeeProvider struct {
+	*alternativeFeeProvider
+	params mempoolSpacePreciseFeeParams
+}
+
+// NewMempoolSpacePreciseFee initializes the provider completely.
+func NewMempoolSpacePreciseFee(chain bchain.BlockChain, params string, metrics *common.Metrics) (alternativeFeeProviderInterface, error) {
+	var paramsParsed mempoolSpacePreciseFeeParams
+	err := json.Unmarshal([]byte(params), &paramsParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain(paramsParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	p.chain = chain
+	p.metrics = metrics
+	p.name = "mempoolspaceprecise"
+	go p.downloader()
+	return p, nil
+}
+
+// NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain initializes the provider from already parsed parameters and without chain.
+// Refactored like this for better testability.
+func NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain(params mempoolSpacePreciseFeeParams) (*mempoolSpacePreciseFeeProvider, error) {
+	if params.URL == "" {
+		return nil, errors.New("NewMempoolSpacePreciseFee: Missing url")
+	}
+	// Negative period would make the timer fire immediately, busy-looping requests
+	if params.PeriodSeconds <= 0 {
+		return nil, errors.New("NewMempoolSpacePreciseFee: Missing periodSeconds")
+	}
+
+	return &mempoolSpacePreciseFeeProvider{
+		alternativeFeeProvider: &alternativeFeeProvider{},
+		params:                 params,
+	}, nil
+}
+
+func (p *mempoolSpacePreciseFeeProvider) downloader() {
+	period := time.Duration(p.params.PeriodSeconds) * time.Second
+	timer := time.NewTimer(period)
+	counter := 0
+	for {
+		var data mempoolSpacePreciseFeeResult
+		err := p.getData(&data)
+		if err != nil {
+			glog.Error("getData ", err)
+		} else {
+			if p.processData(&data) {
+				if counter%60 == 0 {
+					p.compareToDefault()
+				}
+				counter++
+			}
+		}
+		<-timer.C
+		timer.Reset(period)
+	}
+}
+
+func (p *mempoolSpacePreciseFeeProvider) processData(data *mempoolSpacePreciseFeeResult) bool {
+	if data.MinimumFee <= 0 || data.EconomyFee <= 0 || data.HourFee <= 0 || data.HalfHourFee <= 0 || data.FastestFee <= 0 {
+		glog.Errorf("processData: invalid data %+v", data)
+		return false
+	}
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	// Block targets follow the mempool.space UI semantics, so Suite's targets 1/3/6/36
+	// map to fastest/halfHour/hour/economy and users see the same numbers as on mempool.space
+	p.fees = []alternativeFeeProviderFee{
+		{blocks: 1, feePerKB: feePerVBToFeePerKB(data.FastestFee)},    // ~10 minutes
+		{blocks: 3, feePerKB: feePerVBToFeePerKB(data.HalfHourFee)},   // ~30 minutes
+		{blocks: 6, feePerKB: feePerVBToFeePerKB(data.HourFee)},       // ~1 hour
+		{blocks: 500, feePerKB: feePerVBToFeePerKB(data.EconomyFee)},  // no priority
+		{blocks: 1008, feePerKB: feePerVBToFeePerKB(data.MinimumFee)}, // purge floor
+	}
+	p.lastSync = time.Now()
+	return true
+}
+
+// feePerVBToFeePerKB converts exactly, without rounding to significant digits,
+// so that the served values are identical to the ones on mempool.space
+func feePerVBToFeePerKB(fee float64) int {
+	return int(math.Round(fee * 1000))
+}
+
+func (p *mempoolSpacePreciseFeeProvider) getData(res interface{}) error {
+	httpReq, err := http.NewRequest("GET", p.params.URL, nil)
+	if err != nil {
+		return err
+	}
+	httpRes, err := http.DefaultClient.Do(httpReq)
+	if httpRes != nil {
+		defer httpRes.Body.Close()
+	}
+	if err != nil {
+		p.observeRequest("network_error")
+		return err
+	}
+	if httpRes.StatusCode != http.StatusOK {
+		p.observeRequest("http_" + strconv.Itoa(httpRes.StatusCode))
+		return errors.New(p.params.URL + " returned status " + strconv.Itoa(httpRes.StatusCode))
+	}
+	if err := common.SafeDecodeResponseFromReader(httpRes.Body, res); err != nil {
+		p.observeRequest("decode_error")
+		return err
+	}
+	p.observeRequest("ok")
+	return nil
+}

--- a/bchain/coins/btc/mempoolspaceprecise_test.go
+++ b/bchain/coins/btc/mempoolspaceprecise_test.go
@@ -4,6 +4,7 @@ package btc
 
 import (
 	"encoding/json"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -96,6 +97,29 @@ func Test_mempoolSpacePreciseFeeProvider(t *testing.T) {
 	}
 }
 
+func Test_feePerVBToFeePerKB(t *testing.T) {
+	tests := []struct {
+		fee  float64
+		want int
+	}{
+		{2.605, 2605},
+		{0.1, 100},
+		{0.001, 1},
+		// not sane positive fees, must convert to 0
+		{0.0004, 0},
+		{0, 0},
+		{-1, 0},
+		{1e100, 0},
+		{math.NaN(), 0},
+		{math.Inf(1), 0},
+	}
+	for _, tt := range tests {
+		if got := feePerVBToFeePerKB(tt.fee); got != tt.want {
+			t.Errorf("feePerVBToFeePerKB(%v) = %d, want %d", tt.fee, got, tt.want)
+		}
+	}
+}
+
 func Test_mempoolSpacePreciseFeeProviderInvalidData(t *testing.T) {
 	tests := []struct {
 		name string
@@ -109,6 +133,22 @@ func Test_mempoolSpacePreciseFeeProviderInvalidData(t *testing.T) {
 			name: "negative field",
 			data: mempoolSpacePreciseFeeResult{FastestFee: 2.605, HalfHourFee: -1, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1},
 		},
+		{
+			name: "huge field overflowing int",
+			data: mempoolSpacePreciseFeeResult{FastestFee: 1e100, HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1},
+		},
+		{
+			name: "field rounding to zero",
+			data: mempoolSpacePreciseFeeResult{FastestFee: 2.605, HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.0004},
+		},
+		{
+			name: "NaN field",
+			data: mempoolSpacePreciseFeeResult{FastestFee: math.NaN(), HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1},
+		},
+		{
+			name: "Inf field",
+			data: mempoolSpacePreciseFeeResult{FastestFee: math.Inf(1), HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -118,6 +158,21 @@ func Test_mempoolSpacePreciseFeeProviderInvalidData(t *testing.T) {
 			}
 			if _, err := m.estimateFee(1); err == nil {
 				t.Error("expected estimateFee to return error when no data was processed")
+			}
+
+			// a rejected poll must keep the previously processed table
+			if !m.processData(&mempoolSpacePreciseFeeResult{FastestFee: 2.605, HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1}) {
+				t.Fatal("expected valid data to be processed successfully")
+			}
+			if m.processData(&tt.data) {
+				t.Error("expected processData to reject invalid data")
+			}
+			got, err := m.estimateFee(1)
+			if err != nil {
+				t.Errorf("estimateFee returned error: %v", err)
+			}
+			if want := big.NewInt(2605); got.Cmp(want) != 0 {
+				t.Errorf("estimateFee(1) = %v, want %v", got, want)
 			}
 		})
 	}

--- a/bchain/coins/btc/mempoolspaceprecise_test.go
+++ b/bchain/coins/btc/mempoolspaceprecise_test.go
@@ -1,0 +1,153 @@
+//go:build unittest
+
+package btc
+
+import (
+	"encoding/json"
+	"math/big"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func newTestMempoolSpacePreciseFeeProvider(t *testing.T) *mempoolSpacePreciseFeeProvider {
+	m, err := NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain(mempoolSpacePreciseFeeParams{
+		URL:           "https://mempool.space/api/v1/fees/precise",
+		PeriodSeconds: 20,
+	})
+	if err != nil {
+		t.Fatalf("NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain returned error: %v", err)
+	}
+	return m
+}
+
+func Test_mempoolSpacePreciseFeeResultParsing(t *testing.T) {
+	// Both the float /fees/precise and the integer /fees/recommended responses must parse
+	tests := []struct {
+		name string
+		json string
+		want mempoolSpacePreciseFeeResult
+	}{
+		{
+			name: "precise",
+			json: `{"fastestFee":2.605,"halfHourFee":1.603,"hourFee":0.843,"economyFee":0.2,"minimumFee":0.1}`,
+			want: mempoolSpacePreciseFeeResult{FastestFee: 2.605, HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1},
+		},
+		{
+			name: "recommended",
+			json: `{"fastestFee":41,"halfHourFee":39,"hourFee":36,"economyFee":36,"minimumFee":20}`,
+			want: mempoolSpacePreciseFeeResult{FastestFee: 41, HalfHourFee: 39, HourFee: 36, EconomyFee: 36, MinimumFee: 20},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got mempoolSpacePreciseFeeResult
+			if err := json.Unmarshal([]byte(tt.json), &got); err != nil {
+				t.Fatalf("json.Unmarshal returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("json.Unmarshal = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mempoolSpacePreciseFeeProvider(t *testing.T) {
+	m := newTestMempoolSpacePreciseFeeProvider(t)
+	if !m.processData(&mempoolSpacePreciseFeeResult{
+		FastestFee:  2.605,
+		HalfHourFee: 1.603,
+		HourFee:     0.843,
+		EconomyFee:  0.2,
+		MinimumFee:  0.1,
+	}) {
+		t.Fatal("expected data to be processed successfully")
+	}
+
+	// 2605 (not 2610) proves the conversion does not round to significant digits
+	tests := []struct {
+		blocks int
+		want   big.Int
+	}{
+		{0, *big.NewInt(2605)},
+		{1, *big.NewInt(2605)},
+		{2, *big.NewInt(1603)},
+		{3, *big.NewInt(1603)},
+		{4, *big.NewInt(843)},
+		{6, *big.NewInt(843)},
+		{7, *big.NewInt(200)},
+		{36, *big.NewInt(200)},
+		{100, *big.NewInt(200)},
+		{500, *big.NewInt(200)},
+		{501, *big.NewInt(100)},
+		{1008, *big.NewInt(100)},
+		{5000000, *big.NewInt(100)},
+	}
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.blocks), func(t *testing.T) {
+			got, err := m.estimateFee(tt.blocks)
+			if err != nil {
+				t.Errorf("estimateFee returned error: %v", err)
+			}
+			if got.Cmp(&tt.want) != 0 {
+				t.Errorf("estimateFee(%d) = %v, want %v", tt.blocks, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mempoolSpacePreciseFeeProviderInvalidData(t *testing.T) {
+	tests := []struct {
+		name string
+		data mempoolSpacePreciseFeeResult
+	}{
+		{
+			name: "zero field",
+			data: mempoolSpacePreciseFeeResult{FastestFee: 2.605, HalfHourFee: 1.603, HourFee: 0.843, EconomyFee: 0.2},
+		},
+		{
+			name: "negative field",
+			data: mempoolSpacePreciseFeeResult{FastestFee: 2.605, HalfHourFee: -1, HourFee: 0.843, EconomyFee: 0.2, MinimumFee: 0.1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMempoolSpacePreciseFeeProvider(t)
+			if m.processData(&tt.data) {
+				t.Error("expected processData to reject invalid data")
+			}
+			if _, err := m.estimateFee(1); err == nil {
+				t.Error("expected estimateFee to return error when no data was processed")
+			}
+		})
+	}
+}
+
+func Test_mempoolSpacePreciseFeeProviderMissingUrl(t *testing.T) {
+	_, err := NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain(mempoolSpacePreciseFeeParams{
+		PeriodSeconds: 20,
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	expectedSubstring := "Missing url"
+	if !strings.Contains(err.Error(), expectedSubstring) {
+		t.Errorf("expected error message to contain %q, got: %v", expectedSubstring, err)
+	}
+}
+
+func Test_mempoolSpacePreciseFeeProviderInvalidPeriodSeconds(t *testing.T) {
+	for _, periodSeconds := range []int{0, -5} {
+		_, err := NewMempoolSpacePreciseFeeProviderFromParamsWithoutChain(mempoolSpacePreciseFeeParams{
+			URL:           "https://mempool.space/api/v1/fees/precise",
+			PeriodSeconds: periodSeconds,
+		})
+		if err == nil {
+			t.Fatalf("expected error for periodSeconds=%d, got nil", periodSeconds)
+		}
+		expectedSubstring := "Missing periodSeconds"
+		if !strings.Contains(err.Error(), expectedSubstring) {
+			t.Errorf("expected error message to contain %q, got: %v", expectedSubstring, err)
+		}
+	}
+}

--- a/configs/coins/bitcoin.json
+++ b/configs/coins/bitcoin.json
@@ -67,8 +67,8 @@
             "xpub_magic_segwit_native": 78792518,
             "additional_params": {
                 "averageBlockTimeMs": 600000,
-                "alternative_estimate_fee": "mempoolspaceblock",
-                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/api/v1/fees/mempool-blocks\", \"periodSeconds\": 20, \"feeRangeIndex\": 5, \"fallbackFeePerKB\": 1000}",
+                "alternative_estimate_fee": "mempoolspaceprecise",
+                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/api/v1/fees/precise\", \"periodSeconds\": 20}",
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"bitcoin\", \"periodSeconds\": 60}",

--- a/configs/coins/bitcoin_regtest.json
+++ b/configs/coins/bitcoin_regtest.json
@@ -65,8 +65,8 @@
             "xpub_magic_segwit_native": 73342198,
             "slip44": 1,
             "additional_params": {
-                "alternative_estimate_fee": "mempoolspaceblock",
-                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/api/v1/fees/mempool-blocks\", \"periodSeconds\": 20, \"feeRangeIndex\": 5, \"fallbackFeePerKB\": 1000}",
+                "alternative_estimate_fee": "mempoolspaceprecise",
+                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/api/v1/fees/precise\", \"periodSeconds\": 20}",
                 "block_golomb_filter_p": 20,
                 "block_filter_scripts": "taproot-noordinals",
                 "block_filter_use_zeroed_key": true,

--- a/configs/coins/bitcoin_testnet4.json
+++ b/configs/coins/bitcoin_testnet4.json
@@ -66,8 +66,8 @@
             "slip44": 1,
             "additional_params": {
                 "averageBlockTimeMs": 600000,
-                "alternative_estimate_fee": "mempoolspace",
-                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/testnet4/api/v1/fees/recommended\", \"periodSeconds\": 60}",
+                "alternative_estimate_fee": "mempoolspaceprecise",
+                "alternative_estimate_fee_params": "{\"url\": \"https://mempool.space/testnet4/api/v1/fees/precise\", \"periodSeconds\": 60}",
                 "block_golomb_filter_p": 20,
                 "block_filter_scripts": "taproot-noordinals",
                 "block_filter_use_zeroed_key": true,

--- a/docs/config.md
+++ b/docs/config.md
@@ -101,6 +101,9 @@ Good examples of coin configuration are
         * `block_addresses_to_keep` – Number of blocks that are to be kept in blockaddresses column.
         * `additional_params` – Object of coin-specific params.
           * Tron-specific endpoint configuration is documented in [Tron Config](/docs/tron-config.md).
+          * Alternative fee provider configuration (BitcoinType):
+            * `alternative_estimate_fee` – Set to `mempoolspaceprecise` (mempool.space [recommended fees with sub-sat/vB precision](https://mempool.space/docs/api/rest#get-recommended-fees-precise); params `url`, `periodSeconds`), `mempoolspace` (mempool.space recommended fees; params `url`, `periodSeconds`), `mempoolspaceblock` (mempool.space projected mempool blocks; params `url`, `periodSeconds`, optional `feeRangeIndex` 0-6 percentile index instead of median, optional `fallbackFeePerKB` for targets beyond the projected blocks) or `whatthefee` (whatthefee.io) to serve provider fees instead of node `estimatesmartfee`. On provider error or stale data (>10 minutes), estimates fall back to the node.
+            * `alternative_estimate_fee_params` – JSON string with the provider params, e.g. `"{\"url\": \"https://mempool.space/api/v1/fees/precise\", \"periodSeconds\": 20}"`.
           * Alternative EIP-1559 fee provider configuration:
             * `alternative_estimate_fee` – Set to `infura` (Infura Gas API, requires `INFURA_API_KEY`) or `1inch` (1inch gas-price API, requires `ONE_INCH_API_KEY`) to use provider fee suggestions instead of native node fee estimation. Startup fails fast if the selected provider's API-key env var is missing.
             * `alternative_estimate_fee_params` – JSON string with `url`, `periodSeconds` and optional `staleSeconds`. `periodSeconds` controls how often Blockbook polls the provider.


### PR DESCRIPTION
Fixes #1754

Adds a new `mempoolspaceprecise` alternative fee provider consuming [`/api/v1/fees/precise`](https://mempool.space/docs/api/rest#get-recommended-fees-precise) (recommended fees with sub-sat/vB precision), so Blockbook serves the same numbers the mempool.space UI shows.

**Block-target mapping** (aligned with mempool.space UI semantics and Suite's targets high=1 / normal=3 / economy=6 / low=36):

| stored target | field | serves |
|---|---|---|
| 1 | `fastestFee` | ~10 min |
| 3 | `halfHourFee` | ~30 min |
| 6 | `hourFee` | ~1 h |
| 500 | `economyFee` | no priority |
| 1008 | `minimumFee` | purge floor |

The economy entry stays at 500 (not 36) so public-API requests for 37–500 blocks are not served the purge floor; Suite results are identical either way.

**Backwards compatible:** new provider key only — `mempoolspace` and `mempoolspaceblock` are untouched, so existing configs keep their exact behavior. The sat/vB→sat/kB conversion is exact (no rounding to significant digits), e.g. `2.605` → `2605`.

Configs for `bitcoin`, `bitcoin_regtest` and `bitcoin_testnet4` switch to the new provider (testnet4 precise endpoint verified live). Unit tests cover parsing (float and legacy int responses), the mapping/conversion table, invalid-data rejection and param validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)