### PR TITLE
fix(eth): stop reporting pending transferFrom as an NFT transfer (#1714)

### DIFF
--- a/bchain/coins/eth/contract.go
+++ b/bchain/coins/eth/contract.go
@@ -14,7 +14,6 @@ import (
 )
 
 const erc20TransferMethodSignature = "0xa9059cbb"                  // transfer(address,uint256)
-const erc721TransferFromMethodSignature = "0x23b872dd"             // transferFrom(address,address,uint256)
 const erc721SafeTransferFromMethodSignature = "0x42842e0e"         // safeTransferFrom(address,address,uint256)
 const erc721SafeTransferFromWithDataMethodSignature = "0xb88d4fde" // safeTransferFrom(address,address,uint256,bytes)
 const erc721TokenURIMethodSignature = "0xc87b56dd"                 // tokenURI(uint256)
@@ -316,8 +315,9 @@ func contractGetTransfersFromTx(tx *bchain.RpcTransaction) (bchain.TokenTransfer
 			Value:    t,
 		})
 	} else if len(tx.Payload) >= 10+192 &&
-		(strings.HasPrefix(tx.Payload, erc721TransferFromMethodSignature) ||
-			strings.HasPrefix(tx.Payload, erc721SafeTransferFromMethodSignature) ||
+		// transferFrom(address,address,uint256) 0x23b872dd is deliberately absent: ERC-20 shares the
+		// selector and is the common case, so without a receipt the standard cannot be told apart
+		(strings.HasPrefix(tx.Payload, erc721SafeTransferFromMethodSignature) ||
 			strings.HasPrefix(tx.Payload, erc721SafeTransferFromWithDataMethodSignature)) {
 		from, err := addressFromPaddedHex(tx.Payload[10 : 10+64])
 		if err != nil {

--- a/bchain/coins/eth/contract_test.go
+++ b/bchain/coins/eth/contract_test.go
@@ -317,8 +317,21 @@ func Test_contractGetTransfersFromTx(t *testing.T) {
 			},
 		},
 		{
-			name: "ERC721 transferFrom",
+			// 0x23b872dd is shared by ERC-20 and ERC-721, so no standard can be derived from calldata
+			name: "transferFrom with the shared ERC-20/ERC-721 selector yields nothing",
 			args: (b2.Txs[2].CoinSpecificData.(bchain.EthereumSpecificData)).Tx,
+			want: bchain.TokenTransfers{},
+		},
+		{
+			name: "ERC721 safeTransferFrom",
+			args: &bchain.RpcTransaction{
+				From: "0x837e3f699d85a4b0b99894567e9233dfb1dcb081",
+				To:   "0xcda9fc258358ecaa88845f19af595e908bb7efe9",
+				Payload: erc721SafeTransferFromMethodSignature +
+					"000000000000000000000000837e3f699d85a4b0b99894567e9233dfb1dcb081" +
+					"0000000000000000000000007b62eb7fe80350dc7ec945c0b73242cb9877fb1b" +
+					"0000000000000000000000000000000000000000000000000000000000000001",
+			},
 			want: bchain.TokenTransfers{
 				{
 					Standard: bchain.NonFungibleToken,
@@ -326,6 +339,28 @@ func Test_contractGetTransfersFromTx(t *testing.T) {
 					From:     "0x837e3f699d85a4b0b99894567e9233dfb1dcb081",
 					To:       "0x7b62eb7fe80350dc7ec945c0b73242cb9877fb1b",
 					Value:    *big.NewInt(1),
+				},
+			},
+		},
+		{
+			name: "ERC721 safeTransferFrom with data",
+			args: &bchain.RpcTransaction{
+				From: "0x837e3f699d85a4b0b99894567e9233dfb1dcb081",
+				To:   "0xcda9fc258358ecaa88845f19af595e908bb7efe9",
+				Payload: erc721SafeTransferFromWithDataMethodSignature +
+					"000000000000000000000000837e3f699d85a4b0b99894567e9233dfb1dcb081" +
+					"0000000000000000000000007b62eb7fe80350dc7ec945c0b73242cb9877fb1b" +
+					"0000000000000000000000000000000000000000000000000000000000000002" +
+					"0000000000000000000000000000000000000000000000000000000000000080" +
+					"0000000000000000000000000000000000000000000000000000000000000000",
+			},
+			want: bchain.TokenTransfers{
+				{
+					Standard: bchain.NonFungibleToken,
+					Contract: "0xcda9fc258358ecaa88845f19af595e908bb7efe9",
+					From:     "0x837e3f699d85a4b0b99894567e9233dfb1dcb081",
+					To:       "0x7b62eb7fe80350dc7ec945c0b73242cb9877fb1b",
+					Value:    *big.NewInt(2),
 				},
 			},
 		},

--- a/bchain/coins/tron/contract_test.go
+++ b/bchain/coins/tron/contract_test.go
@@ -186,7 +186,8 @@ func TestTronParser_EthereumTypeGetTokenTransfersFromTx(t *testing.T) {
 			},
 		},
 		{
-			name: "TRC721 transfer",
+			// pending transferFrom: the selector is shared with TRC-20, so no standard can be derived
+			name: "pending TRC721 transferFrom yields nothing",
 			tx: &bchain.Tx{
 				Txid: "0x49ced31cd0fd6d8e1126775f53ade165fe7ca43e9cc968d64a9ce1aff597423c",
 				CoinSpecificData: bchain.EthereumSpecificData{
@@ -194,6 +195,20 @@ func TestTronParser_EthereumTypeGetTokenTransfersFromTx(t *testing.T) {
 						From:    "0x34627862d50389c8d7a1ab5ef074b84ab4ddb9e9",
 						To:      "0x0b17822171ee88e98d4a61029f97c9f8edc15fcd",
 						Payload: "0x23b872dd00000000000000000000000034627862d50389c8d7a1ab5ef074b84ab4ddb9e90000000000000000000000000cecca0e53477d2b6c562ab68c3452fc99f7817e000000000000000000000000000000000000000000000000000000000000067f",
+					},
+				},
+			},
+			expected: bchain.TokenTransfers{},
+		},
+		{
+			name: "pending TRC721 safeTransferFrom",
+			tx: &bchain.Tx{
+				Txid: "0x49ced31cd0fd6d8e1126775f53ade165fe7ca43e9cc968d64a9ce1aff597423c",
+				CoinSpecificData: bchain.EthereumSpecificData{
+					Tx: &bchain.RpcTransaction{
+						From:    "0x34627862d50389c8d7a1ab5ef074b84ab4ddb9e9",
+						To:      "0x0b17822171ee88e98d4a61029f97c9f8edc15fcd",
+						Payload: "0x42842e0e00000000000000000000000034627862d50389c8d7a1ab5ef074b84ab4ddb9e90000000000000000000000000cecca0e53477d2b6c562ab68c3452fc99f7817e000000000000000000000000000000000000000000000000000000000000067f",
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #1714.

## Problem

`contractGetTransfersFromTx`, the only source of token transfers for a **pending** transaction (no receipt, no logs), mapped `transferFrom(address,address,uint256)` = `0x23b872dd` to ERC-721 and reported the third argument as a token id. ERC-20 shares that selector, and on mainnet it is the common case: in a 30-block sample (25,900,000–25,900,029), 75 of 77 `transferFrom` calls were ERC-20 (USDC 34, USDT 28), 2 were ERC-721.

Without a receipt the standard cannot be told apart, so the shared selector is no longer parsed from calldata. The ERC-721-only `safeTransferFrom` selectors (`0x42842e0e`, `0xb88d4fde`) still are. Confirmed transactions always parse from receipt logs and are unaffected.

## Consequences for Suite users

While such a transaction was pending, Suite received `standard: "ERC721"` with the amount in the id slot, so:

- the history row rendered through the NFT formatter as e.g. "Token ID: 1717292743 USDC" instead of "1717.29 USDC";
- because the standard was ERC721, the fake-token phishing detector looked the contract up in the NFT definitions, did not find it, and flagged the whole receive as a potential fraud (blurred amount, warning icon);
- a token contract with no stored `cfContracts` row yet was stamped `ERC721` permanently via `standardFromContext` (`api/worker.go`, `db/rocksdb_contracts.go`), which nothing later corrects.

After this change a pending `transferFrom` shows no token transfer until it confirms, the same as a pending suffixed `transfer` today. Suite maps this selector to `'unknown'` in `getEvmTransactionTextSignature`, so nothing on the Suite side depends on the removed row. Pending ERC-721 transfers via plain `transferFrom` (the 2-of-77 minority) lose their pending row.

## Follow-up

- Resolve the standard from the stored contract info instead of the selector, so pending ERC-20 `transferFrom` gets a correct row and pending ERC-721 `transferFrom` comes back. Needs a DB-backed lookup reachable from the parser and the mempool address indexer; same hook fixes #1712 (suffixed `transfer` calldata) safely.
- Pass `UnknownTokenStandard` as `standardFromContext` for receipt-less transactions so no calldata-derived guess can ever be persisted.

## Testing

`go test -tags unittest ./bchain/ ./bchain/coins/eth/ ./bchain/coins/tron/ ./api/ ./db/` (httptest-bound tests skipped in the sandbox). The Tron parser test that pinned the old guess is updated the same way, since TRC-20 shares the selector too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
