### PR TITLE
fix(evm): keep confirmations sane when the reference height lags

### DIFF
--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -1497,6 +1497,11 @@ func (b *EthereumRPC) computeConfirmations(n uint64) (uint32, error) {
 		return 0, err
 	}
 	bn := bh.Number().Uint64()
+	// The cached tip is advanced asynchronously, so a block fetched straight from the
+	// backend can be ahead of it; report the mined minimum instead of underflowing.
+	if bn < n {
+		return 1, nil
+	}
 	// transaction in the best block has 1 confirmation
 	return uint32(bn - n + 1), nil
 }

--- a/bchain/coins/eth/ethrpc_confirmations_test.go
+++ b/bchain/coins/eth/ethrpc_confirmations_test.go
@@ -1,0 +1,33 @@
+package eth
+
+import "testing"
+
+// The cached tip is advanced by the newHeads subscription and the watchdog poll, while the
+// block height passed in is read straight from the backend, so the height can be ahead of
+// the tip. That must not underflow the unsigned subtraction into a bogus finality count.
+func TestComputeConfirmations_TipBehindHeight(t *testing.T) {
+	const tip = 18000000
+	tests := []struct {
+		name   string
+		height uint64
+		want   uint32
+	}{
+		{"height below tip", tip - 1, 2},
+		{"height at tip", tip, 1},
+		{"tip behind by 1 block", tip + 1, 1},
+		{"tip behind by 2 blocks", tip + 2, 1},
+		{"tip behind by many blocks", tip + 300, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &EthereumRPC{bestHeader: stubHeader{n: tip}}
+			got, err := b.computeConfirmations(tt.height)
+			if err != nil {
+				t.Fatalf("computeConfirmations(%d) error %v", tt.height, err)
+			}
+			if got != tt.want {
+				t.Errorf("computeConfirmations(%d) with tip %d = %d, want %d", tt.height, tip, got, tt.want)
+			}
+		})
+	}
+}

--- a/db/txcache.go
+++ b/db/txcache.go
@@ -47,7 +47,13 @@ func (c *TxCache) GetTransaction(txid string) (*bchain.Tx, int, error) {
 		if tx != nil {
 			// number of confirmations is not stored in cache, they change all the time
 			_, bestheight, _, _ := c.is.GetSyncState()
-			tx.Confirmations = bestheight - h + 1
+			// Ethereum-type txs are cached at their chain height, which can be above the
+			// indexed height; report the mined minimum instead of underflowing.
+			if bestheight < h {
+				tx.Confirmations = 1
+			} else {
+				tx.Confirmations = bestheight - h + 1
+			}
 			c.metrics.TxCacheEfficiency.With(common.Labels{"status": "hit"}).Inc()
 			return tx, int(h), nil
 		}

--- a/db/txcache_test.go
+++ b/db/txcache_test.go
@@ -1,0 +1,75 @@
+//go:build unittest
+
+package db
+
+import (
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/eth"
+	"github.com/trezor/blockbook/common"
+)
+
+// confirmationsStubParser packs just enough to round-trip a txid at a fixed height, so the
+// test does not depend on a complete Ethereum transaction fixture.
+type confirmationsStubParser struct {
+	*eth.EthereumParser
+	height uint32
+}
+
+func (p *confirmationsStubParser) PackTx(tx *bchain.Tx, height uint32, blockTime int64) ([]byte, error) {
+	return []byte(tx.Txid), nil
+}
+
+func (p *confirmationsStubParser) UnpackTx(buf []byte) (*bchain.Tx, uint32, error) {
+	return &bchain.Tx{Txid: string(buf)}, p.height, nil
+}
+
+// Ethereum-type transactions are cached at their chain height, which can be above the
+// height Blockbook has indexed. Recomputing confirmations on a cache hit must then not
+// underflow the unsigned subtraction into a bogus finality count.
+func TestTxCacheGetTransaction_HeightAboveIndexedBestHeight(t *testing.T) {
+	const txHeight = 18000010
+	const txid = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+
+	parser := &confirmationsStubParser{EthereumParser: eth.NewEthereumParser(1, true), height: txHeight}
+	d := setupRocksDB(t, parser)
+	defer closeAndDestroyRocksDB(t, d)
+
+	metrics, err := common.GetMetrics("coin-unittest-txcache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &TxCache{db: d, metrics: metrics, is: d.is, enabled: true, chainType: bchain.ChainEthereumType}
+
+	if err := d.PutTx(&bchain.Tx{Txid: txid}, txHeight, 1600000000); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		bestHeight uint32
+		want       uint32
+	}{
+		{"indexed height above tx", txHeight + 4, 5},
+		{"indexed height at tx", txHeight, 1},
+		{"indexed height behind by 1 block", txHeight - 1, 1},
+		{"indexed height behind by many blocks", txHeight - 300, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d.is.BestHeight = tt.bestHeight
+			tx, h, err := c.GetTransaction(txid)
+			if err != nil {
+				t.Fatalf("GetTransaction error %v", err)
+			}
+			if h != txHeight {
+				t.Errorf("GetTransaction height = %d, want %d", h, txHeight)
+			}
+			if tx.Confirmations != tt.want {
+				t.Errorf("Confirmations with best height %d and tx height %d = %d, want %d",
+					tt.bestHeight, txHeight, tx.Confirmations, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ethereum-type confirmation counts are unsigned subtractions with no check that the reference height is actually ahead of the height being reported on:

- `eth.computeConfirmations` subtracts the **asynchronously cached tip** (advanced by the `newHeads` subscription and the watchdog poll) from a block/tx height read **straight from the backend** on that call.
- `TxCache.GetTransaction` subtracts the **indexed best height** from the chain height an Ethereum-type tx was cached at — and on a cache miss such a tx is stored at its real chain height, which can be above what Blockbook has indexed.

Either reference can be behind by a block or more, and `uint` subtraction then wraps: a tx that is genuinely 2 blocks old is reported with ~4.29e9 confirmations, on both `/api/v2/tx/{txid}` and the explorer page, for every Ethereum-type coin. A lag of exactly 1 block yields `0` instead, which makes a mined tx render as unconfirmed with a zeroed blocktime.

Both are clamped to `1` — the mined minimum, and the truthful floor since the block is known to exist — matching the guard `tron.computeBlockConfirmations` already has.

Regression tests cover both paths across the lag range.