### PR TITLE
fix(eth): retire mempool entries by mined nonce, not by a null lookup

### DIFF
--- a/bchain/basemempool.go
+++ b/bchain/basemempool.go
@@ -15,6 +15,10 @@ type txEntry struct {
 	addrIndexes []addrIndex
 	time        uint32
 	filter      string
+	// EthereumType only: sender addrDesc and account nonce, so a mined nonce can retire the
+	// entry without asking the backend whether it is still in the pool.
+	from  string
+	nonce uint64
 }
 
 type txidio struct {

--- a/bchain/coins/eth/alternativesendtx.go
+++ b/bchain/coins/eth/alternativesendtx.go
@@ -1485,11 +1485,13 @@ func (p *AlternativeSendTxProvider) removeMempoolTx(txid string) bool {
 }
 
 // RemoveTransaction removes a transaction from the alternative mempool cache. It is the entry point for
-// removals carrying no reconcile decision of their own - block sync indexing a mined transaction, the
-// read path finding one mined or unknown - and meters them as sync_removed, which nothing else would.
-// In practice block sync is the sole source: the read path serves cached entries without asking the
-// node, so its mined/unknown branches run only on a cache miss, where there is nothing to remove. Reached again as removeMempoolTx's
-// delegate, where the entry is already gone, so nothing is metered twice.
+// removals carrying no reconcile decision of their own - block sync indexing a mined transaction or
+// retiring the sender's entries at or below its nonce, the read path finding one mined - and meters
+// them as sync_removed, which nothing else would. A null answer on the read path never removes
+// anything (#1709). In practice block sync is the sole source: the read path serves cached entries
+// without asking the node, so its mined branch runs only on a cache miss, where there is nothing to
+// remove. Reached again as removeMempoolTx's delegate, where the entry is already gone, so nothing is
+// metered twice.
 func (p *AlternativeSendTxProvider) RemoveTransaction(txid string) bool {
 	return p.removeTransaction(txid, "sync_removed")
 }

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -1836,6 +1836,7 @@ func (b *EthereumRPC) GetBlock(hash string, height uint32) (*bchain.Block, error
 		}
 		btxs[i] = *btx
 		b.removeTransactionFromMempool(tx.Hash)
+		b.removeSupersededFromMempool(tx)
 	}
 	bbk := bchain.Block{
 		BlockHeader:      *bbh,
@@ -1888,6 +1889,26 @@ func (b *EthereumRPC) removeTransactionFromMempool(txid string) {
 	}
 }
 
+// removeSupersededFromMempool retires the pending entries a mined transaction's nonce
+// invalidates: the sender's slots at or below it can never mine (#1709).
+func (b *EthereumRPC) removeSupersededFromMempool(tx *bchain.RpcTransaction) {
+	if !b.mempoolInitialized || tx.From == "" || tx.AccountNonce == "" {
+		return
+	}
+	nonce, err := ethNumber(tx.AccountNonce)
+	if err != nil || nonce < 0 {
+		return
+	}
+	from, err := b.Parser.GetAddrDescFromAddress(tx.From)
+	if err != nil {
+		return
+	}
+	for _, txid := range b.Mempool.RemoveSenderTransactionsUpToNonce(from, uint64(nonce)) {
+		// also clears the alternative provider's copy
+		b.removeTransactionFromMempool(txid)
+	}
+}
+
 // callContextWithTimeout issues a single JSON-RPC call under its own fresh b.Timeout
 // deadline, so sequential calls in a recovery sequence do not share (and progressively
 // shrink) one deadline budget.
@@ -1937,7 +1958,7 @@ func (b *EthereumRPC) recoverMinedTransaction(txid string) (*bchain.RpcTransacti
 		return nil, nil
 	}
 	if receipt.BlockHash == "" {
-		// No receipt: the transaction is genuinely unknown to the backend.
+		// No receipt: not mined - pending or unknown to the backend - so nothing to recover.
 		return nil, nil
 	}
 	// Fast path: fetch the single tx by (blockHash, index) - an O(1), ~900x smaller lookup
@@ -1987,11 +2008,13 @@ func (b *EthereumRPC) GetTransaction(txid string) (*bchain.Tx, error) {
 		// than that window is invisible to this call even though it is fully retained.
 		// Recover it from its receipt (which carries the block hash and index) before
 		// treating it as not found.
+		// A null is not evidence the transaction is gone (queued sub-pool, another node behind a
+		// balancer, private relay), so it must not evict the mempool entry; mined nonces and the
+		// timeout retire entries instead (#1709).
 		if recovered, receipt := b.recoverMinedTransaction(txid); recovered != nil {
 			tx = recovered
 			recoveredReceipt = receipt
 		} else {
-			b.removeTransactionFromMempool(txid)
 			return nil, bchain.ErrTxNotFound
 		}
 	}

