### PR TITLE
feat(tron): log the outcome and txid of every direct send

### DIFF
--- a/bchain/coins/tron/tronhttp_endpoints.go
+++ b/bchain/coins/tron/tronhttp_endpoints.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/juju/errors"
@@ -283,18 +284,27 @@ func (b *TronRPC) SendRawTransaction(tx string, disableAlternativeRPC bool) (str
 	ctx, cancel := context.WithTimeout(b.requestContext(), b.Timeout)
 	defer cancel()
 
+	// A send is the only moment Blockbook sees a transaction the wallet cares about before it is
+	// indexed, so log the outcome and txid - a later "my tx vanished" report has nothing else to
+	// reconcile against on a chain with no pending-tx feed.
+	start := time.Now()
 	resp, err := b.requestBroadcastHex(ctx, strip0xPrefix(tx))
+	duration := time.Since(start).Round(time.Millisecond)
 	if err != nil {
+		glog.Errorf("tron broadcasthex failed after %v: %v", duration, err)
 		return "", err
 	}
 	if !resp.Result {
 		if resp.Code != "" || resp.Message != "" {
+			glog.Errorf("tron broadcasthex rejected txid %s after %v: %s %s", strip0xPrefix(resp.TxID), duration, resp.Code, resp.Message)
 			return "", errors.Errorf("Tron broadcasthex failed: %s %s", resp.Code, resp.Message)
 		}
+		glog.Errorf("tron broadcasthex rejected txid %s after %v without a reason", strip0xPrefix(resp.TxID), duration)
 		return "", errors.New("Tron broadcasthex failed")
 	}
 
 	txID := strip0xPrefix(resp.TxID)
+	glog.Infof("tron broadcasthex accepted txid %s in %v", txID, duration)
 	if b.ChainConfig != nil && b.ChainConfig.DisableMempoolSync && b.Mempool != nil {
 		b.Mempool.AddTransactionToMempool(txID)
 	}


### PR DESCRIPTION
Logs the result of every transaction broadcast through `TronRPC.SendRawTransaction` (the path behind `/api/v2/sendtx` and the websocket `sendTransaction`), so a directly-sent txid is recoverable from the logs:

```
tron broadcasthex accepted txid <txid> in 123ms
tron broadcasthex rejected txid <txid> after 123ms: <code> <message>
tron broadcasthex failed after 123ms: <transport error>
```

A send is the only moment Blockbook sees a transaction before it is indexed, and Tron has no pending-tx feed (ZeroMQ subscribes to blocks only), so an own send is otherwise invisible until the next mempool resync. Wording and the elapsed-time field mirror the existing `eth_sendRawTransaction` log lines; the sender/nonce are not decoded because Tron's raw tx is protobuf rather than RLP.

Success is `Info`, failures are `Error`. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)