### PR TITLE
fix(sync): un-wedge steady-state EVM sync that falls behind the backend

### DIFF
--- a/configs/grafana/panels.yaml
+++ b/configs/grafana/panels.yaml
@@ -181,7 +181,7 @@ panels:
         legend: '{{type}}'
   sync.index_sync_yields:
     title: Index sync yields
-    description: The retry loop gave control back to outer resync because a deadline elapsed or chain-state probes kept failing.
+    description: Sync gave control back to outer resync because a deadline elapsed, chain-state probes kept failing, or the sequential loop fell too far behind the backend tip.
     queries:
       yields:
         promql: sum(increase({{name:index_sync_yields}}{job="blockbook", coin="$coin"}[$__interval])) by (reason)

--- a/configs/metrics.yaml
+++ b/configs/metrics.yaml
@@ -213,7 +213,7 @@ metrics:
   index_sync_yields:
     name: blockbook_index_sync_yields
     type: counter_vec
-    help: 'Number of times sync yielded to the outer resync machinery for non-reorg reasons (reason=deadline: MaxStallDuration elapsed in retry loop; reason=probe_failed: chain-state probe failed for the configured streak)'
+    help: 'Number of times sync yielded to the outer resync machinery for non-reorg reasons (reason=deadline: MaxStallDuration elapsed in retry loop; reason=probe_failed: chain-state probe failed for the configured streak; reason=fell_behind: sequential sync lagged too far behind the backend tip and yielded for parallel catch-up)'
     labels: [reason]
   index_db_size:
     name: blockbook_index_db_size