--- a/bchain/coins/eth/mempool_nonce_watermark_test.go
+++ b/bchain/coins/eth/mempool_nonce_watermark_test.go
@@ -1,0 +1,136 @@
+package eth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+// pendingTxRPC serves eth_getTransactionByHash from a map and answers null for anything else,
+// including every receipt - the shape of a backend that only holds pending transactions.
+type pendingTxRPC struct {
+	txs map[string]*bchain.RpcTransaction
+}
+
+func (m *pendingTxRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *pendingTxRPC) Close() {}
+
+func (m *pendingTxRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	raw := []byte("null")
+	if method == "eth_getTransactionByHash" {
+		if tx, ok := m.txs[args[0].(interface{ String() string }).String()]; ok {
+			raw, _ = json.Marshal(tx)
+		}
+	}
+	return json.Unmarshal(raw, result)
+}
+
+const (
+	watermarkSender    = "0x1111111111111111111111111111111111111111"
+	watermarkRecipient = "0x2222222222222222222222222222222222222222"
+)
+
+func pendingTx(hash, from, to, nonce string) *bchain.RpcTransaction {
+	return &bchain.RpcTransaction{Hash: hash, From: from, To: to, AccountNonce: nonce, Value: "0x0", GasLimit: "0x5208", GasPrice: "0x1"}
+}
+
+// newWatermarkTestRPC wires a real MempoolEthereumType over the fake backend and indexes every
+// transaction the backend serves, as the pending-tx subscription would.
+func newWatermarkTestRPC(t *testing.T, txs ...*bchain.RpcTransaction) (*EthereumRPC, *pendingTxRPC) {
+	t.Helper()
+	rpc := &pendingTxRPC{txs: map[string]*bchain.RpcTransaction{}}
+	b := &EthereumRPC{RPC: rpc, Parser: NewEthereumParser(1, false), Timeout: time.Second, mempoolInitialized: true}
+	b.Mempool = bchain.NewMempoolEthereumType(b, time.Hour, false)
+	for _, tx := range txs {
+		rpc.txs[tx.Hash] = tx
+		if !b.Mempool.AddTransactionToMempool(tx.Hash) {
+			t.Fatalf("AddTransactionToMempool(%s) = false", tx.Hash)
+		}
+	}
+	return b, rpc
+}
+
+func mempoolTxids(t *testing.T, b *EthereumRPC, address string) []string {
+	t.Helper()
+	outpoints, err := b.Mempool.GetTransactions(address)
+	if err != nil {
+		t.Fatalf("GetTransactions(%s) error = %v", address, err)
+	}
+	txids := make([]string, 0, len(outpoints))
+	for _, o := range outpoints {
+		txids = append(txids, o.Txid)
+	}
+	return txids
+}
+
+func sameTxids(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	set := map[string]struct{}{}
+	for _, txid := range got {
+		set[txid] = struct{}{}
+	}
+	for _, txid := range want {
+		if _, ok := set[txid]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// A null eth_getTransactionByHash is not proof the transaction is gone, so GetTransaction must report
+// ErrTxNotFound without touching the mempool index (#1709).
+func TestGetTransactionNullKeepsMempoolEntry(t *testing.T) {
+	const hash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	b, rpc := newWatermarkTestRPC(t, pendingTx(hash, watermarkSender, watermarkRecipient, "0x5"))
+	delete(rpc.txs, hash)
+
+	if _, err := b.GetTransaction(hash); err != bchain.ErrTxNotFound {
+		t.Fatalf("GetTransaction() error = %v, want ErrTxNotFound", err)
+	}
+	if got := mempoolTxids(t, b, watermarkSender); len(got) != 1 || got[0] != hash {
+		t.Fatalf("sender mempool txids = %v, want [%s] (a null answer must not evict)", got, hash)
+	}
+}
+
+// A mined transaction retires the sender's pending entries at or below its nonce - including the
+// alternative provider's copy - and leaves higher nonces and other senders alone.
+func TestRemoveSupersededFromMempoolRetiresLowerNonces(t *testing.T) {
+	const (
+		stale    = "0x0000000000000000000000000000000000000000000000000000000000000005"
+		replaced = "0x0000000000000000000000000000000000000000000000000000000000000006"
+		next     = "0x0000000000000000000000000000000000000000000000000000000000000007"
+		incoming = "0x0000000000000000000000000000000000000000000000000000000000000106"
+	)
+	b, _ := newWatermarkTestRPC(t,
+		pendingTx(stale, watermarkSender, watermarkRecipient, "0x5"),
+		pendingTx(replaced, watermarkSender, watermarkRecipient, "0x6"),
+		pendingTx(next, watermarkSender, watermarkRecipient, "0x7"),
+		pendingTx(incoming, watermarkRecipient, watermarkSender, "0x6"),
+	)
+	b.alternativeSendTxProvider = &AlternativeSendTxProvider{
+		fetchMempoolTx: true,
+		mempoolTxs:     map[string]storedTx{stale: {tx: pendingTx(stale, watermarkSender, watermarkRecipient, "0x5")}},
+	}
+
+	// the mined replacement of nonce 6 is a different hash - the RBF/cancel case
+	b.removeSupersededFromMempool(pendingTx("0xfeed", watermarkSender, watermarkRecipient, "0x6"))
+
+	if got := mempoolTxids(t, b, watermarkSender); !sameTxids(got, next, incoming) {
+		t.Fatalf("sender mempool txids = %v, want next and incoming", got)
+	}
+	if got := mempoolTxids(t, b, watermarkRecipient); len(got) != 2 {
+		t.Fatalf("recipient mempool txids = %v, want next and incoming", got)
+	}
+	if _, found := b.alternativeSendTxProvider.mempoolTxs[stale]; found {
+		t.Fatal("alternative provider still caches the retired transaction")
+	}
+}

--- a/bchain/mempool_bitcoin_type.go
+++ b/bchain/mempool_bitcoin_type.go
@@ -319,7 +319,7 @@ func (m *MempoolBitcoinType) dispatchResyncPayloads(txids []string, cache map[st
 			select {
 			// store as many processed transactions as possible
 			case tio := <-m.chanAddrIndex:
-				onNewEntry(tio.txid, txEntry{tio.io, txTime, tio.filter})
+				onNewEntry(tio.txid, txEntry{addrIndexes: tio.io, time: txTime, filter: tio.filter})
 				dispatched--
 			// send transaction to be processed
 			case m.chanTx <- txPayload{txid: txid, tx: tx}:
@@ -330,7 +330,7 @@ func (m *MempoolBitcoinType) dispatchResyncPayloads(txids []string, cache map[st
 	}
 	for i := 0; i < dispatched; i++ {
 		tio := <-m.chanAddrIndex
-		onNewEntry(tio.txid, txEntry{tio.io, txTime, tio.filter})
+		onNewEntry(tio.txid, txEntry{addrIndexes: tio.io, time: txTime, filter: tio.filter})
 	}
 }
 

--- a/bchain/mempool_ethereum_type.go
+++ b/bchain/mempool_ethereum_type.go
@@ -91,7 +91,10 @@ func (m *MempoolEthereumType) createTxEntry(txid string, txTime uint32) (txEntry
 	}
 	entry := txEntry{addrIndexes: addrIndexes, time: txTime}
 	if csd, ok := tx.CoinSpecificData.(EthereumSpecificData); ok && csd.Tx != nil && len(mtx.Vin) > 0 {
-		if nonce, err := strconv.ParseUint(strings.TrimPrefix(csd.Tx.AccountNonce, "0x"), 16, 64); err == nil {
+		nonce, err := strconv.ParseUint(strings.TrimPrefix(csd.Tx.AccountNonce, "0x"), 16, 64)
+		if err != nil {
+			glog.Warning("cannot parse nonce ", csd.Tx.AccountNonce, " of tx ", txid, ": ", err)
+		} else {
 			entry.from = string(mtx.Vin[0].AddrDesc)
 			entry.nonce = nonce
 		}

--- a/bchain/mempool_ethereum_type.go
+++ b/bchain/mempool_ethereum_type.go
@@ -2,6 +2,8 @@ package bchain
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -87,7 +89,38 @@ func (m *MempoolEthereumType) createTxEntry(txid string, txTime uint32) (txEntry
 	if m.OnNewTx != nil {
 		m.OnNewTx(mtx)
 	}
-	return txEntry{addrIndexes: addrIndexes, time: txTime}, true
+	entry := txEntry{addrIndexes: addrIndexes, time: txTime}
+	if csd, ok := tx.CoinSpecificData.(EthereumSpecificData); ok && csd.Tx != nil && len(mtx.Vin) > 0 {
+		if nonce, err := strconv.ParseUint(strings.TrimPrefix(csd.Tx.AccountNonce, "0x"), 16, 64); err == nil {
+			entry.from = string(mtx.Vin[0].AddrDesc)
+			entry.nonce = nonce
+		}
+	}
+	return entry, true
+}
+
+// RemoveSenderTransactionsUpToNonce retires every entry sent by from with a nonce at or below the
+// mined one - no such transaction can ever mine, whatever the backend says about its pool presence.
+// Returns the removed txids.
+func (m *MempoolEthereumType) RemoveSenderTransactionsUpToNonce(from AddressDescriptor, nonce uint64) []string {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	// collect first - removeEntryFromMempool compacts the outpoint slice being scanned
+	var candidates []string
+	for _, o := range m.addrDescToTx[string(from)] {
+		if entry, ok := m.txEntries[o.Txid]; ok && entry.from != "" && entry.from == string(from) && entry.nonce <= nonce {
+			candidates = append(candidates, o.Txid)
+		}
+	}
+	var removed []string
+	for _, txid := range candidates {
+		// a self-transfer lists the txid twice under the same address
+		if entry, ok := m.txEntries[txid]; ok {
+			m.removeEntryFromMempool(txid, entry)
+			removed = append(removed, txid)
+		}
+	}
+	return removed
 }
 
 // Resync ethereum type removes timed out transactions and returns number of transactions in mempool.

--- a/bchain/mempool_ethereum_type_test.go
+++ b/bchain/mempool_ethereum_type_test.go
@@ -78,3 +78,42 @@ func TestMempoolEthereumTypeAddOrRefreshRestampsExistingEntry(t *testing.T) {
 		t.Fatalf("addrIndexes = %+v, want the original index kept", got)
 	}
 }
+
+// A mined nonce retires the sender's entries at or below it and nothing else: higher nonces, entries
+// where the address is only a recipient, and entries without nonce data (pre-upgrade) all stay (#1709).
+func TestMempoolEthereumType_RemoveSenderTransactionsUpToNonce(t *testing.T) {
+	m := NewMempoolEthereumType(nil, 10*time.Minute, false)
+	add := func(txid, from string, nonce uint64, addrs ...string) {
+		entry := txEntry{from: from, nonce: nonce}
+		for _, a := range addrs {
+			entry.addrIndexes = append(entry.addrIndexes, addrIndex{addrDesc: a})
+			m.addrDescToTx[a] = append(m.addrDescToTx[a], Outpoint{Txid: txid})
+		}
+		m.txEntries[txid] = entry
+	}
+	add("stale", "sender", 5, "sender", "other")
+	add("mined", "sender", 6, "sender", "other")
+	add("next", "sender", 7, "sender", "other")
+	add("incoming", "other", 6, "other", "sender")
+	add("legacy", "", 0, "sender")
+
+	removed := m.RemoveSenderTransactionsUpToNonce(AddressDescriptor("sender"), 6)
+	if len(removed) != 2 || m.txEntries["stale"].from != "" || m.txEntries["mined"].from != "" {
+		t.Fatalf("removed = %v, want stale and mined", removed)
+	}
+	for _, kept := range []string{"next", "incoming", "legacy"} {
+		if _, found := m.txEntries[kept]; !found {
+			t.Fatalf("entry %q was removed, want kept", kept)
+		}
+	}
+	wantAddrDescToTx := map[string][]Outpoint{
+		"sender": {{Txid: "next"}, {Txid: "incoming"}, {Txid: "legacy"}},
+		"other":  {{Txid: "next"}, {Txid: "incoming"}},
+	}
+	if !reflect.DeepEqual(m.addrDescToTx, wantAddrDescToTx) {
+		t.Fatalf("addrDescToTx = %+v, want %+v", m.addrDescToTx, wantAddrDescToTx)
+	}
+	if got := m.RemoveSenderTransactionsUpToNonce(AddressDescriptor("nobody"), 100); len(got) != 0 {
+		t.Fatalf("removed = %v for an unknown sender, want none", got)
+	}
+}

--- a/docs/evm-send-mempools.md
+++ b/docs/evm-send-mempools.md
@@ -59,8 +59,8 @@ flowchart TD
     pubrec["Mempool Resync, every 60 s<br/>timeout sweep at most every 10 min<br/>plus backend-missing removal"]
 
     readalt["GetTransaction read path<br/>entry past the cache timeout"]
-    blk["GetBlock: tx in a connected block"]
-    readmined["GetTransaction: mined or unknown"]
+    blk["GetBlock: tx in a connected block, plus the<br/>sender's entries at or below its nonce"]
+    readmined["GetTransaction: mined<br/>(a null answer evicts nothing)"]
 
     altrm[("removeMempoolTx<br/>cache delete decides the race<br/>release nonce routing<br/>metered by its caller, on its bool")]
     bothrm[("removeTransactionFromMempool<br/>clears BOTH stores")]

--- a/docs/evm-send.md
+++ b/docs/evm-send.md
@@ -38,7 +38,7 @@ flowchart TD
     end
 
     readpath["GetTransaction read path<br/>expired entry → evict"]
-    syncrm["block sync indexing its block, or the<br/>read path finding it mined or unknown"]
+    syncrm["block sync indexing its block or a later<br/>nonce of its sender, or the read path finding it mined"]
     remove[("clear cache + wrapped mempool<br/>+ release nonce routing")]
 
     send --> route
@@ -111,8 +111,9 @@ Key invariants:
   generation; an older submission's slow fetch-back neither caches itself over, nor evicts, a newer
   replacement that already holds the nonce slot.
 - **Every exit clears both stores and is metered exactly once.** The reconcile and RBF evictions go
-  through `removeMempoolTx`; `sync_removed` — block sync, and the read path finding a transaction
-  mined or unknown — goes through `RemoveTransaction` directly. Neither meters anything itself:
+  through `removeMempoolTx`; `sync_removed` — block sync (the mined transaction and the sender's
+  entries at or below its nonce), and the read path finding a transaction mined — goes through
+  `RemoveTransaction` directly. A null answer on the read path evicts nothing (#1709). Neither meters anything itself:
   `removeMempoolTx` passes an empty action, so its callers do the metering, gated on the bool it
   returns, and `RemoveTransaction` passes `sync_removed`, which nothing else would record. The gating
   is what keeps concurrent reconcile / read-path / RBF evictions of the same entry from
@@ -244,9 +245,9 @@ Prometheus counters for the cache lifecycle:
   (`mined`, `nonce_superseded`, `provider_missing`, `timeout`, `rbf_replaced`, `sync_removed`) plus
   the kept actions (`skipped_fresh`, `skipped_backoff`, `provider_missing_pending`, `kept`,
   `provider_error`). `sync_removed` — block sync indexing the tx's block — should dominate, `mined`
-  should be rare. The read path's mined-or-unknown removal also meters here, but it can fire only on
-  a cache miss (a cached entry is served without asking the node), so block sync is effectively the
-  sole source.
+  should be rare. The read path's mined removal also meters here, but it can fire only on a cache
+  miss (a cached entry is served without asking the node), so block sync is effectively the sole
+  source.
 - `blockbook_eth_alternative_mempool_tx_residence_seconds{action}` — entry lifetime per eviction
   reason. `provider_missing` is the dropped/cancelled exit; residence counts age since broadcast,
   so a cancel N minutes after the send records ~N plus `alternativeMissingTxTimeout` — read the


### PR DESCRIPTION
Fixes #1709

`GetTransaction` deleted a mempool entry as soon as `eth_getTransactionByHash` returned null, and nothing ever re-added it. A null is not proof the transaction is gone (queued sub-pool, another node behind a balancer, private relay), so a live pending transaction vanished from its sender's address page while staying fetchable by hash. The `recoverMinedTransaction` guard in front of the eviction can never fire for a pending tx, since it keys off the receipt.

**Change**
- Stop evicting on a null answer; return `ErrTxNotFound` without touching the index.
- Store the sender and nonce on each ETH mempool entry (`txEntry.from` / `nonce`, filled in `createTxEntry`).
- On block connect, `removeSupersededFromMempool` retires every entry from the same sender with a nonce at or below the mined one. Zero extra RPC, deterministic, and it also cleans up the RBF/cancel losers the null-eviction used to catch. Victims go through `removeTransactionFromMempool` so the private-relay store is cleared too.
- Fix the misleading "genuinely unknown to the backend" comment.

**Trade-off**: a transaction that is dropped and never replaced now stays pending until the existing 48h timeout. It is still valid and could be re-broadcast, so "pending" is not wrong; losing a live tx is strictly worse.

**Out of scope** (as in the issue): the mined-branch eviction, `removeTransactionsMissingFromBackend` (used by ETC/Tron), the timeout value, and the "skip recovery for known mempool entries" latency tweak. Tron has its own `GetBlock`/`GetTransaction` and is untouched.

**Tests**
- `TestGetTransactionNullKeepsMempoolEntry` fails on the old code (entry evicted) and passes now.
- `TestRemoveSupersededFromMempoolRetiresLowerNonces` covers lower/equal nonce removal, higher nonce and recipient-only entries kept, alt-provider copy cleared.
- `TestMempoolEthereumType_RemoveSenderTransactionsUpToNonce` covers index compaction and pre-upgrade entries without nonce data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
