### PR TITLE
feat(build): allow per-environment coin config values

### DIFF
--- a/build/tools/additional_params.go
+++ b/build/tools/additional_params.go
@@ -1,0 +1,113 @@
+package build
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validateAdditionalParamsOverlay rejects an override of a setting the production
+// additional_params does not declare, so a typo fails the build and additional_params
+// stays the complete inventory of settings with their production values.
+func validateAdditionalParamsOverlay(base, overlay map[string]json.RawMessage) error {
+	var unknown []string
+	for name := range overlay {
+		if _, ok := base[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("additional_params_dev overrides settings missing from additional_params: %s (declare the setting with its production value first)", strings.Join(unknown, ", "))
+}
+
+// mergeAdditionalParams applies the dev overlay over the production additional_params.
+func mergeAdditionalParams(base, overlay map[string]json.RawMessage) (map[string]json.RawMessage, error) {
+	if len(overlay) == 0 {
+		return base, nil
+	}
+
+	merged := make(map[string]json.RawMessage, len(base))
+	for name, value := range base {
+		merged[name] = value
+	}
+	for name, override := range overlay {
+		value, err := mergeJSONValues(base[name], override)
+		if err != nil {
+			return nil, fmt.Errorf("additional_params_dev %q: %w", name, err)
+		}
+		merged[name] = value
+	}
+	return merged, nil
+}
+
+// mergeJSONValues merges two JSON objects field by field and replaces anything else
+// outright. A field the base object does not have is added: the must-exist rule is a
+// typo guard for setting names, not for the fields inside one setting's parameters.
+func mergeJSONValues(base, overlay json.RawMessage) (json.RawMessage, error) {
+	baseObject, baseWasString, baseOK := decodeJSONObject(base)
+	overlayObject, _, overlayOK := decodeJSONObject(overlay)
+	if !baseOK || !overlayOK {
+		return overlay, nil
+	}
+
+	for name, override := range overlayObject {
+		value, err := mergeJSONValues(baseObject[name], override)
+		if err != nil {
+			return nil, err
+		}
+		baseObject[name] = value
+	}
+
+	// Re-encoding normalizes whitespace and sorts keys inside the value; every consumer
+	// unmarshals it, so only the rendered text differs from the production config.
+	encoded, err := json.Marshal(baseObject)
+	if err != nil {
+		return nil, err
+	}
+	if !baseWasString {
+		return encoded, nil
+	}
+	// The *_params settings carry their object inside a JSON string; keep that form so
+	// the runtime schema of the setting is unchanged.
+	quoted, err := json.Marshal(string(encoded))
+	if err != nil {
+		return nil, err
+	}
+	return quoted, nil
+}
+
+// decodeJSONObject decodes a JSON object, either given directly or encoded in a JSON
+// string as the *_params settings are, reporting which of the two forms it was.
+func decodeJSONObject(raw json.RawMessage) (object map[string]json.RawMessage, wasString bool, ok bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, false
+	}
+
+	switch trimmed[0] {
+	case '{':
+		if err := json.Unmarshal(trimmed, &object); err != nil {
+			return nil, false, false
+		}
+		return object, false, true
+	case '"':
+		var unquoted string
+		if err := json.Unmarshal(trimmed, &unquoted); err != nil {
+			return nil, false, false
+		}
+		inner := bytes.TrimSpace([]byte(unquoted))
+		if len(inner) == 0 || inner[0] != '{' {
+			return nil, false, false
+		}
+		if err := json.Unmarshal(inner, &object); err != nil {
+			return nil, false, false
+		}
+		return object, true, true
+	}
+	return nil, false, false
+}

--- a/build/tools/additional_params_test.go
+++ b/build/tools/additional_params_test.go
@@ -1,0 +1,148 @@
+package build
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateAdditionalParamsOverlayRejectsUndeclaredSetting(t *testing.T) {
+	base := map[string]json.RawMessage{
+		"alternative_estimate_fee_params": json.RawMessage(`"{\"periodSeconds\": 10}"`),
+	}
+	overlay := map[string]json.RawMessage{
+		"alternative_estimate_fee_paarms": json.RawMessage(`{"periodSeconds": 300}`),
+	}
+
+	err := validateAdditionalParamsOverlay(base, overlay)
+	if err == nil {
+		t.Fatal("expected a setting missing from additional_params to be rejected")
+	}
+	if !strings.Contains(err.Error(), "alternative_estimate_fee_paarms") {
+		t.Fatalf("expected the offending setting to be named, got %v", err)
+	}
+
+	if err := validateAdditionalParamsOverlay(base, nil); err != nil {
+		t.Fatalf("validateAdditionalParamsOverlay(no overlay) error = %v", err)
+	}
+}
+
+func TestMergeAdditionalParams(t *testing.T) {
+	const feeParams = `"{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees\", \"periodSeconds\": 10, \"staleSeconds\": 600}"`
+
+	tests := []struct {
+		name    string
+		base    map[string]json.RawMessage
+		overlay map[string]json.RawMessage
+		want    map[string]string
+	}{
+		{
+			name:    "no overlay keeps base",
+			base:    map[string]json.RawMessage{"eip1559Fees": json.RawMessage(`true`)},
+			overlay: nil,
+			want:    map[string]string{"eip1559Fees": `true`},
+		},
+		{
+			name:    "scalar is replaced",
+			base:    map[string]json.RawMessage{"disableMempoolSync": json.RawMessage(`false`)},
+			overlay: map[string]json.RawMessage{"disableMempoolSync": json.RawMessage(`true`)},
+			want:    map[string]string{"disableMempoolSync": `true`},
+		},
+		{
+			name:    "string encoded params merge field by field and stay a string",
+			base:    map[string]json.RawMessage{"alternative_estimate_fee_params": json.RawMessage(feeParams)},
+			overlay: map[string]json.RawMessage{"alternative_estimate_fee_params": json.RawMessage(`{"periodSeconds": 300}`)},
+			want: map[string]string{
+				"alternative_estimate_fee_params": `"{\"periodSeconds\":300,\"staleSeconds\":600,\"url\":\"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees\"}"`,
+			},
+		},
+		{
+			name:    "string encoded overlay is accepted too",
+			base:    map[string]json.RawMessage{"fiat_rates_params": json.RawMessage(`"{\"coin\": \"ethereum\", \"periodSeconds\": 900}"`)},
+			overlay: map[string]json.RawMessage{"fiat_rates_params": json.RawMessage(`"{\"periodSeconds\": 3600}"`)},
+			want: map[string]string{
+				"fiat_rates_params": `"{\"coin\":\"ethereum\",\"periodSeconds\":3600}"`,
+			},
+		},
+		{
+			name:    "overlay may add a field the base params omit",
+			base:    map[string]json.RawMessage{"alternative_estimate_fee_params": json.RawMessage(`"{\"periodSeconds\": 10}"`)},
+			overlay: map[string]json.RawMessage{"alternative_estimate_fee_params": json.RawMessage(`{"staleSeconds": 1800}`)},
+			want: map[string]string{
+				"alternative_estimate_fee_params": `"{\"periodSeconds\":10,\"staleSeconds\":1800}"`,
+			},
+		},
+		{
+			name:    "plain objects merge recursively",
+			base:    map[string]json.RawMessage{"missingBlockRetry": json.RawMessage(`{"attempts": 3, "backoff": {"initialMs": 500, "maxMs": 5000}}`)},
+			overlay: map[string]json.RawMessage{"missingBlockRetry": json.RawMessage(`{"backoff": {"maxMs": 60000}}`)},
+			want: map[string]string{
+				"missingBlockRetry": `{"attempts":3,"backoff":{"initialMs":500,"maxMs":60000}}`,
+			},
+		},
+		{
+			name:    "settings outside the overlay are untouched",
+			base:    map[string]json.RawMessage{"eip1559Fees": json.RawMessage(`true`), "mempoolTxTimeoutHours": json.RawMessage(`48`)},
+			overlay: map[string]json.RawMessage{"mempoolTxTimeoutHours": json.RawMessage(`2`)},
+			want:    map[string]string{"eip1559Fees": `true`, "mempoolTxTimeoutHours": `2`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged, err := mergeAdditionalParams(tt.base, tt.overlay)
+			if err != nil {
+				t.Fatalf("mergeAdditionalParams() error = %v", err)
+			}
+			if len(merged) != len(tt.want) {
+				t.Fatalf("merged has %d settings, want %d: %v", len(merged), len(tt.want), merged)
+			}
+			for name, want := range tt.want {
+				if got := string(merged[name]); got != want {
+					t.Fatalf("merged[%q] = %s, want %s", name, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestMergeAdditionalParamsDoesNotMutateBase(t *testing.T) {
+	const original = `"{\"url\": \"https://example.invalid\", \"periodSeconds\": 10}"`
+	base := map[string]json.RawMessage{"alternative_estimate_fee_params": json.RawMessage(original)}
+	overlay := map[string]json.RawMessage{"alternative_estimate_fee_params": json.RawMessage(`{"periodSeconds": 300}`)}
+
+	if _, err := mergeAdditionalParams(base, overlay); err != nil {
+		t.Fatalf("mergeAdditionalParams() error = %v", err)
+	}
+	if got := string(base["alternative_estimate_fee_params"]); got != original {
+		t.Fatalf("base was mutated: %s", got)
+	}
+}
+
+func TestDecodeJSONObjectReportsForm(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		wantOK        bool
+		wantWasString bool
+	}{
+		{name: "object", raw: `{"a": 1}`, wantOK: true},
+		{name: "string encoded object", raw: `"{\"a\": 1}"`, wantOK: true, wantWasString: true},
+		{name: "plain string", raw: `"infura"`},
+		{name: "number", raw: `42`},
+		{name: "array", raw: `[1, 2]`},
+		{name: "empty", raw: ``},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, wasString, ok := decodeJSONObject(json.RawMessage(tt.raw))
+			if ok != tt.wantOK {
+				t.Fatalf("decodeJSONObject(%s) ok = %v, want %v", tt.raw, ok, tt.wantOK)
+			}
+			if wasString != tt.wantWasString {
+				t.Fatalf("decodeJSONObject(%s) wasString = %v, want %v", tt.raw, wasString, tt.wantWasString)
+			}
+		})
+	}
+}

--- a/build/tools/templates.go
+++ b/build/tools/templates.go
@@ -93,6 +93,9 @@ type Config struct {
 			Slip44                 uint32 `json:"slip44,omitempty"`
 
 			AdditionalParams map[string]json.RawMessage `json:"additional_params"`
+			// Overrides merged over AdditionalParams only when BB_BUILD_ENV=dev, so a value
+			// tuned for a dev instance cannot reach a production package.
+			AdditionalParamsDev map[string]json.RawMessage `json:"additional_params_dev,omitempty"`
 		} `json:"block_chain"`
 	} `json:"blockbook"`
 	Meta struct {
@@ -411,6 +414,18 @@ func LoadConfig(configsDir, coin string) (*Config, error) {
 	err = d.Decode(&config.Env)
 	if err != nil {
 		return nil, err
+	}
+
+	blockChain := &config.Blockbook.BlockChain
+	// Validate in every build env so a typo in a dev override fails a production build too.
+	if err := validateAdditionalParamsOverlay(blockChain.AdditionalParams, blockChain.AdditionalParamsDev); err != nil {
+		return nil, fmt.Errorf("%s: %w", coin, err)
+	}
+	if buildEnv == buildEnvDev {
+		blockChain.AdditionalParams, err = mergeAdditionalParams(blockChain.AdditionalParams, blockChain.AdditionalParamsDev)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", coin, err)
+		}
 	}
 
 	config.Meta.BuildDatetime = time.Now().Format("Mon, 02 Jan 2006 15:04:05 -0700")

--- a/build/tools/templates_test.go
+++ b/build/tools/templates_test.go
@@ -454,3 +454,115 @@ func withTemporarilyUnsetEnv(t *testing.T, keys ...string) {
 		}
 	})
 }
+
+func renderBlockchainCfg(t *testing.T, config *Config) []byte {
+	t.Helper()
+
+	templ := config.ParseTemplate()
+	templ = template.Must(templ.ParseFiles(filepath.Join("..", "templates", "blockbook", "blockchaincfg.json")))
+
+	var rendered bytes.Buffer
+	if err := templ.ExecuteTemplate(&rendered, "main", config); err != nil {
+		t.Fatalf("ExecuteTemplate(blockchaincfg) error = %v", err)
+	}
+	return rendered.Bytes()
+}
+
+func TestAdditionalParamsDevOverlayAppliesOnlyToDevBuilds(t *testing.T) {
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	tests := []struct {
+		buildEnv       string
+		wantFeePeriod  float64
+		wantFiatPeriod float64
+	}{
+		{buildEnv: buildEnvProd, wantFeePeriod: 10, wantFiatPeriod: 900},
+		{buildEnv: buildEnvDev, wantFeePeriod: 300, wantFiatPeriod: 3600},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.buildEnv, func(t *testing.T) {
+			withTemporarilyUnsetEnv(t, buildEnvVar)
+			t.Setenv(buildEnvVar, tt.buildEnv)
+
+			config, err := LoadConfig(configsDir, "ethereum_archive")
+			if err != nil {
+				t.Fatalf("LoadConfig() error = %v", err)
+			}
+
+			rendered := renderBlockchainCfg(t, config)
+
+			var renderedCfg struct {
+				FeeParams  string          `json:"alternative_estimate_fee_params"`
+				FiatParams string          `json:"fiat_rates_params"`
+				DevOverlay json.RawMessage `json:"additional_params_dev"`
+			}
+			if err := json.Unmarshal(rendered, &renderedCfg); err != nil {
+				t.Fatalf("json.Unmarshal(blockchaincfg) error = %v", err)
+			}
+			if renderedCfg.DevOverlay != nil {
+				t.Fatalf("additional_params_dev leaked into the rendered config: %s", renderedCfg.DevOverlay)
+			}
+
+			for name, params := range map[string]struct {
+				raw  string
+				want float64
+			}{
+				"alternative_estimate_fee_params": {raw: renderedCfg.FeeParams, want: tt.wantFeePeriod},
+				"fiat_rates_params":               {raw: renderedCfg.FiatParams, want: tt.wantFiatPeriod},
+			} {
+				var decoded map[string]interface{}
+				if err := json.Unmarshal([]byte(params.raw), &decoded); err != nil {
+					t.Fatalf("json.Unmarshal(%s = %q) error = %v", name, params.raw, err)
+				}
+				if got := decoded["periodSeconds"]; got != params.want {
+					t.Fatalf("%s periodSeconds = %v, want %v", name, got, params.want)
+				}
+			}
+
+			// The overlay retunes one field, so the rest of the setting must survive intact.
+			if !strings.Contains(renderedCfg.FeeParams, "gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees") {
+				t.Fatalf("fee provider url lost in overlay merge: %q", renderedCfg.FeeParams)
+			}
+		})
+	}
+}
+
+func TestAllCoinConfigsRenderInBothBuildEnvs(t *testing.T) {
+	configsDir := filepath.Clean(filepath.Join("..", "..", "configs"))
+
+	entries, err := os.ReadDir(filepath.Join(configsDir, "coins"))
+	if err != nil {
+		t.Fatalf("ReadDir(coins) error = %v", err)
+	}
+
+	for _, entry := range entries {
+		coin := strings.TrimSuffix(entry.Name(), ".json")
+		if entry.IsDir() || coin == entry.Name() {
+			continue
+		}
+
+		t.Run(coin, func(t *testing.T) {
+			for _, buildEnv := range []string{buildEnvDev, buildEnvProd} {
+				withTemporarilyUnsetEnv(t, buildEnvVar)
+				t.Setenv(buildEnvVar, buildEnv)
+
+				config, err := LoadConfig(configsDir, coin)
+				if err != nil {
+					t.Fatalf("LoadConfig(%s) in %s error = %v", coin, buildEnv, err)
+				}
+				if isEmpty(config, "blockbook") {
+					continue
+				}
+
+				var renderedCfg map[string]json.RawMessage
+				if err := json.Unmarshal(renderBlockchainCfg(t, config), &renderedCfg); err != nil {
+					t.Fatalf("json.Unmarshal(blockchaincfg for %s in %s) error = %v", coin, buildEnv, err)
+				}
+				if _, ok := renderedCfg["additional_params_dev"]; ok {
+					t.Fatalf("additional_params_dev leaked into the rendered config of %s in %s", coin, buildEnv)
+				}
+			}
+		})
+	}
+}

--- a/configs/coins/arbitrum_archive.json
+++ b/configs/coins/arbitrum_archive.json
@@ -74,6 +74,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"arbitrum-one\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/avalanche.json
+++ b/configs/coins/avalanche.json
@@ -70,6 +70,14 @@
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"avalanche-2\",\"platformIdentifier\": \"avalanche\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/avalanche_archive.json
+++ b/configs/coins/avalanche_archive.json
@@ -75,6 +75,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"avalanche-2\",\"platformIdentifier\": \"avalanche\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/base_archive.json
+++ b/configs/coins/base_archive.json
@@ -76,6 +76,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"base\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/ethereum_archive.json
+++ b/configs/coins/ethereum_archive.json
@@ -80,6 +80,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"ethereum\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/hyperevm_archive.json
+++ b/configs/coins/hyperevm_archive.json
@@ -72,6 +72,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"hyperliquid\",\"platformIdentifier\": \"hyperevm\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/optimism_archive.json
+++ b/configs/coins/optimism_archive.json
@@ -74,6 +74,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"optimistic-ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/polygon_archive.json
+++ b/configs/coins/polygon_archive.json
@@ -79,6 +79,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"polygon-ecosystem-token\",\"platformIdentifier\": \"polygon-pos\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/configs/coins/robinhood_archive.json
+++ b/configs/coins/robinhood_archive.json
@@ -73,6 +73,14 @@
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"robinhood\",\"platformVsCurrency\": \"usd\",\"periodSeconds\": 900}",
                 "fourByteSignatures": "https://www.4byte.directory/api/v1/signatures/"
+            },
+            "additional_params_dev": {
+                "alternative_estimate_fee_params": {
+                    "periodSeconds": 300
+                },
+                "fiat_rates_params": {
+                    "periodSeconds": 3600
+                }
             }
         }
     },

