### PR TITLE
fix(btc): estimate 2 blocks when legacy estimatefee is asked for 1 and reject negative fees

### DIFF
--- a/bchain/coins/btc/bitcoinrpc.go
+++ b/bchain/coins/btc/bitcoinrpc.go
@@ -1074,6 +1074,11 @@ func (b *BitcoinRPC) EstimateFee(blocks int) (big.Int, error) {
 		return b.EstimateSmartFee(blocks, true)
 	}
 
+	// Core-0.14-lineage estimatefee never estimates 1 block (always -1); the node's own
+	// estimatesmartfee bumps the target to 2, so mirror that here.
+	if blocks == 1 {
+		blocks = 2
+	}
 	glog.V(1).Info("rpc: estimatefee ", blocks)
 
 	res := ResEstimateFee{}
@@ -1090,6 +1095,10 @@ func (b *BitcoinRPC) EstimateFee(blocks int) (big.Int, error) {
 	r, err = b.Parser.AmountToBigInt(res.Result)
 	if err != nil {
 		return r, err
+	}
+	// the node signals "not enough data" with -1; never hand a negative fee to clients
+	if r.Sign() < 0 {
+		return r, errors.Errorf("estimatefee: no fee estimate available for %d blocks", blocks)
 	}
 	return r, nil
 }

--- a/bchain/coins/btc/bitcoinrpc_estimatefee_test.go
+++ b/bchain/coins/btc/bitcoinrpc_estimatefee_test.go
@@ -1,0 +1,98 @@
+package btc
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/trezor/blockbook/bchain"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// newLegacyFeeRPC wires a BitcoinRPC to an in-process backend (no listening socket)
+// configured like dogecoind: only the legacy estimatefee is available.
+func newLegacyFeeRPC(backend func(body string) string) *BitcoinRPC {
+	cfg := &Configuration{SupportsEstimateFee: true}
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(backend(string(body)))),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	return &BitcoinRPC{
+		BaseChain:    &bchain.BaseChain{Parser: NewBitcoinParser(GetChainParams("main"), cfg)},
+		client:       http.Client{Transport: transport},
+		rpcURL:       "http://backend",
+		ChainConfig:  cfg,
+		RPCMarshaler: JSONMarshalerV1{},
+	}
+}
+
+// Replies are what dogecoind 1.14.9 returned live on 2026-09-10.
+func fakeLegacyEstimateFee(requests *[]string) func(string) string {
+	return func(body string) string {
+		*requests = append(*requests, body)
+		switch body {
+		case `{"method":"estimatefee","params":[1]}`:
+			return `{"result":-1,"error":null,"id":1}`
+		case `{"method":"estimatefee","params":[2]}`:
+			return `{"result":0.50427075,"error":null,"id":1}`
+		case `{"method":"estimatefee","params":[8]}`:
+			return `{"result":0.01002515,"error":null,"id":1}`
+		default:
+			return `{"result":-1,"error":null,"id":1}`
+		}
+	}
+}
+
+func TestEstimateFeeLegacyRemapsOneBlock(t *testing.T) {
+	var requests []string
+	b := newLegacyFeeRPC(fakeLegacyEstimateFee(&requests))
+
+	tests := []struct {
+		name    string
+		call    func() (fee string, err error)
+		wantReq string
+		want    string
+	}{
+		{"EstimateFee(1) asks for 2", func() (string, error) { f, e := b.EstimateFee(1); return f.String(), e },
+			`{"method":"estimatefee","params":[2]}`, "50427075"},
+		{"EstimateSmartFee(1) falls back to estimatefee 2", func() (string, error) { f, e := b.EstimateSmartFee(1, true); return f.String(), e },
+			`{"method":"estimatefee","params":[2]}`, "50427075"},
+		{"other targets pass through", func() (string, error) { f, e := b.EstimateFee(8); return f.String(), e },
+			`{"method":"estimatefee","params":[8]}`, "1002515"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests = requests[:0]
+			fee, err := tt.call()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fee != tt.want {
+				t.Errorf("fee = %s, want %s", fee, tt.want)
+			}
+			if len(requests) != 1 || requests[0] != tt.wantReq {
+				t.Errorf("requests = %q, want [%s]", requests, tt.wantReq)
+			}
+		})
+	}
+}
+
+func TestEstimateFeeLegacyNegativeIsError(t *testing.T) {
+	var requests []string
+	b := newLegacyFeeRPC(fakeLegacyEstimateFee(&requests))
+
+	if fee, err := b.EstimateFee(1008); err == nil {
+		t.Errorf("expected error for result -1, got fee %s", fee.String())
+	}
+	if _, err := b.LongTermFeeRate(); err == nil {
+		t.Error("expected error for result -1 from LongTermFeeRate")
+	}
+}

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -125,7 +125,7 @@
         "connectivity": ["http"],
         "api": ["Status", "GetBlockIndex", "GetBlockByHeight", "GetBlock", "GetTransaction", "GetTransactionSpecific",
                 "GetAddress", "GetCurrentFiatRates", "GetTickersList", "GetMultiTickers", "GetBalanceHistory", "GetAddressTxids", "GetAddressTxs", "GetUtxo", "GetUtxoConfirmedFilter"],
