### PR TITLE
fix(eth): surface per-tx debug_traceBlockByHash errors instead of storing empty traces

### DIFF
--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -1594,7 +1594,30 @@ type rpcCallTrace struct {
 type rpcTraceResult struct {
 	Result rpcCallTrace `json:"result"`
 	// tracer failure for the whole tx (typically a timeout), distinct from the EVM revert in Result.Error
-	Error string `json:"error"`
+	Error rpcTraceError `json:"error"`
+}
+
+// rpcTraceError tolerates both envelope shapes: geth forks send a plain string, Erigon a {code,message} object
+type rpcTraceError string
+
+func (e *rpcTraceError) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		*e = rpcTraceError(s)
+		return nil
+	}
+	var o struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(b, &o); err != nil {
+		return err
+	}
+	if o.Message == "" {
+		o.Message = fmt.Sprintf("error code %d", o.Code)
+	}
+	*e = rpcTraceError(o.Message)
+	return nil
 }
 
 // isBridgingTx identifies the Polygon state-sync tx, which bor traces separately and unreliably

--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -1593,6 +1593,13 @@ type rpcCallTrace struct {
 
 type rpcTraceResult struct {
 	Result rpcCallTrace `json:"result"`
+	// tracer failure for the whole tx (typically a timeout), distinct from the EVM revert in Result.Error
+	Error string `json:"error"`
+}
+
+// isBridgingTx identifies the Polygon state-sync tx, which bor traces separately and unreliably
+func isBridgingTx(tx *bchain.RpcTransaction) bool {
+	return tx.To == "0x0000000000000000000000000000000000000000" && tx.From == "0x0000000000000000000000000000000000000000"
 }
 
 func (b *EthereumRPC) getCreationContractInfo(contract string, height uint32) *bchain.ContractInfo {
@@ -1682,8 +1689,7 @@ func (b *EthereumRPC) getInternalDataForBlock(ctx context.Context, blockHash str
 				for i := range transactions {
 					tx := &transactions[i]
 					// bridging transactions in Polygon do not create trace and cause mismatch between the trace size and block size, it is necessary to adjust the trace size
-					// bridging transaction that from and to zero address
-					if tx.To == "0x0000000000000000000000000000000000000000" && tx.From == "0x0000000000000000000000000000000000000000" {
+					if isBridgingTx(tx) {
 						if i >= len(trace) {
 							trace = append(trace, rpcTraceResult{})
 						} else {
@@ -1702,6 +1708,12 @@ func (b *EthereumRPC) getInternalDataForBlock(ctx context.Context, blockHash str
 			}
 		}
 		for i, result := range trace {
+			// a failed per-tx trace must not be committed as an empty one; the error queues the block for HealInternalData
+			if result.Error != "" && !isBridgingTx(&transactions[i]) {
+				e := fmt.Sprintf("trace of tx %s failed: %s", transactions[i].Hash, result.Error)
+				glog.Error("debug_traceBlockByHash block ", blockHash, ", error: ", e)
+				return data, contracts, errors.New(e)
+			}
 			r := &result.Result
 			d := &data[i]
 			if r.Type == "CREATE" || r.Type == "CREATE2" {

--- a/bchain/coins/eth/ethrpc_trace_test.go
+++ b/bchain/coins/eth/ethrpc_trace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -13,6 +14,7 @@ import (
 type mockTraceRPC struct {
 	method string
 	args   []interface{}
+	trace  []rpcTraceResult // canned debug_traceBlockByHash reply
 }
 
 func (m *mockTraceRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (bchain.EVMClientSubscription, error) {
@@ -23,7 +25,7 @@ func (m *mockTraceRPC) CallContext(ctx context.Context, result interface{}, meth
 	m.method = method
 	m.args = append([]interface{}{}, args...)
 	if out, ok := result.(*[]rpcTraceResult); ok {
-		*out = []rpcTraceResult{}
+		*out = append([]rpcTraceResult{}, m.trace...)
 	}
 	return nil
 }
@@ -152,5 +154,56 @@ func TestProcessCallTraceIgnoresFakeCallcodeTransfers(t *testing.T) {
 			d.Transfers[i].Value.Cmp(&want[i].Value) != 0 || d.Transfers[i].Type != want[i].Type {
 			t.Errorf("transfer[%d] = %+v, want %+v", i, d.Transfers[i], want[i])
 		}
+	}
+}
+
+// Erigon reports a per-tx tracer failure (e.g. timeout) as an envelope carrying "error" instead of
+// "result" and keeps tracing the rest of the block (issue #1760).
+func TestGetInternalDataForBlockFailsOnPerTxTraceError(t *testing.T) {
+	txs := []bchain.RpcTransaction{
+		{Hash: "0x01", From: "0xaaaa", To: "0xbbbb"},
+		{Hash: "0x02", From: "0xcccc", To: "0xdddd"},
+	}
+	rpcClient := &mockTraceRPC{trace: []rpcTraceResult{
+		{Result: rpcCallTrace{Type: "CALL", From: "0xaaaa", To: "0xbbbb", Value: "0x1"}},
+		{Error: "execution timeout"},
+	}}
+	b := &EthereumRPC{RPC: rpcClient, ChainConfig: &Configuration{ProcessInternalTransactions: true}}
+	bchain.ProcessInternalTransactions = true
+	t.Cleanup(func() { bchain.ProcessInternalTransactions = false })
+
+	_, _, err := b.getInternalDataForBlock(context.Background(), "0xabc", 1, txs)
+	if err == nil {
+		t.Fatal("expected error for failed per-tx trace, got nil")
+	}
+	for _, want := range []string{"0x02", "execution timeout"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// The Polygon state-sync tx is already exempt from the trace-length check; a failed trace of it must
+// not queue every block that contains one for healing.
+func TestGetInternalDataForBlockIgnoresBridgingTxTraceError(t *testing.T) {
+	const zero = "0x0000000000000000000000000000000000000000"
+	txs := []bchain.RpcTransaction{
+		{Hash: "0x01", From: "0xaaaa", To: "0xbbbb"},
+		{Hash: "0x02", From: zero, To: zero},
+	}
+	rpcClient := &mockTraceRPC{trace: []rpcTraceResult{
+		{Result: rpcCallTrace{Type: "CALL", From: "0xaaaa", To: "0xbbbb", Value: "0x1"}},
+		{Error: "state sync trace failed"},
+	}}
+	b := &EthereumRPC{RPC: rpcClient, ChainConfig: &Configuration{ProcessInternalTransactions: true}}
+	bchain.ProcessInternalTransactions = true
+	t.Cleanup(func() { bchain.ProcessInternalTransactions = false })
+
+	data, _, err := b.getInternalDataForBlock(context.Background(), "0xabc", 1, txs)
+	if err != nil {
+		t.Fatalf("getInternalDataForBlock() error = %v", err)
+	}
+	if len(data) != 2 || data[1].Error != "" || len(data[1].Transfers) != 0 {
+		t.Fatalf("bridging tx should decode to empty internal data, got %+v", data)
 	}
 }

--- a/bchain/coins/eth/ethrpc_trace_test.go
+++ b/bchain/coins/eth/ethrpc_trace_test.go
@@ -207,3 +207,55 @@ func TestGetInternalDataForBlockIgnoresBridgingTxTraceError(t *testing.T) {
 		t.Fatalf("bridging tx should decode to empty internal data, got %+v", data)
 	}
 }
+
+func TestRpcTraceErrorUnmarshalAcceptsStringAndObject(t *testing.T) {
+	tests := []struct {
+		name, raw, want string
+	}{
+		{"geth string", `{"error":"execution timeout"}`, "execution timeout"},
+		{"erigon object", `{"error":{"code":-32000,"message":"execution timeout"}}`, "execution timeout"},
+		{"erigon object without message", `{"error":{"code":-32000}}`, "error code -32000"},
+		{"null", `{"error":null}`, ""},
+		{"absent", `{"result":{"type":"CALL"}}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r rpcTraceResult
+			if err := json.Unmarshal([]byte(tt.raw), &r); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", tt.raw, err)
+			}
+			if string(r.Error) != tt.want {
+				t.Fatalf("Error = %q, want %q", r.Error, tt.want)
+			}
+		})
+	}
+}
+
+// Erigon's actual wire shape for a per-tx tracer failure, as written by rpc.HandleError.
+func TestGetInternalDataForBlockFailsOnErigonTraceErrorObject(t *testing.T) {
+	const raw = `[
+		{"txHash":"0x01","result":{"type":"CALL","from":"0xaaaa","to":"0xbbbb","value":"0x1"}},
+		{"txHash":"0x02","result":null,"error":{"code":-32000,"message":"execution timeout"}}
+	]`
+	rpcClient := &mockTraceRPC{}
+	if err := json.Unmarshal([]byte(raw), &rpcClient.trace); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	txs := []bchain.RpcTransaction{
+		{Hash: "0x01", From: "0xaaaa", To: "0xbbbb"},
+		{Hash: "0x02", From: "0xcccc", To: "0xdddd"},
+	}
+	b := &EthereumRPC{RPC: rpcClient, ChainConfig: &Configuration{ProcessInternalTransactions: true}}
+	bchain.ProcessInternalTransactions = true
+	t.Cleanup(func() { bchain.ProcessInternalTransactions = false })
+
+	_, _, err := b.getInternalDataForBlock(context.Background(), "0xabc", 1, txs)
+	if err == nil {
+		t.Fatal("expected error for failed per-tx trace, got nil")
+	}
+	for _, want := range []string{"0x02", "execution timeout"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1760

## Problem

`debug_traceBlockByHash` returns one envelope per transaction that carries either `result` or `error`. Blockbook's `rpcTraceResult` decoded only `result`. When a single transaction failed to trace, its envelope decoded to a zero-value trace, the length guard passed, and the block was committed as fully processed.

Verified against client sources: geth's native callTracer fails the whole call on a per-tx error, so that path was already handled. **Erigon** writes the per-tx `error` field and keeps tracing the rest of the block, which is the live case for our Erigon-backed instances. bor does the same for the Polygon state-sync transaction.

## Consequences

- The failing transaction's internal transfers, `CREATE`/`SELFDESTRUCT` rows and address links were lost. Since the native balance is a live RPC, the account showed the right balance with the transaction that explains it missing.
- No `InternalDataError` was set, so nothing reached the heal queue, `internal_data_error_queue` stayed at 0, and `/internal` listed nothing. Only a reindex repaired it, and nothing recorded that it happened.
- Because the tracer timeout is per transaction, the losses concentrate on the heaviest transactions, which carry the most internal transfers.

## Fix

Decode the envelope `error` and return an error from `getInternalDataForBlock` naming the block and transaction. The field is decoded through a small `rpcTraceError` type because the two client families disagree on its shape: geth forks send a plain string, Erigon's `rpc.HandleError` sends a `{code, message}` object. Decoding Erigon's object into a string field would fail the whole call, which still queues the block for healing but loses the transaction hash and tracer reason from the log line and the `/internal` listing. Everything downstream already exists: `GetBlock` stores the block with its transactions and logs intact and sets `InternalDataError`, the block is queued, and `HealInternalData` re-traces it on the hourly pass.

The Polygon bridging transaction (from and to both zero address) keeps the exemption it already has in the trace-length adjustment, extracted into a small shared helper. Without it, a deterministic bor state-sync trace failure would queue every Polygon block containing one, and the heal loop never abandons entries.

## Why this solution

- **Reuses existing machinery end to end.** No new storage, metric, or retry path.
- **Transient failures self-heal** on the next pass. Deterministic ones become visible in the queue gauge, `internal_data_heals{result="failed"}` and `/internal`, and heal automatically once `trace_timeout` is raised or the backend gets faster. No reindex.
- Alternatives considered: recording the failure only in the transaction's error string keeps the data lost with no retry; re-tracing inline with `debug_traceTransaction` adds code on the sync hot path and still needs a fallback; failing `GetBlock` would stall sync.

## Tests

New cases in `ethrpc_trace_test.go`: a failing envelope returns an error naming the transaction, the same for Erigon's exact object-shaped wire form, a failing envelope for the bridging transaction is tolerated, and a decode table covering string, object, object without message, null and absent error fields. The `bchain/coins/eth` package passes locally apart from tests that bind a local HTTP server, which the sandbox forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

