### PR TITLE
fix(sync): return from parallel connect when a worker exits without its block

### DIFF
--- a/db/sync.go
+++ b/db/sync.go
@@ -601,6 +601,25 @@ func isRetryableGetBlockError(err error) bool {
 	return cause != nil && isRetryable(cause)
 }
 
+// waitWorkersOrAbort returns once every worker has exited, or as soon as a worker reports
+// an abort after the hash queue closed. Without the abort branch a worker that exits on a
+// tail block without producing it parks the writer and its siblings forever (#1767).
+func waitWorkersOrAbort(wg *sync.WaitGroup, abortCh <-chan error, terminate func()) error {
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(workersDone)
+	}()
+	select {
+	case <-workersDone:
+		return nil
+	case abortErr := <-abortCh:
+		terminate()
+		<-workersDone
+		return abortErr
+	}
+}
+
 // ParallelConnectBlocks uses parallel goroutines to get data from blockchain daemon but keeps Blockbook in
 func (w *SyncWorker) ParallelConnectBlocks(onNewBlock bchain.OnNewBlockFunc, lower, higher uint32, syncWorkers uint32) error {
 	var err error
@@ -614,6 +633,8 @@ func (w *SyncWorker) ParallelConnectBlocks(onNewBlock bchain.OnNewBlockFunc, low
 	hchClosed.Store(false)
 	writeBlockDone := make(chan struct{})
 	terminating := make(chan struct{})
+	// The connect loop and the worker wait can both decide to stop the round; guard the close.
+	terminate := sync.OnceFunc(func() { close(terminating) })
 	// abortCh is used by workers to signal a resync-worthy reorg or a terminal worker error.
 	// Keep it buffered so the first worker can report without blocking while the
 	// coordinator is closing channels/terminating.
@@ -651,9 +672,6 @@ func (w *SyncWorker) ParallelConnectBlocks(onNewBlock bchain.OnNewBlockFunc, low
 				break WriteBlockLoop
 			}
 		}
-		if err != nil {
-			glog.Error("sync: ParallelConnectBlocks.Close error ", err)
-		}
 		glog.Info("WriteBlock exiting...")
 	}
 	for i := 0; i < int(syncWorkers); i++ {
@@ -672,13 +690,13 @@ ConnectLoop:
 				glog.Error("sync: parallel connect aborted, worker error ", abortErr)
 			}
 			err = abortErr
-			close(terminating)
+			terminate()
 			break ConnectLoop
 		case <-w.chanOsSignal:
 			glog.Info("connectBlocksParallel interrupted at height ", h)
 			err = ErrOperationInterrupted
 			// signal all workers to terminate their loops (error loops are interrupted below)
-			close(terminating)
+			terminate()
 			break ConnectLoop
 		default:
 			hash, err = w.chain.GetBlockHash(h)
@@ -696,7 +714,7 @@ ConnectLoop:
 				} else {
 					glog.Error("sync: parallel connect aborted while queueing block hash, worker error ", err)
 				}
-				close(terminating)
+				terminate()
 				break ConnectLoop
 			}
 			h++
@@ -706,7 +724,16 @@ ConnectLoop:
 	// signal stop to workers that are in a error loop
 	hchClosed.Store(true)
 	// wait for workers and close bch that will stop writer loop
-	wg.Wait()
+	if abortErr := waitWorkersOrAbort(&wg, abortCh, terminate); abortErr != nil {
+		if stdErrors.Is(abortErr, errResync) {
+			glog.Warning("sync: parallel connect aborted at tail, restarting sync")
+		} else {
+			glog.Error("sync: parallel connect aborted at tail, worker error ", abortErr)
+		}
+		if err == nil {
+			err = abortErr
+		}
+	}
 	// Hardening: a worker can report a terminal tail error after ConnectLoop has
 	// already ended (for example once hchClosed=true). Drain once so we return
 	// that error instead of silently succeeding.
@@ -855,6 +882,8 @@ func (w *SyncWorker) BulkConnectBlocks(lower, higher uint32) error {
 	hchClosed.Store(false)
 	writeBlockDone := make(chan struct{})
 	terminating := make(chan struct{})
+	// The connect loop and the worker wait can both decide to stop the round; guard the close.
+	terminate := sync.OnceFunc(func() { close(terminating) })
 	// abortCh is used by workers to signal a resync-worthy reorg or a terminal worker error.
 	// Keep it buffered so the first worker can report without blocking while the
 	// coordinator is closing channels/terminating.
@@ -912,13 +941,13 @@ ConnectLoop:
 				glog.Error("sync: bulk connect aborted, worker error ", abortErr)
 			}
 			err = abortErr
-			close(terminating)
+			terminate()
 			break ConnectLoop
 		case <-w.chanOsSignal:
 			glog.Info("BulkConnectBlocks interrupted at height ", h)
 			err = ErrOperationInterrupted
 			// signal all workers to terminate their loops (error loops are interrupted below)
-			close(terminating)
+			terminate()
 			break ConnectLoop
 		default:
 			hash, err = w.chain.GetBlockHash(h)
@@ -936,7 +965,7 @@ ConnectLoop:
 				} else {
 					glog.Error("sync: bulk connect aborted while queueing block hash, worker error ", err)
 				}
