### PR TITLE
fix(eth): bound decoded contract name/symbol/tokenURI length

### DIFF
--- a/bchain/coins/eth/dataparser.go
+++ b/bchain/coins/eth/dataparser.go
@@ -32,6 +32,11 @@ func parseSimpleNumericProperty(data string) *big.Int {
 	return nil
 }
 
+// maxParsedStringBytes caps how many bytes any decoded contract string (name/symbol/tokenURI) may
+// hold. A malicious contract can make a free eth_call return an arbitrarily large string; without
+// this ceiling the live, unstored tokenURI path would decode the whole blob on every request.
+const maxParsedStringBytes = 64 << 10
+
 func parseSimpleStringProperty(data string) string {
 	if has0xPrefix(data) {
 		data = data[2:]
@@ -41,6 +46,9 @@ func parseSimpleStringProperty(data string) string {
 		if n != nil {
 			l := n.Int64()
 			if l > 0 && int(l) <= ((len(data)-128)>>1) {
+				if l > maxParsedStringBytes {
+					l = maxParsedStringBytes
+				}
 				b, err := hex.DecodeString(data[128 : 128+2*l])
 				if err == nil {
 					return string(b)
@@ -49,7 +57,7 @@ func parseSimpleStringProperty(data string) string {
 		}
 	}
 	// allow string properties as UTF-8 data
-	b, err := hex.DecodeString(data)
+	b, err := hex.DecodeString(data[:min(len(data), 2*maxParsedStringBytes)])
 	if err == nil {
 		i := min(bytes.Index(b, []byte{0}), 32)
 		if i > 0 {

--- a/bchain/coins/eth/dataparser_test.go
+++ b/bchain/coins/eth/dataparser_test.go
@@ -3,7 +3,9 @@
 package eth
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/trezor/blockbook/bchain"
@@ -59,6 +61,24 @@ func Test_parseSimpleStringProperty(t *testing.T) {
 				t.Errorf("parseSimpleStringProperty = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// A malicious contract can make a free eth_call return an arbitrarily large ABI string;
+// parseSimpleStringProperty must cap the decode at maxParsedStringBytes instead of honoring the
+// attacker-declared length.
+func Test_parseSimpleStringProperty_CapsOversizedString(t *testing.T) {
+	const declared = maxParsedStringBytes * 4
+	offset := "0000000000000000000000000000000000000000000000000000000000000020"
+	lengthWord := fmt.Sprintf("%064x", declared)
+	payload := strings.Repeat("41", declared) // 'A' repeated `declared` times
+
+	got := parseSimpleStringProperty("0x" + offset + lengthWord + payload)
+	if len(got) != maxParsedStringBytes {
+		t.Fatalf("decoded length = %d, want ceiling %d", len(got), maxParsedStringBytes)
+	}
+	if strings.Trim(got, "A") != "" {
+		t.Errorf("decoded string contains unexpected bytes, want all 'A'")
 	}
 }
 

--- a/db/rocksdb_contracts.go
+++ b/db/rocksdb_contracts.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"unicode/utf8"
+
 	vlq "github.com/bsm/go-vlq"
 	"github.com/golang/glog"
 	"github.com/juju/errors"
@@ -10,9 +12,26 @@ import (
 
 var cachedContracts = newContractInfoLRU(cachedContractsLRUMaxSize)
 
+// maxContractNameSymbolBytes bounds the token name/symbol persisted per contract. A malicious
+// contract can return a multi-megabyte name()/symbol() over a free eth_call; capping here (the sole
+// pack chokepoint for every write path) keeps one cheap deployment from bloating the index forever.
+const maxContractNameSymbolBytes = 256
+
+// clampUTF8 truncates s to at most max bytes without leaving a split trailing rune.
+func clampUTF8(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	s = s[:max]
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
 func packContractInfo(contractInfo *bchain.ContractInfo) []byte {
-	buf := packString(contractInfo.Name)
-	buf = append(buf, packString(contractInfo.Symbol)...)
+	buf := packString(clampUTF8(contractInfo.Name, maxContractNameSymbolBytes))
+	buf = append(buf, packString(clampUTF8(contractInfo.Symbol, maxContractNameSymbolBytes))...)
 	buf = append(buf, packString(string(contractInfo.Standard))...)
 	varBuf := make([]byte, vlq.MaxLen64)
 	l := packVaruint(uint(contractInfo.Decimals), varBuf)

--- a/db/rocksdb_contracts_test.go
+++ b/db/rocksdb_contracts_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/linxGnu/grocksdb"
 	"github.com/trezor/blockbook/bchain"
@@ -482,5 +483,33 @@ func Test_packUnpackContractInfo(t *testing.T) {
 				t.Errorf("packUnpackContractInfo() = %+v, want %+v", *got, tt.contractInfo)
 			}
 		})
+	}
+}
+
+// A contract whose name()/symbol() return a multi-megabyte string must not bloat the index: the
+// pack chokepoint clamps both to maxContractNameSymbolBytes without leaving a split trailing rune.
+func Test_packContractInfo_ClampsNameSymbol(t *testing.T) {
+	ci := bchain.ContractInfo{
+		Standard: bchain.ERC20TokenStandard,
+		Type:     bchain.ERC20TokenStandard,
+		// last byte within the cap starts a 4-byte rune, so a naive byte cut would split it
+		Name:   strings.Repeat("a", maxContractNameSymbolBytes-1) + "🟢" + strings.Repeat("b", 5<<20),
+		Symbol: strings.Repeat("🟢", 5<<20),
+	}
+	got, err := unpackContractInfo(packContractInfo(&ci))
+	if err != nil {
+		t.Fatalf("unpackContractInfo() err = %v", err)
+	}
+	if len(got.Name) > maxContractNameSymbolBytes {
+		t.Errorf("Name len = %d, want <= %d", len(got.Name), maxContractNameSymbolBytes)
+	}
+	if len(got.Symbol) > maxContractNameSymbolBytes {
+		t.Errorf("Symbol len = %d, want <= %d", len(got.Symbol), maxContractNameSymbolBytes)
+	}
+	if !utf8.ValidString(got.Name) || !utf8.ValidString(got.Symbol) {
+		t.Errorf("clamp left invalid UTF-8: name valid=%v symbol valid=%v", utf8.ValidString(got.Name), utf8.ValidString(got.Symbol))
+	}
+	if !strings.HasPrefix(got.Name, strings.Repeat("a", maxContractNameSymbolBytes-1)) {
+		t.Errorf("clamp dropped legitimate leading bytes of Name")
 	}
 }


### PR DESCRIPTION
## Summary

Contract metadata strings (`name()`, `symbol()`, `tokenURI()`) are read via `eth_call` and decoded without any length limit. `name`/`symbol` are then persisted in the `cfContracts` column family as-is. A contract that returns an unusually large string therefore grows the index and per-request memory use with no upper bound.

This adds two independent bounds:

- **Decode ceiling (64 KiB)** in `parseSimpleStringProperty` — applies to every reader, including the live `tokenURI` path whose result is not stored and is re-decoded on each request.
- **Stored name/symbol clamp (256 B, rune-safe)** in `packContractInfo` — the single funnel for every write path (EVM single call, Multicall3 batch, Tron), so what lands on disk stays bounded regardless of caller.

Both limits are generous for legitimate ERC-20/TRC-20 metadata and for the `http`/`ipfs` URIs that `GetTokenURI` actually returns.

## Tests

- `Test_parseSimpleStringProperty_CapsOversizedString` — an oversized ABI string decodes to exactly the ceiling.
- `Test_packContractInfo_ClampsNameSymbol` — large name/symbol round-trip to ≤256 bytes, stay valid UTF-8 (no split rune), and keep their leading bytes.