### PR TITLE
fix(evm): flush the address-contracts cache from the block-connect goroutine

### DIFF
--- a/db/bulkconnect.go
+++ b/db/bulkconnect.go
@@ -491,6 +491,7 @@ func (b *BulkConnect) connectBlockEthereumType(block *bchain.Block, storeBlockTx
 			return err
 		}
 	}
+	b.d.storeAddrContractsCacheIfDue()
 	return nil
 }
 

--- a/db/rocksdb.go
+++ b/db/rocksdb.go
@@ -279,6 +279,9 @@ const (
 
 const addrContractsCacheMinSize = 300_000 // limit for caching address contracts in memory to speed up indexing
 
+// addrContractsCacheStorePeriod is how often the cache is packed to disk during block connect.
+const addrContractsCacheStorePeriod = 5 * time.Minute
+
 // RocksDB handle
 type RocksDB struct {
 	path            string
@@ -316,7 +319,9 @@ type RocksDB struct {
 	// addrContractsCacheBytes tracks cached size based on the packed size at insertion time.
 	addrContractsCacheBytes int64
 	hotAddrTracker          *addressHotness
-	setBlockTimesWG         sync.WaitGroup
+	// lastAddrContractsCacheStore is only read/written from the block-connect goroutine.
+	lastAddrContractsCacheStore time.Time
+	setBlockTimesWG             sync.WaitGroup
 }
 
 const (
@@ -446,7 +451,7 @@ func NewRocksDB(path string, cacheSize, maxOpenFiles int, parser bchain.BlockCha
 		if r.bulkAddrContractsCacheMaxBytes == 0 {
 			r.bulkAddrContractsCacheMaxBytes = r.addrContractsCacheMaxBytes
 		}
-		go r.periodicStoreAddrContractsCache()
+		r.lastAddrContractsCacheStore = time.Now()
 	}
 	return r, nil
 }
@@ -745,6 +750,9 @@ func (d *RocksDB) ConnectBlock(block *bchain.Block) error {
 	}
 	if err := d.WriteBatch(wb); err != nil {
 		return err
+	}
+	if chainType == bchain.ChainEthereumType {
+		d.storeAddrContractsCacheIfDue()
 	}
 	// Fractional seconds: the integer average truncates to 0 on sub-second chains, which
 	// silently excludes them from any rule gated on this gauge being > 0. SetBlockTime

--- a/db/rocksdb_ethereumtype.go
+++ b/db/rocksdb_ethereumtype.go
@@ -2108,12 +2108,13 @@ func (d *RocksDB) storeAddrContractsCache() {
 	glog.Info("storeAddrContractsCache: store ", len(d.addrContractsCache), " entries in ", time.Since(start))
 }
 
-func (d *RocksDB) periodicStoreAddrContractsCache() {
-	period := time.Duration(5) * time.Minute
-	timer := time.NewTimer(period)
-	for {
-		<-timer.C
-		timer.Reset(period)
-		d.storeAddrContractsCache()
+// storeAddrContractsCacheIfDue periodically flushes the cache from the block-connect
+// goroutine. Cached records are mutated without addrContractsCacheMux while a block is
+// connected, so packing them from any other goroutine would race with that mutation.
+func (d *RocksDB) storeAddrContractsCacheIfDue() {
+	if time.Since(d.lastAddrContractsCacheStore) < addrContractsCacheStorePeriod {
+		return
 	}
+	d.lastAddrContractsCacheStore = time.Now()
+	d.storeAddrContractsCache()
 }


### PR DESCRIPTION
## Problem

`getUnpackedAddrDescContracts` releases `addrContractsCacheMux` before returning the cached `*unpackedAddrContracts`, and the block-connect path then mutates that record — `Contracts` append, `Ids` / `MultiTokenValues` insert, `Txs` and `TotalTxs` counters — with no lock held. `BulkConnect`'s Ethereum path holds no lock at all.

The `periodicStoreAddrContractsCache` goroutine packed those same records every 5 minutes while holding only `addrContractsCacheMux`. That is a different critical section from the one the mutation runs in, so the two provided no mutual exclusion against each other.

`packUnpackedAddrContracts` reads a slice length and then ranges the same slice as two separate reads, and `cfAddressContracts` is a positional varint format whose element counts the unpacker trusts. A flush overlapping a mutation could therefore emit a record whose remaining bytes are shifted, which reads back as wrong token holdings for that address until the next flush rewrites it.

Only records over `addrContractsCacheMinSize` (300 KB) are cached, and `storeUnpackedAddressContracts` deliberately skips those, so for them the periodic flush is the only writer.

## Change

Replace the timer goroutine with `storeAddrContractsCacheIfDue`, called from `ConnectBlock` and `BulkConnect.connectBlockEthereumType` once the period has elapsed. The flush now runs on the only goroutine that mutates these records, so no extra locking or copying is needed.

This mirrors `flushAddrContractsCacheIfOverCap`, which already flushes synchronously from the same path.

Dropping the goroutine also removes a shutdown hazard: it had no stop channel and was never joined, so a tick landing inside `closeDB()` would have used column family handles that were already destroyed.

## Notes

- Block connect now blocks for the flush duration every 5 minutes. `flushAddrContractsCacheIfOverCap` already imposes the same stall on this path, so this is not a new class of pause.
- Flushes are now driven by block arrival rather than wall clock, so a chain producing no blocks does not flush. Cached mutations are already unflushed for up to 5 minutes today (`storeUnpackedAddressContracts` skips cached addresses), and `Close()` still flushes on shutdown, so this only extends that window on an idle chain.
- The unpackers (`partiallyUnpackAddrContracts`, `unpackBigint`) index into the buffer using in-buffer length bytes without bounds checks. That is left alone here; hardening it is separate from this change.

## Testing

`gofmt` clean. The package could not be compiled or tested in this environment — cgo builds fail on a sandbox restriction unrelated to the change (`cc: couldn't create cache file .../xcrun_db-*`), so `go build ./db/` and `go test ./db/` still need to be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)