-				close(terminating)
+				terminate()
 				break ConnectLoop
 			}
 			if h > 0 && h%1000 == 0 {
@@ -958,7 +987,16 @@ ConnectLoop:
 	// signal stop to workers that are in a error loop
 	hchClosed.Store(true)
 	// wait for workers and close bch that will stop writer loop
-	wg.Wait()
+	if abortErr := waitWorkersOrAbort(&wg, abortCh, terminate); abortErr != nil {
+		if stdErrors.Is(abortErr, errResync) {
+			glog.Warning("sync: bulk connect aborted at tail, restarting sync")
+		} else {
+			glog.Error("sync: bulk connect aborted at tail, worker error ", abortErr)
+		}
+		if err == nil {
+			err = abortErr
+		}
+	}
 	// Hardening: capture a late worker error reported after the connect loop
 	// exits so the caller can retry instead of treating sync as successful.
 	select {

--- a/db/sync_test.go
+++ b/db/sync_test.go
@@ -746,3 +746,93 @@ func TestGetBlockChainFallBehindYieldGating(t *testing.T) {
 		})
 	}
 }
+
+// parallelTailTestChain serves a fixed range and fails one height forever. Unlike
+// getBlockChainTestChain it is safe for concurrent getBlockWorkers.
+type parallelTailTestChain struct {
+	bchain.BlockChain
+	mu         sync.Mutex
+	failHeight uint32
+	failErr    error
+	calls      map[uint32]int
+}
+
+func (c *parallelTailTestChain) GetChainParser() bchain.BlockChainParser {
+	return &getBlockChainTestParser{chainType: bchain.ChainEthereumType}
+}
+
+func (c *parallelTailTestChain) GetBlockHash(height uint32) (string, error) {
+	return "h" + strconv.Itoa(int(height)), nil
+}
+
+func (c *parallelTailTestChain) GetBlock(hash string, height uint32) (*bchain.Block, error) {
+	c.mu.Lock()
+	c.calls[height]++
+	c.mu.Unlock()
+	if height == c.failHeight {
+		return nil, c.failErr
+	}
+	return &bchain.Block{BlockHeader: bchain.BlockHeader{Hash: hash, Height: height}}, nil
+}
+
+// Regression for #1767: a worker that exits on a tail block without producing it must not
+// leave the coordinator waiting forever on siblings parked behind the missing height.
+func TestParallelConnectBlocksReturnsWhenTailWorkerExitsWithoutBlock(t *testing.T) {
+	wantErr := stdErrors.New("rpc -32000: logs unavailable")
+	chain := &parallelTailTestChain{failHeight: 1, failErr: wantErr, calls: map[uint32]int{}}
+	w := &SyncWorker{
+		chain: chain,
+		missingBlockRetry: MissingBlockRetryConfig{
+			TipRecheckThreshold: 2,
+			RetryDelay:          time.Millisecond,
+		},
+		metrics: getTestMetrics(t),
+	}
+	done := make(chan error, 1)
+	go func() { done <- w.ParallelConnectBlocks(nil, 1, 4, 4) }()
+	select {
+	case err := <-done:
+		if !stdErrors.Is(err, wantErr) {
+			t.Fatalf("ParallelConnectBlocks error = %v, want %v", err, wantErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ParallelConnectBlocks did not return: coordinator wedged on a tail worker exit")
+	}
+}
+
+func TestWaitWorkersOrAbort(t *testing.T) {
+	t.Run("workers finish without abort", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go wg.Done()
+		terminated := false
+		if err := waitWorkersOrAbort(&wg, make(chan error, 1), func() { terminated = true }); err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if terminated {
+			t.Fatal("terminate called although all workers exited cleanly")
+		}
+	})
+	t.Run("abort unparks a blocked worker", func(t *testing.T) {
+		var wg sync.WaitGroup
+		terminating := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-terminating
+		}()
+		abortCh := make(chan error, 1)
+		wantErr := stdErrors.New("worker failed")
+		abortCh <- wantErr
+		done := make(chan error, 1)
+		go func() { done <- waitWorkersOrAbort(&wg, abortCh, func() { close(terminating) }) }()
+		select {
+		case err := <-done:
+			if !stdErrors.Is(err, wantErr) {
+				t.Fatalf("error = %v, want %v", err, wantErr)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("waitWorkersOrAbort did not return after abort")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #1767

## Problem

`ParallelConnectBlocks` and `BulkConnectBlocks` wait for their workers with a bare `wg.Wait()`. A `getBlockWorker` that aborts after the hash queue is closed returns without producing its block. The writer waits on that height forever, sibling workers park on their unbuffered block sends, and the coordinator never reads `abortCh`. Steady-state EVM sync wedged this way on bsc-b4 on 2026-09-06 and needed a restart.

This affects every abort-then-return exit at the tail, not only the non-retryable error seen in the incident: probe failure, stall deadline and vanished-hash resync go through the same path.

## Fix

- New `waitWorkersOrAbort` helper used by both coordinators: waits for the workers while also selecting on `abortCh`. On abort it terminates the round, lets the parked workers drain, and returns the error so the sync loop retries. The `errResync` distinction is kept so reorgs still restart the resync.
- `terminating` is now closed through a `sync.OnceFunc`, since the connect loop may already have closed it when the tail abort arrives.
- Dropped the parallel writer's read of the coordinator's `err`, which was a data race and logged a misleading `ParallelConnectBlocks.Close error`.

## Validation

- `TestParallelConnectBlocksReturnsWhenTailWorkerExitsWithoutBlock` reproduces the issue scenario (4 workers, heights 1..4, height 1 fails non-retryably). It times out after 5 s on master with the `Exiting...`-without-`WriteBlock exiting...` fingerprint and returns the worker error in 40 ms with the fix.
- `TestWaitWorkersOrAbort` covers the helper in isolation.
- `go test -race -tags unittest ./db` passes; `go vet` clean under `unittest` and `integration` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