--- a/db/sync.go
+++ b/db/sync.go
@@ -1077,7 +1077,7 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 			if bestHeight, bestErr := w.chain.GetBestBlockHeight(); bestErr == nil && bestHeight > height && bestHeight-height > fallBehindGap {
 				glog.Warningf("getBlockChain: sequential sync at %d is %d blocks behind backend tip %d; yielding to resync for parallel catch-up",
 					height, bestHeight-height, bestHeight)
-				w.metrics.IndexSyncYields.With(common.Labels{"reason": "fell-behind"}).Inc()
+				w.metrics.IndexSyncYields.With(common.Labels{"reason": "fell_behind"}).Inc()
 				select {
 				case out <- blockResult{err: errResync}:
 				case <-done:

--- a/db/sync.go
+++ b/db/sync.go
@@ -105,6 +105,46 @@ func ApplyMissingBlockRetryOverride(o *bchain.MissingBlockRetry) MissingBlockRet
 	return cfg
 }
 
+// Steady-state EVM parallel sync tuning. The sequential connect loop cannot
+// re-evaluate the parallel gate while it runs, so on chains that outpace it the
+// fall-behind check is the only way back to the parallel path.
+const (
+	// minParallelGap is the trigger threshold for the parallel path; below it the
+	// per-round pool setup costs more than sequential connect.
+	minParallelGap = 4
+	// fallBehindCheckBlocks is how many connected blocks the sequential producer
+	// waits between backend tip probes.
+	fallBehindCheckBlocks = 100
+	// fallBehindWorkerFactor and fallBehindMinYieldGap size the yield threshold
+	// well above minParallelGap so tip races do not thrash between the paths.
+	fallBehindWorkerFactor = 4
+	fallBehindMinYieldGap  = 64
+)
+
+// parallelSyncWorkerCount caps the configured pool at the number of blocks to
+// connect; ParallelConnectBlocks needs exactly one write channel per worker, so
+// a pool larger than the range would leave the height window non-contiguous.
+func parallelSyncWorkerCount(configured int, gap uint32) uint32 {
+	workers := uint32(configured)
+	if workers > gap {
+		workers = gap
+	}
+	return workers
+}
+
+// sequentialFallBehindGap returns the fall-behind yield threshold for the
+// sequential loop, or 0 when the parallel path is not available.
+func (w *SyncWorker) sequentialFallBehindGap() uint32 {
+	if w.syncWorkers <= 1 || w.chain.GetChainParser().GetChainType() != bchain.ChainEthereumType {
+		return 0
+	}
+	gap := uint32(w.syncWorkers) * fallBehindWorkerFactor
+	if gap < fallBehindMinYieldGap {
+		gap = fallBehindMinYieldGap
+	}
+	return gap
+}
+
 // NewSyncWorker creates new SyncWorker and returns its handle
 func NewSyncWorker(db *RocksDB, chain bchain.BlockChain, syncWorkers, syncChunk int, minStartHeight int, dryRun bool, chanOsSignal chan os.Signal, metrics *common.Metrics, is *common.InternalState) (*SyncWorker, error) {
 	return NewSyncWorkerWithConfig(db, chain, syncWorkers, syncChunk, minStartHeight, dryRun, chanOsSignal, metrics, is, nil)
@@ -309,8 +349,12 @@ func (w *SyncWorker) resyncIndex(onNewBlock bchain.OnNewBlockFunc, initialSync b
 				}
 			}
 			if w.chain.GetChainParser().GetChainType() == bchain.ChainEthereumType {
-				syncWorkers := uint32(4)
-				if remoteBestHeight-w.startHeight >= syncWorkers {
+				// The trigger threshold is deliberately independent of the pool size:
+				// gating on the configured worker count would push small steady-state
+				// rounds onto the slower sequential path.
+				gap := remoteBestHeight - w.startHeight
+				if gap >= minParallelGap {
+					syncWorkers := parallelSyncWorkerCount(w.syncWorkers, gap)
 					glog.Infof("resync: parallel sync of blocks %d-%d, using %d workers", w.startHeight, remoteBestHeight, syncWorkers)
 					// Parallel sync also returns errResync when a requested hash no longer
 					// exists at its height; restart to realign with the canonical chain.
@@ -931,6 +975,8 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 	hash := w.startHash
 	height := w.startHeight
 	prevHash := ""
+	fallBehindGap := w.sequentialFallBehindGap()
+	blocksSinceTipCheck := 0
 	cfg := w.missingBlockRetry
 	retryDelay := cfg.RetryDelay
 	if retryDelay <= 0 || retryDelay > 250*time.Millisecond {
@@ -1023,6 +1069,23 @@ func (w *SyncWorker) getBlockChain(out chan blockResult, done chan struct{}) {
 		hash = block.Next
 		height++
 		out <- blockResult{block: block}
+		blocksSinceTipCheck++
+		if fallBehindGap > 0 && blocksSinceTipCheck >= fallBehindCheckBlocks {
+			blocksSinceTipCheck = 0
+			// A probe error is ignored: yielding is an optimization, the loop can
+			// keep connecting and re-probe after the next batch.
+			if bestHeight, bestErr := w.chain.GetBestBlockHeight(); bestErr == nil && bestHeight > height && bestHeight-height > fallBehindGap {
+				glog.Warningf("getBlockChain: sequential sync at %d is %d blocks behind backend tip %d; yielding to resync for parallel catch-up",
+					height, bestHeight-height, bestHeight)
+				w.metrics.IndexSyncYields.With(common.Labels{"reason": "fell-behind"}).Inc()
+				select {
+				case out <- blockResult{err: errResync}:
+				case <-done:
+				case <-w.chanOsSignal:
+				}
+				return
+			}
+		}
 	}
 }
 

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -167,6 +167,18 @@ type getBlockChainTestChain struct {
 	blockErrors     map[uint32][]error
 	getBlockCalls   map[uint32]int
 	getBlockHashErr error
+	chainType       bchain.ChainType
+}
+
+type getBlockChainTestParser struct {
+	bchain.BlockChainParser
+	chainType bchain.ChainType
+}
+
+func (p *getBlockChainTestParser) GetChainType() bchain.ChainType { return p.chainType }
+
+func (c *getBlockChainTestChain) GetChainParser() bchain.BlockChainParser {
+	return &getBlockChainTestParser{chainType: c.chainType}
 }
 
 func (c *getBlockChainTestChain) GetBestBlockHeight() (uint32, error) {
@@ -556,6 +568,130 @@ func TestNewSyncWorkerClampsMaxStallDuration(t *testing.T) {
 			}
 			if got := w.missingBlockRetry.MaxStallDuration; got != tc.want {
 				t.Fatalf("MaxStallDuration = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParallelSyncWorkerCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		gap        uint32
+		want       uint32
+	}{
+		{name: "large gap uses configured pool", configured: 16, gap: 140000, want: 16},
+		{name: "pool capped by gap", configured: 16, gap: 4, want: 4},
+		{name: "configured below gap", configured: 8, gap: 100, want: 8},
+		{name: "minimum configured pool", configured: 2, gap: 4, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parallelSyncWorkerCount(tt.configured, tt.gap); got != tt.want {
+				t.Fatalf("parallelSyncWorkerCount(%d, %d) = %d, want %d", tt.configured, tt.gap, got, tt.want)
+			}
+		})
+	}
+}
+
+func makeSequentialTestBlocks(n uint32) map[uint32]*bchain.Block {
+	blocks := make(map[uint32]*bchain.Block, n)
+	for h := uint32(1); h <= n; h++ {
+		blocks[h] = &bchain.Block{BlockHeader: bchain.BlockHeader{Hash: "h" + strconv.Itoa(int(h)), Height: h}}
+	}
+	return blocks
+}
+
+func TestGetBlockChainYieldsWhenFallingBehind(t *testing.T) {
+	chain := &getBlockChainTestChain{
+		bestHeight:    100000,
+		chainType:     bchain.ChainEthereumType,
+		hashes:        map[uint32]string{},
+		blocks:        makeSequentialTestBlocks(fallBehindCheckBlocks),
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(t, chain, "h1", 1)
+	w.syncWorkers = 16
+
+	results := runGetBlockChain(w)
+	if len(results) != fallBehindCheckBlocks+1 {
+		t.Fatalf("got %d results, want %d", len(results), fallBehindCheckBlocks+1)
+	}
+	for i := 0; i < fallBehindCheckBlocks; i++ {
+		if results[i].err != nil {
+			t.Fatalf("result %d error = %v, want block", i, results[i].err)
+		}
+	}
+	if !stdErrors.Is(results[fallBehindCheckBlocks].err, errResync) {
+		t.Fatalf("last error = %v, want errResync", results[fallBehindCheckBlocks].err)
+	}
+	if chain.bestHeightCalls != 1 {
+		t.Fatalf("GetBestBlockHeight calls = %d, want 1", chain.bestHeightCalls)
+	}
+}
+
+func TestGetBlockChainNoYieldNearTip(t *testing.T) {
+	const tip = fallBehindCheckBlocks + 50
+	chain := &getBlockChainTestChain{
+		bestHeight:    tip,
+		chainType:     bchain.ChainEthereumType,
+		hashes:        map[uint32]string{},
+		blocks:        makeSequentialTestBlocks(tip),
+		blockErrors:   map[uint32][]error{},
+		getBlockCalls: map[uint32]int{},
+	}
+	w := newGetBlockChainTestWorker(t, chain, "h1", 1)
+	w.syncWorkers = 16
+
+	results := runGetBlockChain(w)
+	if len(results) != tip {
+		t.Fatalf("got %d results, want %d", len(results), tip)
+	}
+	for i, res := range results {
+		if res.err != nil {
+			t.Fatalf("result %d error = %v, want block", i, res.err)
+		}
+	}
+}
+
+func TestGetBlockChainFallBehindYieldGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		syncWorkers int
+		chainType   bchain.ChainType
+	}{
+		{name: "single worker never yields", syncWorkers: 1, chainType: bchain.ChainEthereumType},
+		{name: "non-EVM chain never yields", syncWorkers: 16, chainType: bchain.ChainBitcoinType},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const available = fallBehindCheckBlocks + 20
+			endErr := stdErrors.New("boom")
+			chain := &getBlockChainTestChain{
+				bestHeight: 100000,
+				chainType:  tt.chainType,
+				hashes:     map[uint32]string{},
+				blocks:     makeSequentialTestBlocks(available),
+				blockErrors: map[uint32][]error{
+					available + 1: {endErr},
+				},
+				getBlockCalls: map[uint32]int{},
+			}
+			w := newGetBlockChainTestWorker(t, chain, "h1", 1)
+			w.syncWorkers = tt.syncWorkers
+
+			results := runGetBlockChain(w)
+			if len(results) != available+1 {
+				t.Fatalf("got %d results, want %d", len(results), available+1)
+			}
+			for i := 0; i < available; i++ {
+				if results[i].err != nil {
+					t.Fatalf("result %d error = %v, want block", i, results[i].err)
+				}
+			}
+			if !stdErrors.Is(results[available].err, endErr) {
+				t.Fatalf("last error = %v, want %v", results[available].err, endErr)
 			}
 		})
 	}

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -171,7 +171,7 @@ When an override is applied, blockbook logs one `sync: missingBlockRetry overrid
 Related Prometheus counters for observing the budget at runtime:
 
 - `blockbook_index_block_not_found_retries` — every transient `ErrBlockNotFound` observed during sync.
-- `blockbook_index_sync_yields{reason="deadline"|"probe_failed"}` — wall-clock cap fired vs chain-state probe failed three times.
+- `blockbook_index_sync_yields{reason="deadline"|"probe_failed"|"fell_behind"}` — wall-clock cap fired, chain-state probe failed three times, or sequential sync fell too far behind the backend tip and yielded for parallel catch-up.
 - `blockbook_index_reorg_events{type="fork"|"resync"|"disconnect"}` — real reorg signals (not stall yields).
 
 For the [tip feed](#tip-feed-and-the-stall-watchdog) (EVM and Tron only):


### PR DESCRIPTION
## Problem

On EVM chains that produce blocks faster than the sequential loop can index them, Blockbook diverges from the tip indefinitely. Observed live on Robinhood Chain (dev2): the backend produces ~10 blk/s while the sequential loop tops out at ~8.3 blk/s (serial `eth_getBlockByNumber` + `eth_getLogs` + `debug_traceBlockByHash` ≈ 121 ms/block), so the gap grew ~130k blocks/day with the instance reporting healthy sync activity.

Root cause: once `resyncIndex` enters the sequential `connectBlocks` round, `getBlockChain` only exits on reaching the tip, a fork, or a stalled block fetch. It never re-checks whether it has fallen behind, so the parallel path is never reconsidered — a restart temporarily fixes it (parallel catch-up), then it wedges again the moment it touches the tip.

## Changes

- **Fall-behind yield**: `getBlockChain` probes the backend tip every 100 connected blocks; if it is more than `max(4×workers, 64)` blocks behind, it yields `errResync` so `resyncIndex` re-evaluates and takes the parallel path. Yields are visible as `blockbook_index_sync_yields{reason="fell-behind"}`. Gated to EVM chains with `-workers > 1` (Bitcoin-type chains have no steady-state parallel path to yield to); probe errors are ignored and re-tried on the next batch.
- **Parallel pool size from config**: the steady-state EVM parallel path used a hardcoded pool of 4 workers, ignoring the `-workers` flag. It now uses the configured count capped by the block range. The trigger threshold stays at 4 blocks, decoupled from the pool size, so small steady-state rounds keep their current behavior.

## Testing

- New unit tests: yield-when-behind (exactly one tip probe, `errResync` after 100 blocks), no-yield-near-tip, gating (single worker / non-EVM never yield), and pool-capping table.
- Full `go test -tags unittest ./db/` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)