--- a/docs/build.md
+++ b/docs/build.md
@@ -88,10 +88,16 @@ command: `make NO_CACHE=true all-bitcoin`.
 
 `PORTABLE`: By default, the RocksDB binaries shipped with Blockbook are optimized for the platform you're compiling on (-march=native or the equivalent). If you want to build a portable binary, use `make PORTABLE=1 all-bitcoin`.
 
-`BB_BUILD_ENV`: Selects which RPC URL override family is active during package/config generation. Defaults to `dev`.
-Accepted values are `dev` and `prod`.
+`BB_BUILD_ENV`: Selects which environment the package is generated for. Defaults to `dev`. Accepted values are `dev`
+and `prod`. It selects the active RPC URL override family, and in a `dev` build it also merges each coin's
+`blockbook.block_chain.additional_params_dev` block over `additional_params` (see
+[config guide](/docs/config.md)) so a dev instance can poll a paid fee or fiat-rates provider less often.
 Generated dev Blockbook services include `-prof=:<blockbook_internal + 20000>` automatically, while generated prod
 services do not include `-prof`.
+
+**Because the default is `dev`, a package intended for production must be built with `BB_BUILD_ENV=prod`.** The
+`Build / Deploy` workflow already does this: `mode=build` passes its `env` input through, and `mode=deploy` (dev-only)
+pins `dev`.
 
 `BB_DEV_RPC_URL_HTTP_<coin alias>` / `BB_PROD_RPC_URL_HTTP_<coin alias>`: Override `ipc.rpc_url_template` while generating
 package definitions so you can target hosted HTTP RPC endpoints without editing coin JSON. The root `Makefile` forwards

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -49,7 +49,9 @@ Inputs:
   - `dev` keeps the current per-coin dev runner mapping
   - `prod` builds selected coins on the `production-builder` runner regardless of `BB_RUNNER_*`
   - default is `dev`