-        "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "MempoolSync"],
+        "rpc": ["GetBlock", "GetBlockHash", "GetTransaction", "MempoolSync", "EstimateSmartFee", "EstimateFee"],
         "sync": ["ConnectBlocksParallel", "ConnectBlocks"]
     },
     "dogecoin_testnet": {


### PR DESCRIPTION
## What

For coins still on the legacy `estimatefee` RPC (Dogecoin, Zcash, PIVX, Firo, ...), a request for **1 block** is now sent to the node as **2 blocks**, and a negative result from the node is returned as an **error** instead of a negative amount.

Nine lines in the legacy branch of `BitcoinRPC.EstimateFee`, plus unit tests using an in-process HTTP transport and the `EstimateSmartFee`/`EstimateFee` integration tests enabled for Dogecoin.

## Why

`doge.trezor.io` answers `estimateFee` with `blocks: [1]` as `feePerUnit: "-100000000"`. That is dogecoind's `-1 DOGE/kB` "no estimate" sentinel, converted to satoshis and forwarded as if it were a fee. The node behaves this way by design: the Bitcoin Core 0.14-lineage estimator refuses a 1-block target (`// It's not possible to get reasonable estimates for confTarget of 1`) and the `estimatefee` help text says "-1 is always returned for nblocks == 1". The node's own `estimatesmartfee` handles this by bumping the target to 2 and reporting `blocks: 2`. This change mirrors that in Blockbook.

**User impact.** Trezor Connect asks every non-BTC UTXO coin for a 1-block estimate and discards negative replies, so Suite has been silently falling back to the static 1000 sat/B default for Dogecoin for as long as this has existed, regardless of network conditions. Today's live 2-block estimate is ~505 sat/B; during a mempool spike the static value can be too low. After this change Connect receives a usable number.

## History

- #565 (2021) reported exactly this symptom. It was closed as "the backend is not able to estimate the fee", which is true, but the -1 still leaked to clients as an amount.
- #1153 (2024, open) retries with more blocks, but only in the REST handler in `server/public.go`. Suite uses the websocket `estimateFee`, which that PR does not touch. This change fixes it once at the chain layer so both REST and websocket benefit, and #1153 can be closed.

## Why this shape

- **Why the shared legacy branch and not a Dogecoin override.** The 1-block rule is a Bitcoin Core property that every legacy-lineage fork inherited, not a Dogecoin quirk, so the fix belongs where the legacy call lives. The branch is only reached when `SupportsEstimateSmartFee = false`; Bitcoin and Litecoin never enter it, and their nodes already do the same 1->2 bump inside `estimatesmartfee` (verified: both return `blocks: 2` for a 1-block request).
- **Why not switch Dogecoin to `estimatesmartfee`.** dogecoind 1.14.9 does have it, but it takes a single positional `nblocks` (rejects `estimate_mode`) and tracks at most 25 confirmations, so it needs a coin-specific request shape and a target clamp. That is a bigger change than the bug warrants; it can be a follow-up if a bucket-without-data case ever shows up.
- **Why the sign check.** A negative fee is never a valid API value. Connect treats a negative and an error identically, so Suite is unaffected either way, but third-party clients no longer have to know about the sentinel.

## Verification

Live against dogecoind 1.14.9 (public RPC), sending the exact bytes the test pins:

| Request | Reply |
|---|---|
| `estimatefee [1]` | `-1` |
| `estimatefee [2]` | `0.5049 DOGE/kB` |
| `estimatesmartfee [1]` | `0.5047`, `blocks: 2` |
| `estimatesmartfee [1, "CONSERVATIVE"]` | error, `estimatesmartfee nblocks` |

Other Suite UTXO coins checked and unaffected: BTC and LTC never reach the legacy branch (modern Core, `estimatefee` removed); ZEC runs on Zebra which has no fee RPC at all (every `estimatefee` target already 500s, separate issue); BCH has its own argument-less `estimatefee` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
