### PR TITLE
fix(btc): derive xpub utxo path from the configured change index

### DIFF
--- a/api/xpub.go
+++ b/api/xpub.go
@@ -801,7 +801,8 @@ func (w *Worker) GetXpubUtxo(xpub string, onlyConfirmed bool, gap int) (Utxos, e
 				return nil, err
 			}
 			if len(utxos) > 0 {
-				t := w.tokenFromXpubAddress(data, ad, ci, i, AccountDetailsTokens)
+				// ci is the position in data.addresses, the derivation path needs the configured change index
+				t := w.tokenFromXpubAddress(data, ad, int(xd.ChangeIndexes[ci]), i, AccountDetailsTokens)
 				for j := range utxos {
 					a := &utxos[j]
 					a.Address = t.Name

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -939,6 +939,17 @@ func httpTestsBitcoinType(t *testing.T, ts *httptest.Server) {
 			},
 		},
 		{
+			// change 1 is the only branch of the descriptor, so its position is 0 - the path
+			// must still name the configured change index
+			name:        "apiUtxo v2 xpub change only descriptor",
+			r:           newGetRequest(ts.URL + "/api/v2/utxo/" + url.QueryEscape("sh(wpkh([5c9e228d/49'/1'/33']"+dbtestdata.Xpub+"/1/*))")),
+			status:      http.StatusOK,
+			contentType: "application/json; charset=utf-8",
+			body: []string{
+				`[{"txid":"3d90d15ed026dc45e19ffb52875ed18fa9e8012ad123d7f7212176e2b0ebdb71","vout":0,"value":"118641975500","height":225494,"confirmations":1,"address":"2N6utyMZfPNUb1Bk8oz7p2JqJrXkq83gegu","path":"m/49'/1'/33'/1/3"}]`,
+			},
+		},
+		{
 			name:        "apiUtxo v2 xpub",
 			r:           newGetRequest(ts.URL + "/api/v2/utxo/" + url.QueryEscape(dbtestdata.TaprootDescriptor)),
 			status:      http.StatusOK,


### PR DESCRIPTION
## Problem

`GetXpubUtxo` builds each utxo's `path` from the branch's **position** in `data.addresses` instead of the change index that branch is configured with:

```go
// api/xpub.go
for ci, da := range data.addresses {
    ...
    t := w.tokenFromXpubAddress(data, ad, ci, i, AccountDetailsTokens)
```

`data.addresses` has one slice per entry of `xd.ChangeIndexes`, so `ci` equals the change index only when the descriptor uses the default `0,1` in that order. `GetXpubAddress` translates it correctly two lines away — that was fixed in ca3a0234, which touched only the one call site.

The result is a path that derives a real but different address of the same account:

```
descriptor sh(wpkh([…/49'/1'/33']upub…/1/*))   ChangeIndexes=[1]
  address 2N6utyMZfPNUb1Bk8oz7p2JqJrXkq83gegu
  GetXpubAddress path  m/49'/1'/33'/1/3   -> that address
  GetXpubUtxo   path  m/49'/1'/33'/0/3   -> 2NEqKzw3BosGnBE9by5uaDy5QgwjHac4Zbg
```

Two descriptor forms hit this in practice:

- a single-branch change descriptor `.../1/*` — the shape `bitcoin-cli listdescriptors` exports, since Core emits receive and change as separate descriptors
- a reordered or non-default multipath descriptor, e.g. `.../<1;0>/*` (paths get swapped between two real addresses of the account) or `.../<5;7>/*`

Bare xpubs, `tr(...)` and `.../<0;1>/*` are unaffected, because there position and index coincide — which is why the existing coverage (`dbtestdata.Xpub`) never caught it.

Reached through `/api/v2/utxo/<descriptor>` and the websocket `getAccountUtxo`. Only `path` was wrong; `address`, `txid`, `vout` and `value` were correct throughout, so nothing about balances or coin selection was affected. A client that fed the path into a signing request would get a rejected transaction rather than a bad signature, since the prevout script is fixed on chain.

## Fix

Pass `int(xd.ChangeIndexes[ci])`, matching `GetXpubAddress`.

## Test

One case added to the `apiUtxo` table in `Test_PublicServer_BitcoinType`. The existing bitcoin-type fixture's only utxo sits on change 1 index 3, so a change-only descriptor puts that branch at position 0 — exactly where the two values diverge. The expected body is identical to the neighbouring bare-xpub case, including `"path":"m/49'/1'/33'/1/3"`; on master this case returns `m/49'/1'/33'/0/3`.