-  - selected value is exported downstream as `BB_BUILD_ENV`
+  - selected value is exported downstream as `BB_BUILD_ENV`, which also decides whether each coin's
+    `blockbook.block_chain.additional_params_dev` overrides are merged into the generated `blockchaincfg.json`
+    (`dev` merges them, `prod` ignores them) — see [config.md](config.md)
   - ignored when `mode=deploy`
 - `backend_mode`:
   - `auto` derives backend builds per coin from the selected `BB_{DEV|PROD}_RPC_URL_HTTP_<coin_alias>` value
@@ -64,7 +66,8 @@ Inputs:
 
 In `mode=build`, selected coins are grouped by runner so one build job can build multiple
 `deb-blockbook-<coin>` targets in a single invocation on the same self-hosted machine.
-Deploy and test-related workflow steps use `BB_BUILD_ENV=dev`.
+Deploy and test-related workflow steps use `BB_BUILD_ENV=dev`, so a deployed instance and the integration/e2e
+suites both get the dev `additional_params` overrides.
 Generated dev Blockbook services start with pprof enabled on `:<blockbook_internal + 20000>`, for example Ethereum
 uses `:29036`. Generated prod services do not include `-prof`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -142,6 +142,48 @@ Good examples of coin configuration are
                 }
             }
             ```
+        * `additional_params_dev` – Overrides merged over `additional_params` **only** when the package is generated
+           with `BB_BUILD_ENV=dev` (see [environment variables](/docs/env.md#build-time-variables)). This is how a dev
+           instance runs a different value than production for a setting that costs money per request — above all the
+           `periodSeconds` of a paid fee or fiat-rates provider. A `BB_BUILD_ENV=prod` build ignores the block entirely,
+           so `additional_params` is always the production truth and a value tuned for dev cannot reach production.
+
+           The merge is sparse, so an override retunes one field and inherits the rest — the provider `url` is never
+           duplicated and so cannot drift from the production value:
+
+           | `additional_params` value | `additional_params_dev` value | Result |
+           | --- | --- | --- |
+           | JSON object | JSON object | merged field by field, recursively |
+           | JSON object encoded in a string (the `*_params` settings) | JSON object, or a string encoding one | the base object is decoded, merged, and re-encoded **as a string**, so the setting keeps the form the runtime expects |
+           | anything else | anything | the override replaces the value outright |
+
+           A setting named in `additional_params_dev` must already be declared in `additional_params`, or package
+           generation fails — that catches a typo, and it keeps `additional_params` a complete inventory of every
+           setting with its production value. The check runs for a `prod` build too, even though the merge does not.
+           To turn a knob on only in dev, declare it with its production value in `additional_params` and override it.
+           Fields *inside* one setting's parameters may be added freely (for example a dev-only `staleSeconds`).
+
+           ```json
+           "additional_params": {
+               "alternative_estimate_fee": "infura",
+               "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees\", \"periodSeconds\": 10}",
+               "fiat_rates_params": "{\"coin\": \"ethereum\", \"periodSeconds\": 900}"
+           },
+           "additional_params_dev": {
+               "alternative_estimate_fee_params": {
+                   "periodSeconds": 300
+               },
+               "fiat_rates_params": {
+                   "periodSeconds": 3600
+               }
+           }
+           ```
+
+           Note that re-encoding normalizes whitespace and sorts the keys inside a string-encoded setting, so the dev
+           render of such a value is not textually similar to the production one. Every consumer unmarshals it, so only
+           the rendered text differs. Two settings must not be overridden: `block_filter_scripts` and
+           `block_golomb_filter_p` are read straight from `additional_params` by the OpenAPI e2e suite
+           (`tests/openapi/src/config.ts`), which knows nothing about the overlay.
 
 * `meta` – Common package metadata.
     * `package_maintainer` – Full name of package maintainer.

--- a/docs/env.md
+++ b/docs/env.md
@@ -81,7 +81,7 @@ Blockbook reads these from its process environment. When installed from the Debi
 
 -   `<coin shortcut>_STAKING_POOL_CONTRACT` - The pool name and contract used for Ethereum staking. The format of the variable is `<pool name>/<pool contract>`. If missing, staking support is disabled.
 
--   `INFURA_API_KEY` - API key for the Infura alternative EIP-1559 fee provider. Archive EVM configs using Infura poll every `periodSeconds` (a required config value; the shipped archive configs set it to 10s) and keep serving the last successful fee data for the configured `staleSeconds` stale window (default 600s / 10 minutes) before falling back to native fee estimation.
+-   `INFURA_API_KEY` - API key for the Infura alternative EIP-1559 fee provider. Archive EVM configs using Infura poll every `periodSeconds` (a required config value; the shipped archive configs set it to 10s) and keep serving the last successful fee data for the configured `staleSeconds` stale window (default 600s / 10 minutes) before falling back to native fee estimation. A dev instance polls less often: the archive configs override `periodSeconds` in their `additional_params_dev` block, which only a `BB_BUILD_ENV=dev` build applies (see [config.md](/docs/config.md)).
 
 -   `ONE_INCH_API_KEY` - API key for the 1inch alternative EIP-1559 fee provider (used by `ethereum_archive`). Required at startup when a config selects `alternative_estimate_fee: 1inch`; the provider polls and caches fees on the same `periodSeconds`/`staleSeconds` schedule as Infura.
 
@@ -132,8 +132,12 @@ On EVM chains the internal server also exposes `/admin/contract-info/` (same Bas
 
 ## Build-time variables
 
--   `BB_BUILD_ENV` - Selects the active RPC URL override family during package/config generation. Defaults to `dev`.
-    Accepted values are `dev` and `prod`.
+-   `BB_BUILD_ENV` - Selects the environment a package/config is generated for. Defaults to `dev`. Accepted values are
+    `dev` and `prod`. It selects the active RPC URL override family, and a `dev` build additionally merges each coin's
+    `blockbook.block_chain.additional_params_dev` block over `additional_params` (see [config.md](/docs/config.md)),
+    which is how a dev instance runs a slower poll period for a paid fee or fiat-rates provider. A `prod` build ignores
+    that block, so a dev value cannot reach production — but for the same reason **a production package must be built
+    with `BB_BUILD_ENV=prod`**, since the default is `dev`.
 -   `BB_DEV_RPC_URL_HTTP_<coin alias>` / `BB_PROD_RPC_URL_HTTP_<coin alias>` - Override `ipc.rpc_url_template` during
     package/config generation so build and integration-test tooling can target hosted HTTP RPC endpoints without editing
     coin JSON. Lookup prefers the exact alias and also accepts archive variants like `<alias>_archive` and

--- a/docs/fees.md
+++ b/docs/fees.md
@@ -54,7 +54,10 @@ How each source is built:
   returns the provider's `maxFeePerGas` **unchanged**. For Infura, this is `suggestedMaxFeePerGas`,
   padded well above the base fee (~2.5× for the high tier); for 1inch, it is the provider's own
   computed `maxFeePerGas`. Blockbook does not rewrite it — the wallet overrides it (see the Suite
-  section).
+  section). The cache is refreshed every `periodSeconds` and stays usable for `staleSeconds`
+  afterwards; because the provider is billed per request, dev instances poll it far less often via
+  the coin config's `additional_params_dev` block, which only a `BB_BUILD_ENV=dev` build applies
+  (see [config.md](/docs/config.md)).
 
 ---
 


### PR DESCRIPTION
Closes #1733.

Dev instances need different values than production for settings billed per request — above all the poll period of a paid fee or fiat-rates provider. Those values are single-valued in `configs/coins/*.json`, so the only way to slow a dev instance down is to edit the production value and build from that branch. That is how [`6cfc6fa0`](https://github.com/trezor/blockbook/commit/6cfc6fa04fb5c7548393a5862ffe967838489eed) ("changed infura periods") reached master and production after being meant for a dev deployment only.

## What changes

The build already knows which environment it produces for. This extends `BB_BUILD_ENV` to `blockbook.block_chain.additional_params`:

```json
"additional_params": {
    "alternative_estimate_fee_params": "{\"url\": \"https://gas.api.infura.io/v3/${api_key}/networks/1/suggestedGasFees\", \"periodSeconds\": 10}",
    "fiat_rates_params": "{\"coin\": \"ethereum\", \"periodSeconds\": 900}"
},
"additional_params_dev": {
    "alternative_estimate_fee_params": { "periodSeconds": 300 },
    "fiat_rates_params": { "periodSeconds": 3600 }
}
```

- A `dev` build merges `additional_params_dev` over `additional_params`; a `prod` build ignores it entirely.
- The merge is sparse — objects merge field by field, and a `*_params` setting whose object lives in a JSON string is decoded, merged and re-encoded **as a string**, so the runtime schema is unchanged and the provider `url` is never duplicated (and so cannot drift from production).
- An override of a setting not declared in `additional_params` fails package generation, **and that check runs in `prod` builds too** even though the merge does not — so a typo can't sit unnoticed in a config that only prod builds from.

Second commit gives the 9 Infura-backed EVM configs a dev overlay: fee period 5–30s → 300s, CoinGecko 900s → 3600s. `bsc_archive` is skipped (`alternative_estimate_fee` is `"infura-disabled"`, so it never polls).

No CI, Makefile or `bb-build-var-prefixes.txt` change — `BB_BUILD_ENV` is already plumbed end to end, and the Python CI helpers only read the `backend` section and package names.

## Verification

- **Prod render is byte-identical to master for all 9 modified coins** — generated on both revisions and diffed.
- Dev render carries 300/3600 with each chain's own Infura URL intact; `additional_params_dev` never appears in the rendered `blockchaincfg.json`.
- New `TestAllCoinConfigsRenderInBothBuildEnvs` loads and renders all 103 coin configs under both envs — nothing validated `additional_params` before this.
- Typo guard, in both envs: `panic: ethereum_archive: additional_params_dev overrides settings missing from additional_params: alternative_estimate_fee_paarms (declare the setting with its production value first)`.
- `validate_backend_artifacts.py`, the 69 `.github/scripts` unit tests and the port-registry generator all pass with no `docs/ports.md` drift.

Not run locally: `make test` / `make test-integration` (need the Docker toolchain). Integration tests will now render dev periods, since `bchain/config_loader.go` defaults `BB_BUILD_ENV` to `dev`.

## Note for reviewers

`BB_BUILD_ENV` defaults to `dev`, so a hand-run `make deb-blockbook-<coin>` now produces dev periods. That matches how the RPC URL overrides already behave, and CI is unaffected (`mode=build` passes its `env` input, `mode=deploy` pins `dev`), but it is called out in bold in `docs/build.md` and `docs/env.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
